### PR TITLE
🎨 Palette: Improve Delete Modal Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Modal Accessibility Gaps]
+**Learning:** Destructive modals often lack basic keyboard accessibility (focus trap, escape key) and ARIA attributes, making them dangerous for screen reader users who might not know context or can't escape easily.
+**Action:** Always implement `role="dialog"`, `aria-modal="true"`, focus management (focus cancel button by default), and escape key listener for all modals.

--- a/resume-builder-ui/src/__tests__/DeleteResumeModal.test.tsx
+++ b/resume-builder-ui/src/__tests__/DeleteResumeModal.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DeleteResumeModal } from '../components/DeleteResumeModal';
+import { ResumeListItem } from '../types';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+import React from 'react';
+
+const mockResume: ResumeListItem = {
+  id: '1',
+  title: 'My Resume',
+  template_id: 'modern',
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+  last_accessed_at: '2024-01-01',
+  thumbnail_url: null
+};
+
+describe('DeleteResumeModal', () => {
+  const mockOnConfirm = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render correct accessible attributes', () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeInTheDocument();
+    expect(modal).toHaveAttribute('aria-modal', 'true');
+    expect(modal).toHaveAttribute('aria-labelledby', 'delete-modal-title');
+    expect(modal).toHaveAttribute('aria-describedby', 'delete-modal-desc');
+  });
+
+  it('should focus cancel button on open', async () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    await waitFor(() => {
+        const cancelButton = screen.getByRole('button', { name: /cancel/i });
+        expect(cancelButton).toHaveFocus();
+    });
+  });
+
+  it('should close on escape key', () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/resume-builder-ui/src/components/DeleteResumeModal.tsx
+++ b/resume-builder-ui/src/components/DeleteResumeModal.tsx
@@ -1,4 +1,5 @@
 import { ResumeListItem } from '../types';
+import { useEffect, useRef } from 'react';
 
 interface DeleteResumeModalProps {
   resume: ResumeListItem | null;
@@ -15,10 +16,39 @@ export function DeleteResumeModal({
   onCancel,
   isDeleting = false
 }: DeleteResumeModalProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+      // Focus cancel button on open for safety
+      // Small timeout to ensure DOM is ready and transition has started
+      setTimeout(() => {
+        cancelButtonRef.current?.focus();
+      }, 50);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onCancel]);
+
   if (!isOpen || !resume) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-modal-title"
+      aria-describedby="delete-modal-desc"
+    >
       <div className="bg-white rounded-2xl shadow-xl max-w-md w-full mx-4">
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">
@@ -28,6 +58,7 @@ export function DeleteResumeModal({
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
@@ -38,12 +69,12 @@ export function DeleteResumeModal({
               </svg>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Delete Resume?</h2>
+              <h2 id="delete-modal-title" className="text-xl font-bold text-gray-900">Delete Resume?</h2>
               <p className="text-sm text-gray-500 mt-1">This action cannot be undone</p>
             </div>
           </div>
 
-          <p className="text-gray-700 mb-6">
+          <p id="delete-modal-desc" className="text-gray-700 mb-6">
             Are you sure you want to delete <strong className="text-gray-900">{resume.title}</strong>?
             This will permanently remove the resume and all its data.
           </p>
@@ -57,6 +88,7 @@ export function DeleteResumeModal({
               {isDeleting ? 'Deleting...' : 'Delete'}
             </button>
             <button
+              ref={cancelButtonRef}
               onClick={onCancel}
               disabled={isDeleting}
               className="flex-1 bg-gray-200 hover:bg-gray-300 disabled:bg-gray-100 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors"


### PR DESCRIPTION
🎨 Palette Improvement: Delete Modal Accessibility

💡 **What:** Enhanced the Delete Resume modal with proper accessibility attributes and keyboard interactions.
🎯 **Why:** Destructive actions must be safe and accessible. Screen reader users need to know they are in a dialog, and keyboard users need to be able to cancel easily (Escape key) and not accidentally delete (focus defaults to Cancel).
♿ **Accessibility:**
*   Added `role="dialog"` and `aria-modal="true"`.
*   Added `aria-labelledby` and `aria-describedby`.
*   Added `aria-hidden="true"` to decorative icon.
*   Added Escape key listener to close modal.
*   Added initial focus on "Cancel" button.
*   Added test coverage in `src/__tests__/DeleteResumeModal.test.tsx`.

---
*PR created automatically by Jules for task [5547655279998230739](https://jules.google.com/task/5547655279998230739) started by @aafre*