### PR TITLE
Fix generate pdf button overlap

### DIFF
--- a/resume-builder-ui/src/components/Editor.tsx
+++ b/resume-builder-ui/src/components/Editor.tsx
@@ -275,8 +275,7 @@ const Editor: React.FC = () => {
         {/* Left Side: Add Section Button */}
         <button
           onClick={() => setShowModal(true)}
-          className="bg-blue-500 text-white px-4 py-2 rounded-lg flex items-center gap-2"
-        >
+          className="bg-blue-500 text-white px-4 py-2 rounded-lg flex items-center gap-2">
           <FaPlus />
           Add Section
         </button>
@@ -428,8 +427,7 @@ const Editor: React.FC = () => {
           return (
             <div
               key={index}
-              ref={index === sections.length - 1 ? newSectionRef : null}
-            >
+              ref={index === sections.length - 1 ? newSectionRef : null}>
               <GenericSection
                 section={section}
                 onUpdate={(updatedSection) =>
@@ -448,14 +446,15 @@ const Editor: React.FC = () => {
         }
       })}
 
-      <div className="fixed bottom-5 left-1/2 transform -translate-x-1/2 z-50">
+      <div
+        className="sticky bottom-5 transform z-50 "
+        style={{ display: "flex", justifyContent: "center" }}>
         <button
           onClick={handleGenerateResume}
           className={`bg-green-600 text-white px-6 py-3 rounded-full shadow hover:bg-green-700 transition-all ${
             generating ? "opacity-50 cursor-not-allowed" : ""
           }`}
-          disabled={generating}
-        >
+          disabled={generating}>
           <FaFilePdf className="inline mr-2" />
           {generating ? "Generating..." : "Generate PDF"}
         </button>

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -23,8 +23,8 @@ main {
 }
 
 footer {
-  margin-top: auto; 
-  width: 100%; 
+  margin-top: auto;
+  width: 100%;
 }
 
 


### PR DESCRIPTION
Fixed Issue : https://github.com/aafre/resume-builder/issues/10

### **What Changed?**  
- Updated the button container positioning from `fixed` to `sticky`.  
- Applied `flexbox` **styling** to ensure proper center alignment of the button.  

### **Why is this Change Required?**  
- Previously, the **"Generate PDF"** button overlapped the footer, impacting usability.  
- Using `sticky` **positioning** ensures the button remains visible while scrolling without obstructing the footer, enhancing the **user experience**.  

## Before: 
![image](https://github.com/user-attachments/assets/6005314a-91c0-4bd8-b49a-4566305a3c8e)


## After : 
![image](https://github.com/user-attachments/assets/f0f0e181-2857-4737-9a81-095512b59e12)
![image](https://github.com/user-attachments/assets/9eb421a9-2353-4509-949e-1b888eba55ae)