### PR TITLE
fix(api): migrate user_preferences on anon-to-auth conversion

### DIFF
--- a/supabase/migrations/20260125000000_add_migrate_preferences_rpc.sql
+++ b/supabase/migrations/20260125000000_add_migrate_preferences_rpc.sql
@@ -1,0 +1,23 @@
+-- RPC function to atomically migrate user preferences
+-- Handles race conditions by performing check-and-update in a single transaction
+
+CREATE OR REPLACE FUNCTION migrate_user_preferences(old_uid uuid, new_uid uuid)
+RETURNS void AS $$
+BEGIN
+  -- Check if the new user already has preferences
+  IF EXISTS (SELECT 1 FROM public.user_preferences WHERE user_id = new_uid) THEN
+    -- New user has preferences, delete the old anonymous user's preferences
+    DELETE FROM public.user_preferences WHERE user_id = old_uid;
+  ELSE
+    -- New user has no preferences, migrate the anonymous user's preferences
+    UPDATE public.user_preferences
+    SET user_id = new_uid
+    WHERE user_id = old_uid;
+  END IF;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp;
+
+COMMENT ON FUNCTION migrate_user_preferences(uuid, uuid)
+IS 'Atomically migrates user preferences from anonymous to authenticated user. If the authenticated user already has preferences, deletes the anonymous preferences. Otherwise, transfers ownership.';


### PR DESCRIPTION
Previously, anonymous user preferences were deleted during migration, causing RLS policy violations when the frontend tried to write with a stale session. Now preferences are transferred by updating user_id, preserving tour_completed, idle_nudge_shown, and announcement_dismissals.

- Check if authenticated user already has preferences
- If not, update user_id from old to new (migrate)
- If yes, delete old preferences (keep authenticated user's)
- Add unit tests for all migration scenarios