### PR TITLE
🎨 Palette: Improve DeleteResumeModal accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Modal Accessibility Pattern
+**Learning:** Custom modals (like `DeleteResumeModal`) are currently implemented as raw `div`s without accessibility attributes or focus management, making them invisible to screen readers and trapping keyboard users.
+**Action:** When touching any modal component, enforce the "Accessible Modal Standard": add `role="dialog"`, `aria-modal="true"`, focus the cancel/close button on mount, and add an Escape key listener.

--- a/resume-builder-ui/src/__tests__/DeleteResumeModal.test.tsx
+++ b/resume-builder-ui/src/__tests__/DeleteResumeModal.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DeleteResumeModal } from '../components/DeleteResumeModal';
+import { ResumeListItem } from '../types';
+
+const mockResume: ResumeListItem = {
+  id: '1',
+  title: 'Test Resume',
+  template_id: 'template1',
+  created_at: '2023-01-01',
+  updated_at: '2023-01-02',
+  last_accessed_at: '2023-01-03',
+};
+
+describe('DeleteResumeModal', () => {
+  it('renders correctly when open', () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    // This will fail initially because role="dialog" is missing
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete Resume?')).toBeInTheDocument();
+    expect(screen.getByText(/Are you sure you want to delete/)).toBeInTheDocument();
+  });
+
+  it('has correct accessibility attributes', () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'delete-modal-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'delete-modal-desc');
+  });
+
+  it('focuses cancel button on mount', async () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await waitFor(() => expect(cancelButton).toHaveFocus());
+  });
+
+  it('calls onCancel when Escape is pressed', () => {
+    const onCancel = vi.fn();
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={true}
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <DeleteResumeModal
+        resume={mockResume}
+        isOpen={false}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/resume-builder-ui/src/components/DeleteResumeModal.tsx
+++ b/resume-builder-ui/src/components/DeleteResumeModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { ResumeListItem } from '../types';
 
 interface DeleteResumeModalProps {
@@ -15,10 +16,41 @@ export function DeleteResumeModal({
   onCancel,
   isDeleting = false
 }: DeleteResumeModalProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Focus the cancel button when modal opens for safety
+      const timer = setTimeout(() => {
+        cancelButtonRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [isOpen, onCancel]);
+
   if (!isOpen || !resume) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-modal-title"
+      aria-describedby="delete-modal-desc"
+    >
       <div className="bg-white rounded-2xl shadow-xl max-w-md w-full mx-4">
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">
@@ -28,6 +60,7 @@ export function DeleteResumeModal({
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
@@ -38,12 +71,12 @@ export function DeleteResumeModal({
               </svg>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Delete Resume?</h2>
+              <h2 id="delete-modal-title" className="text-xl font-bold text-gray-900">Delete Resume?</h2>
               <p className="text-sm text-gray-500 mt-1">This action cannot be undone</p>
             </div>
           </div>
 
-          <p className="text-gray-700 mb-6">
+          <p id="delete-modal-desc" className="text-gray-700 mb-6">
             Are you sure you want to delete <strong className="text-gray-900">{resume.title}</strong>?
             This will permanently remove the resume and all its data.
           </p>
@@ -57,6 +90,7 @@ export function DeleteResumeModal({
               {isDeleting ? 'Deleting...' : 'Delete'}
             </button>
             <button
+              ref={cancelButtonRef}
               onClick={onCancel}
               disabled={isDeleting}
               className="flex-1 bg-gray-200 hover:bg-gray-300 disabled:bg-gray-100 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors"


### PR DESCRIPTION
💡 What: Added ARIA roles, labels, and focus management to the DeleteResumeModal.
🎯 Why: The delete modal was inaccessible to screen readers and keyboard users.
♿ Accessibility: Added role="dialog", aria-modal="true", focus on Cancel button, and Escape key listener.
Tests: Added unit test verifying attributes and behavior.

---
*PR created automatically by Jules for task [16783605382172606071](https://jules.google.com/task/16783605382172606071) started by @aafre*