### PR TITLE
docs: fix license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Please submit a pull request or open an issue to discuss your ideas.
 
 ## License
 
-This project is open source and available under the [MIT License](LICENSE).
+This project is open source and available under the [Apache License 2.0](LICENSE).
 
 ---
 


### PR DESCRIPTION
Change license reference from MIT to Apache 2.0 to match the actual LICENSE file.