### PR TITLE
fix(auth): restore original OAuth redirect behavior

### DIFF
--- a/resume-builder-ui/src/contexts/AuthContext.tsx
+++ b/resume-builder-ui/src/contexts/AuthContext.tsx
@@ -681,7 +681,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${import.meta.env.VITE_APP_URL}/auth/callback`,
+        redirectTo: window.location.href, // Return to current page
       },
     });
 
@@ -694,7 +694,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'linkedin_oidc',
       options: {
-        redirectTo: `${import.meta.env.VITE_APP_URL}/auth/callback`,
+        redirectTo: window.location.href, // Return to current page
       },
     });
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,12 +149,10 @@ site_url = "http://localhost:5173"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 # IMPORTANT: Must include full callback path, not just origins
 additional_redirect_urls = [
-  "http://localhost:5173/auth/callback",
-  "http://127.0.0.1:5173/auth/callback",
-  "http://localhost:5173",
-  "http://127.0.0.1:5173",
-  "https://easyfreeresume.com/auth/callback",
-  "https://easyfreeresume.com"
+  "http://localhost:5173/**",
+  "http://127.0.0.1:5173/**",
+  "https://easyfreeresume.com/**",
+  "https://dev.easyfreeresume.com/**"
 ]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600


### PR DESCRIPTION
Use window.location.href for OAuth redirectTo to return users to the page they started from, matching email login behavior.

This fixes 404 errors after OAuth and restores the working dev behavior.