### PR TITLE
Fix content overflow issue by replacing h-screen with min-h-screen

### DIFF
--- a/resume-builder-ui/src/components/TemplateCarousel.tsx
+++ b/resume-builder-ui/src/components/TemplateCarousel.tsx
@@ -63,7 +63,7 @@
     }
 
     return (
-      <div className="flex flex-col md:flex-row h-screen">
+      <div className="flex flex-col md:flex-row min-h-screen">
         {/* Left Pane: List of Templates */}
         <div className="w-full md:w-1/3 bg-gray-100 p-4 overflow-y-auto">
           <h2 className="text-lg font-bold text-gray-700 mb-4">Templates</h2>


### PR DESCRIPTION
@aafre  This issue was not tracked, but I noticed a content overflow problem due to the use of `h-screen`. Here’s the fix:  
## What Changed?
- Replaced `h-screen` with `min-h-screen` in the `TemplateCarousel.tsx` component.

## Why is this Change Required?
- `h-screen` was causing content overflow issues, especially when the content exceeded the viewport height.
- `min-h-screen` ensures the container is at least the height of the viewport but can expand as needed, preventing unintended clipping or overflow.

## Before vs After
### Before (with `h-screen`, causing overflow)
![Screenshot 2025-02-12 184304](https://github.com/user-attachments/assets/66918e74-465a-48b7-a06b-9932f443bf39)

### After (with `min-h-screen`, fixing overflow)
![Screenshot 2025-02-12 184346](https://github.com/user-attachments/assets/624435e9-7b0a-4523-8f0b-ac6a42569fab)


## Impact
- Improves responsiveness and ensures proper scrolling behavior.
- Enhances user experience by allowing content to be fully accessible.
