### PR TITLE
Dockerfile to run API locally 

### DIFF
--- a/Dockerfile.dev.api
+++ b/Dockerfile.dev.api
@@ -1,0 +1,23 @@
+# Use the official Python image as a base
+FROM python:3.11-slim-bullseye
+
+# Set the working directory
+WORKDIR /app
+
+# Install wkhtmltopdf and other dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wkhtmltopdf \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy only the requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the Flask app
+COPY . .
+
+# Expose the port that Flask uses
+EXPOSE 5000
+
+# Command to run the Flask development server
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Visit our [GitHub Issues](https://github.com/aafre/resume-builder/issues) page.
 
 1. **Build the Docker Image**:
    ```bash
-   docker build -t resume-api -f .\Docker.dev.api .
+   docker build -t resume-api -f .\Dockerfile.dev.api .
    ```
 
 2. **Run the Container**:


### PR DESCRIPTION
Use commands to spin up the API locally: 


```
docker build -t resume-api -f .\Dockerfile.dev.api .
docker run -p 5000:5000 resume-api
```

then spin up the front end

```
cd resume-builder-ui
npm run dev
```