### PR TITLE
Improve Inline List & Dynamic Column List Layout  

### DIFF
--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -97,7 +97,6 @@ const GenericSection: React.FC<GenericSectionProps> = ({
           Remove
         </button>
       </div>
-
       <div className="mt-4">
         {section.type === "text" && (
           <textarea
@@ -106,18 +105,61 @@ const GenericSection: React.FC<GenericSectionProps> = ({
             className="w-full border border-gray-300 rounded-lg p-2"
           ></textarea>
         )}
-        {["bulleted-list", "inline-list", "dynamic-column-list"].includes(
+        {["bulleted-list"].includes(
           section.type || ""
         ) && (
           <>
+              {Array.isArray(section.content) &&
+                section.content.map((item: string, index: number) => (
+                  <div key={index} className="flex items-center gap-2 mb-4 mr-4">
+                    <input
+                      type="text"
+                      value={item}
+                      onChange={(e) => handleContentChange(e.target.value, index)}
+                      className="w-full border border-gray-300 rounded-lg p-2"
+                    />
+                    <button
+                      onClick={() => handleRemoveItem(index)}
+                      className="text-red-600 hover:text-red-800"
+                      title="Remove Item"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                ))}
+            <button
+              onClick={() => {
+                const updatedContent = [...(section.content || []), ""];
+                onUpdate({ ...section, content: updatedContent });
+              }}
+              className="bg-blue-500 text-white px-4 py-2 rounded-lg mt-2"
+            >
+              Add Item
+            </button>
+          </>
+        )}
+      </div>
+      <div className="mt-4 flex flex-col gap-4">
+        {section.type === "text" && (
+          <textarea
+            value={section.content || ""}
+            onChange={(e) => handleContentChange(e.target.value)}
+            className="w-full border border-gray-300 rounded-lg p-2"
+          ></textarea>
+        )}
+        {["inline-list", "dynamic-column-list"].includes(
+          section.type || ""
+        ) && (
+          <>
+          <div className="flex flex-wrap justify-start gap-4">
             {Array.isArray(section.content) &&
               section.content.map((item: string, index: number) => (
-                <div key={index} className="flex items-center gap-2 mb-4">
+                <div key={index} className="flex items-center gap-2 mb-4 mr-4">
                   <input
                     type="text"
                     value={item}
                     onChange={(e) => handleContentChange(e.target.value, index)}
-                    className="w-full border border-gray-300 rounded-lg p-2"
+                    className="w-full border border-gray-300 rounded-lg p-2 text-ellipsis" 
                   />
                   <button
                     onClick={() => handleRemoveItem(index)}
@@ -128,12 +170,13 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                   </button>
                 </div>
               ))}
+            </div>
             <button
               onClick={() => {
                 const updatedContent = [...(section.content || []), ""];
                 onUpdate({ ...section, content: updatedContent });
               }}
-              className="bg-blue-500 text-white px-4 py-2 rounded-lg mt-2"
+              className="bg-blue-500 text-white px-4 py-2 rounded-lg mt-2 w-fit"
             >
               Add Item
             </button>

--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -109,24 +109,26 @@ const GenericSection: React.FC<GenericSectionProps> = ({
           section.type || ""
         ) && (
           <>
-              {Array.isArray(section.content) &&
-                section.content.map((item: string, index: number) => (
-                  <div key={index} className="flex items-center gap-2 mb-4 mr-4">
-                    <input
-                      type="text"
-                      value={item}
-                      onChange={(e) => handleContentChange(e.target.value, index)}
-                      className="w-full border border-gray-300 rounded-lg p-2"
-                    />
-                    <button
-                      onClick={() => handleRemoveItem(index)}
-                      className="text-red-600 hover:text-red-800"
-                      title="Remove Item"
-                    >
-                      🗑️
-                    </button>
-                  </div>
-                ))}
+          <div className={`flex justify-start ${(section.type === "inline-list" || section.type === "dynamic-column-list")? "flex-row flex-wrap" : "flex-col"}`}>
+            {Array.isArray(section.content) &&
+              section.content.map((item: string, index: number) => (
+                <div key={index} className="flex items-center gap-2 mb-4 mr-10">
+                  <input
+                    type="text"
+                    value={item}
+                    onChange={(e) => handleContentChange(e.target.value, index)}
+                    className="w-full border border-gray-300 rounded-lg p-2 overflow-hidden text-ellipsis"
+                  />
+                  <button
+                    onClick={() => handleRemoveItem(index)}
+                    className="text-red-600 hover:text-red-800"
+                    title="Remove Item"
+                  >
+                    🗑️
+                  </button>
+                </div>
+              ))}
+            </div>
             <button
               onClick={() => {
                 const updatedContent = [...(section.content || []), ""];


### PR DESCRIPTION

## Fixed issue: https://github.com/aafre/resume-builder/issues/20

## What Changed?  
- Updated the **Inline List** and **Dynamic Column List** sections to prevent items from taking up the full width.  
- Implemented **flexbox-based styling** to allow multiple items per row.  
- Applied **text truncation (`text-ellipsis`)** for long items.  
- Adjusted the **"Add Item"** button to fit within the new layout.  

## Why is this Change Required?  
- Previously, each item occupied an entire row, making the UI **inefficient and visually unappealing**.  
- This update allows **two or more items per row**, **better utilizing space** and improving readability.  
- The **text length restriction will be handled separately**, but this ensures items fit within a reasonable width.
## Before vs After : 

### **Before**  

![image](https://github.com/user-attachments/assets/965d0142-1ab7-490c-993f-138eea1f4000)


### **After**  
![image](https://github.com/user-attachments/assets/332b7116-c126-49c4-8668-5b0490b5c116)
  

## Impact : 
🚀 **Improves UI layout**, making it **more compact and user-friendly**.  
📱 **Better responsiveness**, ensuring a clean design across devices.  
