### PR TITLE
fix(preview): add previewUrl to loading state dependency array

### DIFF
--- a/resume-builder-ui/src/components/PreviewModal.tsx
+++ b/resume-builder-ui/src/components/PreviewModal.tsx
@@ -37,8 +37,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({
       setLoadingState('idle');
     }
     // Note: 'loaded' state is set by iframe onLoad event
-    // previewUrl removed from deps to prevent flashing when URL updates
-  }, [isGenerating, error]);
+  }, [isGenerating, error, previewUrl]);
 
   // Handle ESC key to close modal
   useEffect(() => {


### PR DESCRIPTION
Include previewUrl in PreviewModal useEffect dependencies to ensure proper loading state transitions when preview is cleared.

This is critical for the clearPreview() flow added in commit 3e50514:
- When Editor clears stale preview, previewUrl becomes null
- Without previewUrl in deps, effect doesn't re-run
- loadingState stays in wrong state instead of transitioning to 'idle'

Follows React best practices and aligns with dependency array approach taken in commits 1add9d0 (usePreview) and addresses Gemini PR feedback.