### PR TITLE
feat: add section type switcher in editor

### DIFF
--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -7,6 +7,7 @@ import ItemDndContext from "./ItemDndContext";
 import SortableItem from "./SortableItem";
 import { GhostButton } from "./shared/GhostButton";
 import { MdDelete } from "react-icons/md";
+import { ChangeableSectionType } from "../services/sectionService";
 
 interface Section {
   name: string;
@@ -26,6 +27,7 @@ interface GenericSectionProps {
   isEditing: boolean;
   temporaryTitle: string;
   setTemporaryTitle: (title: string) => void;
+  onChangeType?: (targetType: ChangeableSectionType) => void;
 }
 
 const GenericSection: React.FC<GenericSectionProps> = ({
@@ -40,6 +42,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
   isEditing,
   temporaryTitle,
   setTemporaryTitle,
+  onChangeType,
 }) => {
   // Collapse state - default to collapsed on mobile, expanded on desktop
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -104,6 +107,8 @@ const GenericSection: React.FC<GenericSectionProps> = ({
         onDelete={onDelete}
         isCollapsed={isCollapsed}
         onToggleCollapse={handleToggleCollapse}
+        sectionType={section.type}
+        onChangeType={onChangeType}
       />
 
       {!isCollapsed && (

--- a/resume-builder-ui/src/components/SectionHeader.tsx
+++ b/resume-builder-ui/src/components/SectionHeader.tsx
@@ -1,8 +1,10 @@
 // src/components/SectionHeader.tsx
 
-import React, { useCallback } from "react";
-import { MdExpandMore, MdExpandLess, MdDeleteOutline } from "react-icons/md";
+import React, { useState, useCallback } from "react";
+import { MdExpandMore, MdExpandLess, MdDeleteOutline, MdSwapHoriz } from "react-icons/md";
 import { InlineTextEditor } from "./shared/InlineTextEditor";
+import { ChangeableSectionType, isChangeableType } from "../services/sectionService";
+import SectionTypePopover from "./SectionTypePopover";
 
 /**
  * Props for the SectionHeader component.
@@ -41,6 +43,12 @@ export interface SectionHeaderProps {
   isCollapsed?: boolean;
   /** Callback when collapse is toggled */
   onToggleCollapse?: () => void;
+
+  // === Type Switching Props ===
+  /** Current section type (used to show/hide Change Type button) */
+  sectionType?: string;
+  /** Callback when section type is changed */
+  onChangeType?: (targetType: ChangeableSectionType) => void;
 }
 
 /**
@@ -50,6 +58,7 @@ export interface SectionHeaderProps {
  * - Inline editable title (click to edit, blur/enter to save)
  * - Optional delete button
  * - Optional collapse/expand toggle
+ * - Optional change type button (for changeable section types)
  *
  * Supports both new simplified API and legacy controlled API for backwards compatibility.
  */
@@ -66,9 +75,16 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
   onDelete,
   isCollapsed = false,
   onToggleCollapse,
+  // Type switching props
+  sectionType,
+  onChangeType,
 }) => {
+  const [showTypePopover, setShowTypePopover] = useState(false);
+
   // Detect if using legacy API
   const isLegacyMode = legacyIsEditing !== undefined || legacyOnTitleEdit !== undefined;
+
+  const canChangeType = sectionType && isChangeableType(sectionType) && onChangeType;
 
   // Handle title save - pass the new title directly to bypass async state update issues
   const handleTitleSave = useCallback((newTitle: string) => {
@@ -117,21 +133,44 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
         />
       </div>
 
-      {onDelete && (
+      {(onDelete || canChangeType) && (
         <div className="flex items-center gap-2 flex-shrink-0 ml-4">
-          <button
-            type="button"
-            onClick={onDelete}
-            className="flex items-center gap-1.5 text-gray-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm font-medium hover:text-red-600 hover:border-red-300 hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
-            title="Remove Section"
-
-
-            aria-label={`Remove ${title || 'Section'}`}
-
-          >
-            <MdDeleteOutline className="text-lg" aria-hidden="true" />
-            <span className="hidden sm:inline">Remove</span>
-          </button>
+          {canChangeType && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setShowTypePopover(!showTypePopover)}
+                className="flex items-center gap-1.5 text-gray-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm font-medium hover:text-accent hover:border-accent/40 hover:bg-accent/[0.06] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+                title="Change Section Type"
+                aria-label="Change section type"
+              >
+                <MdSwapHoriz className="text-lg" aria-hidden="true" />
+                <span className="hidden sm:inline">Change Type</span>
+              </button>
+              {showTypePopover && (
+                <SectionTypePopover
+                  currentType={sectionType}
+                  onSelect={(type) => {
+                    onChangeType(type);
+                    setShowTypePopover(false);
+                  }}
+                  onClose={() => setShowTypePopover(false)}
+                />
+              )}
+            </div>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="flex items-center gap-1.5 text-gray-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm font-medium hover:text-red-600 hover:border-red-300 hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+              title="Remove Section"
+              aria-label={`Remove ${title || 'Section'}`}
+            >
+              <MdDeleteOutline className="text-lg" aria-hidden="true" />
+              <span className="hidden sm:inline">Remove</span>
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/resume-builder-ui/src/components/SectionTypeModal.tsx
+++ b/resume-builder-ui/src/components/SectionTypeModal.tsx
@@ -1,15 +1,7 @@
 import { useState } from 'react';
 import { MdVerticalAlignTop, MdVerticalAlignBottom } from 'react-icons/md';
 import { SectionType } from '../services/sectionService';
-import {
-  ExperienceVisual,
-  EducationVisual,
-  TextVisual,
-  BulletedListVisual,
-  InlineListVisual,
-  SmartTableVisual,
-  CertificationVisual,
-} from './sectionVisuals';
+import { ALL_SECTION_TYPE_OPTIONS } from './sectionTypeConfig';
 
 // Position types for section insertion
 export type InsertPosition = 'top' | 'bottom' | number;
@@ -26,13 +18,6 @@ interface SectionTypeModalProps {
   sections?: Section[];
 }
 
-interface SectionTypeOption {
-  type: SectionType;
-  title: string;
-  description: string;
-  Visual: React.FC<{ className?: string }>;
-}
-
 const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
   onClose,
   onSelect,
@@ -43,55 +28,10 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
   const [showAfterSection, setShowAfterSection] = useState(false);
   const [selectedType, setSelectedType] = useState<SectionType | null>(null);
 
-  const allSectionTypes: SectionTypeOption[] = [
-    {
-      type: "experience",
-      title: "Experience",
-      description: "Work history with company, title, dates, and achievements.",
-      Visual: ExperienceVisual,
-    },
-    {
-      type: "education",
-      title: "Education",
-      description: "Academic qualifications with degree, school, and year.",
-      Visual: EducationVisual,
-    },
-    {
-      type: "text",
-      title: "Text Block",
-      description: "Simple paragraph for summaries or statements.",
-      Visual: TextVisual,
-    },
-    {
-      type: "bulleted-list",
-      title: "Bulleted List",
-      description: "Traditional vertical list with bullet points.",
-      Visual: BulletedListVisual,
-    },
-    {
-      type: "inline-list",
-      title: "Inline List",
-      description: "Items displayed horizontally, flowing like tags.",
-      Visual: InlineListVisual,
-    },
-    {
-      type: "dynamic-column-list",
-      title: "Smart Table",
-      description: "Auto-arranges items in columns for space efficiency.",
-      Visual: SmartTableVisual,
-    },
-    {
-      type: "icon-list",
-      title: "Certifications",
-      description: "Professional certifications with issuer and dates.",
-      Visual: CertificationVisual,
-    },
-  ];
-
   // Filter out icon-list if template doesn't support icons
   const sectionTypes = supportsIcons
-    ? allSectionTypes
-    : allSectionTypes.filter(section => section.type !== "icon-list");
+    ? ALL_SECTION_TYPE_OPTIONS
+    : ALL_SECTION_TYPE_OPTIONS.filter(section => section.type !== "icon-list");
 
   const handleTopBottomSelect = (position: 'top' | 'bottom') => {
     setSelectedPosition(position);

--- a/resume-builder-ui/src/components/SectionTypePopover.tsx
+++ b/resume-builder-ui/src/components/SectionTypePopover.tsx
@@ -1,25 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { ChangeableSectionType, CHANGEABLE_TYPES, TYPE_DISPLAY_NAMES } from '../services/sectionService';
-import {
-  TextVisual,
-  BulletedListVisual,
-  InlineListVisual,
-  SmartTableVisual,
-} from './sectionVisuals';
-
-const TYPE_VISUALS: Record<ChangeableSectionType, React.FC<{ className?: string }>> = {
-  'text': TextVisual,
-  'bulleted-list': BulletedListVisual,
-  'inline-list': InlineListVisual,
-  'dynamic-column-list': SmartTableVisual,
-};
-
-const TYPE_DESCRIPTIONS: Record<ChangeableSectionType, string> = {
-  'text': 'Simple paragraph',
-  'bulleted-list': 'Vertical bullet points',
-  'inline-list': 'Horizontal flowing tags',
-  'dynamic-column-list': 'Auto-arranged columns',
-};
+import { ChangeableSectionType, CHANGEABLE_TYPES } from '../services/sectionService';
+import { ALL_SECTION_TYPE_OPTIONS } from './sectionTypeConfig';
 
 interface SectionTypePopoverProps {
   currentType: string;
@@ -60,7 +41,11 @@ const SectionTypePopover: React.FC<SectionTypePopoverProps> = ({
     return () => document.removeEventListener('keydown', handleKey);
   }, [onClose]);
 
-  const options = CHANGEABLE_TYPES.filter(t => t !== currentType);
+  // Show only changeable types, excluding the current one
+  const changeableSet = new Set<string>(CHANGEABLE_TYPES);
+  const options = ALL_SECTION_TYPE_OPTIONS.filter(
+    o => changeableSet.has(o.type) && o.type !== currentType
+  );
 
   return (
     <div
@@ -74,26 +59,23 @@ const SectionTypePopover: React.FC<SectionTypePopoverProps> = ({
           Change Type
         </span>
       </div>
-      {options.map(type => {
-        const Visual = TYPE_VISUALS[type];
-        return (
-          <button
-            key={type}
-            type="button"
-            role="option"
-            onClick={() => onSelect(type)}
-            className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent/[0.06] transition-colors text-left"
-          >
-            <div className="w-10 h-10 flex-shrink-0 flex items-center justify-center bg-gray-50 rounded-lg">
-              <Visual className="w-7 h-7" />
-            </div>
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-ink">{TYPE_DISPLAY_NAMES[type]}</div>
-              <div className="text-xs text-stone-warm">{TYPE_DESCRIPTIONS[type]}</div>
-            </div>
-          </button>
-        );
-      })}
+      {options.map(({ type, title, description, Visual }) => (
+        <button
+          key={type}
+          type="button"
+          role="option"
+          onClick={() => onSelect(type as ChangeableSectionType)}
+          className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent/[0.06] transition-colors text-left"
+        >
+          <div className="w-10 h-10 flex-shrink-0 flex items-center justify-center bg-gray-50 rounded-lg">
+            <Visual className="w-7 h-7" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-ink">{title}</div>
+            <div className="text-xs text-stone-warm">{description}</div>
+          </div>
+        </button>
+      ))}
     </div>
   );
 };

--- a/resume-builder-ui/src/components/SectionTypePopover.tsx
+++ b/resume-builder-ui/src/components/SectionTypePopover.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react';
+import { ChangeableSectionType, CHANGEABLE_TYPES, TYPE_DISPLAY_NAMES } from '../services/sectionService';
+import {
+  TextVisual,
+  BulletedListVisual,
+  InlineListVisual,
+  SmartTableVisual,
+} from './sectionVisuals';
+
+const TYPE_VISUALS: Record<ChangeableSectionType, React.FC<{ className?: string }>> = {
+  'text': TextVisual,
+  'bulleted-list': BulletedListVisual,
+  'inline-list': InlineListVisual,
+  'dynamic-column-list': SmartTableVisual,
+};
+
+const TYPE_DESCRIPTIONS: Record<ChangeableSectionType, string> = {
+  'text': 'Simple paragraph',
+  'bulleted-list': 'Vertical bullet points',
+  'inline-list': 'Horizontal flowing tags',
+  'dynamic-column-list': 'Auto-arranged columns',
+};
+
+interface SectionTypePopoverProps {
+  currentType: string;
+  onSelect: (type: ChangeableSectionType) => void;
+  onClose: () => void;
+}
+
+const SectionTypePopover: React.FC<SectionTypePopoverProps> = ({
+  currentType,
+  onSelect,
+  onClose,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on click outside
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    // Delay listener to avoid immediate close from the button click that opened this
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClick);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const options = CHANGEABLE_TYPES.filter(t => t !== currentType);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-2 w-64 bg-white rounded-xl shadow-lg border border-black/[0.06] z-50 overflow-hidden"
+      role="listbox"
+      aria-label="Change section type"
+    >
+      <div className="px-3 py-2 border-b border-gray-100">
+        <span className="text-xs font-semibold text-stone-warm uppercase tracking-wide">
+          Change Type
+        </span>
+      </div>
+      {options.map(type => {
+        const Visual = TYPE_VISUALS[type];
+        return (
+          <button
+            key={type}
+            type="button"
+            role="option"
+            onClick={() => onSelect(type)}
+            className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-accent/[0.06] transition-colors text-left"
+          >
+            <div className="w-10 h-10 flex-shrink-0 flex items-center justify-center bg-gray-50 rounded-lg">
+              <Visual className="w-7 h-7" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-ink">{TYPE_DISPLAY_NAMES[type]}</div>
+              <div className="text-xs text-stone-warm">{TYPE_DESCRIPTIONS[type]}</div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SectionTypePopover;

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -337,6 +337,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
                   handleDeleteSection={sectionManagement.handleDeleteSection}
                   handleDeleteEntry={sectionManagement.handleDeleteEntry}
                   handleReorderEntry={sectionManagement.handleReorderEntry}
+                  handleChangeSectionType={sectionManagement.handleChangeSectionType}
                   handleTitleEdit={sectionManagement.handleTitleEdit}
                   handleTitleSave={sectionManagement.handleTitleSave}
                   handleTitleCancel={sectionManagement.handleTitleCancel}

--- a/resume-builder-ui/src/components/editor/SectionRenderer.tsx
+++ b/resume-builder-ui/src/components/editor/SectionRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { Section, IconListItem } from '../../types';
 import { EditorContentIconRegistry } from './EditorContent';
+import { ChangeableSectionType } from '../../services/sectionService';
 import { isExperienceSection, isEducationSection } from '../../utils/sectionTypeChecker';
 import ExperienceSection from '../ExperienceSection';
 import EducationSection from '../EducationSection';
@@ -16,6 +17,7 @@ interface SectionRendererProps {
   handleDeleteSection: (index: number) => void;
   handleDeleteEntry: (sectionIndex: number, entryIndex: number) => void;
   handleReorderEntry: (sectionIndex: number, oldIndex: number, newIndex: number) => void;
+  handleChangeSectionType: (index: number, targetType: ChangeableSectionType) => void;
   handleTitleEdit: (index: number) => void;
   handleTitleSave: (newTitle?: string) => void;
   handleTitleCancel: () => void;
@@ -37,6 +39,7 @@ const SectionRenderer: React.FC<SectionRendererProps> = React.memo(({
   handleDeleteSection,
   handleDeleteEntry,
   handleReorderEntry,
+  handleChangeSectionType,
   handleTitleEdit,
   handleTitleSave,
   handleTitleCancel,
@@ -59,6 +62,10 @@ const SectionRenderer: React.FC<SectionRendererProps> = React.memo(({
   const onReorder = useCallback((oldIndex: number, newIndex: number) => {
     handleReorderEntry(index, oldIndex, newIndex);
   }, [handleReorderEntry, index]);
+
+  const onChangeType = useCallback((targetType: ChangeableSectionType) => {
+    handleChangeSectionType(index, targetType);
+  }, [handleChangeSectionType, index]);
 
   const onUpdate = useCallback((updatedContent: unknown) => {
     // Pass-through wrapper: content type varies by section and is enforced
@@ -141,6 +148,7 @@ const SectionRenderer: React.FC<SectionRendererProps> = React.memo(({
         isEditing={isEditingTitle}
         temporaryTitle={temporaryTitle}
         setTemporaryTitle={setTemporaryTitle}
+        onChangeType={onChangeType}
       />
     );
   }

--- a/resume-builder-ui/src/components/sectionTypeConfig.ts
+++ b/resume-builder-ui/src/components/sectionTypeConfig.ts
@@ -1,0 +1,73 @@
+// Shared section type metadata used by SectionTypeModal and SectionTypePopover.
+// Single source of truth for type labels, descriptions, and visuals.
+
+import { SectionType } from '../services/sectionService';
+import {
+  ExperienceVisual,
+  EducationVisual,
+  TextVisual,
+  BulletedListVisual,
+  InlineListVisual,
+  SmartTableVisual,
+  CertificationVisual,
+} from './sectionVisuals';
+
+export interface SectionTypeOption {
+  type: SectionType;
+  title: string;
+  description: string;
+  Visual: React.FC<{ className?: string }>;
+}
+
+/**
+ * Complete registry of all section types with display metadata.
+ * Order determines presentation order in UI.
+ */
+export const ALL_SECTION_TYPE_OPTIONS: SectionTypeOption[] = [
+  {
+    type: 'experience',
+    title: 'Experience',
+    description: 'Work history with company, title, dates, and achievements.',
+    Visual: ExperienceVisual,
+  },
+  {
+    type: 'education',
+    title: 'Education',
+    description: 'Academic qualifications with degree, school, and year.',
+    Visual: EducationVisual,
+  },
+  {
+    type: 'text',
+    title: 'Text Block',
+    description: 'Simple paragraph for summaries or statements.',
+    Visual: TextVisual,
+  },
+  {
+    type: 'bulleted-list',
+    title: 'Bulleted List',
+    description: 'Traditional vertical list with bullet points.',
+    Visual: BulletedListVisual,
+  },
+  {
+    type: 'inline-list',
+    title: 'Inline List',
+    description: 'Items displayed horizontally, flowing like tags.',
+    Visual: InlineListVisual,
+  },
+  {
+    type: 'dynamic-column-list',
+    title: 'Smart Table',
+    description: 'Auto-arranges items in columns for space efficiency.',
+    Visual: SmartTableVisual,
+  },
+  {
+    type: 'icon-list',
+    title: 'Certifications',
+    description: 'Professional certifications with issuer and dates.',
+    Visual: CertificationVisual,
+  },
+];
+
+/** Lookup a section type option by type key */
+export const getSectionTypeOption = (type: string): SectionTypeOption | undefined =>
+  ALL_SECTION_TYPE_OPTIONS.find(o => o.type === type);

--- a/resume-builder-ui/src/hooks/editor/useSectionManagement.ts
+++ b/resume-builder-ui/src/hooks/editor/useSectionManagement.ts
@@ -5,7 +5,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 import { Section } from '../../types';
 import { DeleteTarget, UseSectionManagementReturn } from '../../types/editor';
-import { createDefaultSection, deleteSectionItem, reorderSectionItems, SectionType } from '../../services/sectionService';
+import { createDefaultSection, deleteSectionItem, reorderSectionItems, convertSectionType, SectionType, ChangeableSectionType, TYPE_DISPLAY_NAMES } from '../../services/sectionService';
 import { InsertPosition } from '../../components/SectionTypeModal';
 
 /**
@@ -200,6 +200,26 @@ export const useSectionManagement = ({
   );
 
   /**
+   * Change a section's type in-place, converting content intelligently.
+   */
+  const handleChangeSectionType = useCallback(
+    (index: number, targetType: ChangeableSectionType) => {
+      setSections((currentSections) => {
+        const section = currentSections[index];
+        if (!section) return currentSections;
+
+        const converted = convertSectionType(section, targetType);
+        const newSections = [...currentSections];
+        newSections[index] = converted;
+        return newSections;
+      });
+
+      toast.success(`Changed to ${TYPE_DISPLAY_NAMES[targetType]}`);
+    },
+    [setSections]
+  );
+
+  /**
    * Confirm and execute the pending delete operation.
    * Handles both section deletion and entry deletion within sections.
    */
@@ -294,6 +314,7 @@ export const useSectionManagement = ({
       handleDeleteSection,
       handleDeleteEntry,
       handleReorderEntry,
+      handleChangeSectionType,
       confirmDelete,
 
       // Title editing
@@ -310,6 +331,7 @@ export const useSectionManagement = ({
       handleDeleteSection,
       handleDeleteEntry,
       handleReorderEntry,
+      handleChangeSectionType,
       confirmDelete,
       editingTitleIndex,
       temporaryTitle,

--- a/resume-builder-ui/src/services/__tests__/sectionConversion.test.ts
+++ b/resume-builder-ui/src/services/__tests__/sectionConversion.test.ts
@@ -1,0 +1,278 @@
+// src/services/__tests__/sectionConversion.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  convertSectionType,
+  isChangeableType,
+  CHANGEABLE_TYPES,
+  TYPE_DISPLAY_NAMES,
+  ChangeableSectionType,
+} from '../sectionService';
+import { Section } from '../../types';
+
+describe('isChangeableType', () => {
+  it.each([...CHANGEABLE_TYPES])('returns true for %s', (type) => {
+    expect(isChangeableType(type)).toBe(true);
+  });
+
+  it.each(['experience', 'education', 'icon-list', undefined, '', 'unknown'])('returns false for %s', (type) => {
+    expect(isChangeableType(type)).toBe(false);
+  });
+});
+
+describe('TYPE_DISPLAY_NAMES', () => {
+  it('has a display name for every changeable type', () => {
+    for (const type of CHANGEABLE_TYPES) {
+      expect(TYPE_DISPLAY_NAMES[type]).toBeTruthy();
+    }
+  });
+});
+
+describe('convertSectionType', () => {
+  const makeSection = (type: string, content: unknown, overrides?: Partial<Section>): Section => ({
+    id: 'test-id',
+    name: 'Test Section',
+    type,
+    content,
+    ...overrides,
+  } as Section);
+
+  // ─── Same type → no-op ──────────────────────────────
+
+  describe('same type → no-op', () => {
+    it('returns the exact same object (reference equality) when type is unchanged', () => {
+      const section = makeSection('text', 'Hello world');
+      const result = convertSectionType(section, 'text');
+      expect(result).toBe(section);
+    });
+
+    it.each([...CHANGEABLE_TYPES])('no-op for %s → %s', (type) => {
+      const content = type === 'text' ? 'some text' : ['item1', 'item2'];
+      const section = makeSection(type, content);
+      expect(convertSectionType(section, type as ChangeableSectionType)).toBe(section);
+    });
+  });
+
+  // ─── text → list types ──────────────────────────────
+
+  describe('text → list types', () => {
+    it('splits text by newlines into bulleted-list', () => {
+      const section = makeSection('text', 'Line 1\nLine 2\nLine 3');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.type).toBe('bulleted-list');
+      expect(result.content).toEqual(['Line 1', 'Line 2', 'Line 3']);
+    });
+
+    it('splits text into inline-list', () => {
+      const section = makeSection('text', 'Skill A\nSkill B');
+      const result = convertSectionType(section, 'inline-list');
+      expect(result.type).toBe('inline-list');
+      expect(result.content).toEqual(['Skill A', 'Skill B']);
+    });
+
+    it('splits text into dynamic-column-list', () => {
+      const section = makeSection('text', 'Item 1\nItem 2');
+      const result = convertSectionType(section, 'dynamic-column-list');
+      expect(result.type).toBe('dynamic-column-list');
+      expect(result.content).toEqual(['Item 1', 'Item 2']);
+    });
+
+    it('filters empty lines when splitting', () => {
+      const section = makeSection('text', 'Line 1\n\n\nLine 2\n  \n');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual(['Line 1', 'Line 2']);
+    });
+
+    it('handles empty string content', () => {
+      const section = makeSection('text', '');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual([]);
+    });
+
+    it('handles whitespace-only text', () => {
+      const section = makeSection('text', '   \n  \n\n');
+      const result = convertSectionType(section, 'inline-list');
+      expect(result.content).toEqual([]);
+    });
+
+    it('preserves leading/trailing whitespace within lines', () => {
+      const section = makeSection('text', '  indented line\ntrailing space  ');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual(['  indented line', 'trailing space  ']);
+    });
+
+    it('handles single line text (no newlines)', () => {
+      const section = makeSection('text', 'Just one line');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual(['Just one line']);
+    });
+
+    it('handles text with \\r\\n (Windows line endings)', () => {
+      const section = makeSection('text', 'Line A\r\nLine B');
+      const result = convertSectionType(section, 'bulleted-list');
+      // \r\n splits on \n, leaving \r on Line A — this is expected behavior
+      // The important thing is it doesn't break
+      expect(result.content).toHaveLength(2);
+    });
+  });
+
+  // ─── list types → text ──────────────────────────────
+
+  describe('list types → text', () => {
+    it('joins bulleted-list items with newlines', () => {
+      const section = makeSection('bulleted-list', ['Item A', 'Item B', 'Item C']);
+      const result = convertSectionType(section, 'text');
+      expect(result.type).toBe('text');
+      expect(result.content).toBe('Item A\nItem B\nItem C');
+    });
+
+    it('joins inline-list items with newlines', () => {
+      const section = makeSection('inline-list', ['Tag 1', 'Tag 2']);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('Tag 1\nTag 2');
+    });
+
+    it('joins dynamic-column-list items with newlines', () => {
+      const section = makeSection('dynamic-column-list', ['Col A', 'Col B']);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('Col A\nCol B');
+    });
+
+    it('handles empty list → empty string', () => {
+      const section = makeSection('bulleted-list', []);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('');
+    });
+
+    it('handles single item list', () => {
+      const section = makeSection('inline-list', ['Only item']);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('Only item');
+    });
+
+    it('handles list with empty string items', () => {
+      const section = makeSection('bulleted-list', ['', 'Real item', '']);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('\nReal item\n');
+    });
+  });
+
+  // ─── list type → list type ──────────────────────────
+
+  describe('list type → list type', () => {
+    it('converts bulleted-list to inline-list preserving content', () => {
+      const items = ['React', 'TypeScript', 'Node.js'];
+      const section = makeSection('bulleted-list', items);
+      const result = convertSectionType(section, 'inline-list');
+      expect(result.type).toBe('inline-list');
+      expect(result.content).toEqual(items);
+    });
+
+    it('converts inline-list to dynamic-column-list preserving content', () => {
+      const items = ['Python', 'Go'];
+      const section = makeSection('inline-list', items);
+      const result = convertSectionType(section, 'dynamic-column-list');
+      expect(result.type).toBe('dynamic-column-list');
+      expect(result.content).toEqual(items);
+    });
+
+    it('converts dynamic-column-list to bulleted-list preserving content', () => {
+      const items = ['A', 'B', 'C'];
+      const section = makeSection('dynamic-column-list', items);
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.type).toBe('bulleted-list');
+      expect(result.content).toEqual(items);
+    });
+
+    it('handles empty array between list types', () => {
+      const section = makeSection('bulleted-list', []);
+      const result = convertSectionType(section, 'dynamic-column-list');
+      expect(result.type).toBe('dynamic-column-list');
+      expect(result.content).toEqual([]);
+    });
+
+    it('does not mutate the original content array', () => {
+      const original = ['A', 'B'];
+      const section = makeSection('bulleted-list', original);
+      const result = convertSectionType(section, 'inline-list');
+      // Modify the result
+      (result.content as string[]).push('C');
+      // Original should be untouched
+      expect(original).toEqual(['A', 'B']);
+    });
+  });
+
+  // ─── Preservation guarantees ────────────────────────
+
+  describe('preserves id and name', () => {
+    it('keeps id and name unchanged after conversion', () => {
+      const section = makeSection('text', 'Some text');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.id).toBe('test-id');
+      expect(result.name).toBe('Test Section');
+    });
+
+    it('preserves custom id', () => {
+      const section = makeSection('bulleted-list', ['item'], { id: 'custom-uuid' });
+      const result = convertSectionType(section, 'text');
+      expect(result.id).toBe('custom-uuid');
+    });
+  });
+
+  // ─── Round-trip conversions ─────────────────────────
+
+  describe('round-trip conversions', () => {
+    it('text → bulleted-list → text preserves content', () => {
+      const original = 'Line 1\nLine 2\nLine 3';
+      const section = makeSection('text', original);
+      const asList = convertSectionType(section, 'bulleted-list');
+      const backToText = convertSectionType(asList, 'text');
+      expect(backToText.content).toBe(original);
+    });
+
+    it('bulleted-list → text → bulleted-list preserves content', () => {
+      const original = ['Item A', 'Item B'];
+      const section = makeSection('bulleted-list', original);
+      const asText = convertSectionType(section, 'text');
+      const backToList = convertSectionType(asText, 'bulleted-list');
+      expect(backToList.content).toEqual(original);
+    });
+
+    it('bulleted-list → inline-list → dynamic-column-list preserves content', () => {
+      const items = ['X', 'Y', 'Z'];
+      const section = makeSection('bulleted-list', items);
+      const asInline = convertSectionType(section, 'inline-list');
+      const asDynamic = convertSectionType(asInline, 'dynamic-column-list');
+      expect(asDynamic.content).toEqual(items);
+      expect(asDynamic.type).toBe('dynamic-column-list');
+    });
+  });
+
+  // ─── Edge cases ─────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles content with special characters', () => {
+      const section = makeSection('text', 'C++ & C#\nNode.js (v18)\n<html> tags');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual(['C++ & C#', 'Node.js (v18)', '<html> tags']);
+    });
+
+    it('handles very long content', () => {
+      const longText = Array.from({ length: 1000 }, (_, i) => `Item ${i}`).join('\n');
+      const section = makeSection('text', longText);
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toHaveLength(1000);
+    });
+
+    it('handles content with markdown formatting', () => {
+      const section = makeSection('bulleted-list', ['**bold**', '*italic*', '[link](url)']);
+      const result = convertSectionType(section, 'text');
+      expect(result.content).toBe('**bold**\n*italic*\n[link](url)');
+    });
+
+    it('handles content with unicode characters', () => {
+      const section = makeSection('text', 'Rsum\nCaf\nNaive');
+      const result = convertSectionType(section, 'inline-list');
+      expect(result.content).toEqual(['Rsum', 'Caf', 'Naive']);
+    });
+  });
+});

--- a/resume-builder-ui/src/services/__tests__/sectionConversion.test.ts
+++ b/resume-builder-ui/src/services/__tests__/sectionConversion.test.ts
@@ -109,9 +109,13 @@ describe('convertSectionType', () => {
     it('handles text with \\r\\n (Windows line endings)', () => {
       const section = makeSection('text', 'Line A\r\nLine B');
       const result = convertSectionType(section, 'bulleted-list');
-      // \r\n splits on \n, leaving \r on Line A — this is expected behavior
-      // The important thing is it doesn't break
-      expect(result.content).toHaveLength(2);
+      expect(result.content).toEqual(['Line A', 'Line B']);
+    });
+
+    it('handles mixed line endings (\\n and \\r\\n)', () => {
+      const section = makeSection('text', 'Line 1\nLine 2\r\nLine 3');
+      const result = convertSectionType(section, 'bulleted-list');
+      expect(result.content).toEqual(['Line 1', 'Line 2', 'Line 3']);
     });
   });
 

--- a/resume-builder-ui/src/services/sectionService.ts
+++ b/resume-builder-ui/src/services/sectionService.ts
@@ -251,7 +251,7 @@ export const convertSectionType = (
   if (sourceType === 'text') {
     // string → string[]
     const text = (section.content as string) || '';
-    newContent = text.split('\n').filter(line => line.trim() !== '');
+    newContent = text.split(/\r?\n/).filter(line => line.trim() !== '');
   } else if (targetType === 'text') {
     // string[] → string
     const items = (Array.isArray(section.content) ? section.content : []) as string[];

--- a/resume-builder-ui/src/services/sectionService.ts
+++ b/resume-builder-ui/src/services/sectionService.ts
@@ -27,6 +27,33 @@ export type SectionType =
   | 'education';
 
 /**
+ * Section types that support in-place type switching.
+ * Excludes experience, education (complex structured content), and icon-list (lossy conversion).
+ */
+export type ChangeableSectionType = 'text' | 'bulleted-list' | 'inline-list' | 'dynamic-column-list';
+
+export const CHANGEABLE_TYPES: readonly ChangeableSectionType[] = [
+  'text', 'bulleted-list', 'inline-list', 'dynamic-column-list',
+] as const;
+
+/**
+ * Display names for changeable types (used in toast messages and UI labels)
+ */
+export const TYPE_DISPLAY_NAMES: Record<ChangeableSectionType, string> = {
+  'text': 'Text Block',
+  'bulleted-list': 'Bulleted List',
+  'inline-list': 'Inline List',
+  'dynamic-column-list': 'Smart Table',
+};
+
+/**
+ * Checks whether a section type supports in-place type switching.
+ */
+export const isChangeableType = (type: string | undefined): type is ChangeableSectionType => {
+  return CHANGEABLE_TYPES.includes(type as ChangeableSectionType);
+};
+
+/**
  * Type name mapping for section types
  */
 const TYPE_NAME_MAP: Record<SectionType, string> = {
@@ -197,6 +224,48 @@ export const createDefaultSection = (
       return section;
     }
   }
+};
+
+/**
+ * Converts a section's content from one changeable type to another.
+ * Preserves id and name. Content is converted intelligently:
+ * - string[] ↔ string[]: content kept as-is, only type changes
+ * - string → string[]: split by newlines, filter empties
+ * - string[] → string: join with newlines
+ *
+ * @param section - The source section (must be a changeable type)
+ * @param targetType - The target changeable type
+ * @returns A new Section with converted type and content
+ */
+export const convertSectionType = (
+  section: Section,
+  targetType: ChangeableSectionType
+): Section => {
+  const sourceType = section.type;
+
+  // Same type — no-op
+  if (sourceType === targetType) return section;
+
+  let newContent: string | string[];
+
+  if (sourceType === 'text') {
+    // string → string[]
+    const text = (section.content as string) || '';
+    newContent = text.split('\n').filter(line => line.trim() !== '');
+  } else if (targetType === 'text') {
+    // string[] → string
+    const items = (Array.isArray(section.content) ? section.content : []) as string[];
+    newContent = items.join('\n');
+  } else {
+    // string[] → string[] (between list types) — keep content as-is
+    newContent = Array.isArray(section.content) ? [...section.content] : [];
+  }
+
+  return {
+    ...section,
+    type: targetType,
+    content: newContent,
+  } as Section;
 };
 
 /**

--- a/resume-builder-ui/src/types/editor.ts
+++ b/resume-builder-ui/src/types/editor.ts
@@ -4,7 +4,7 @@
 import React from 'react';
 import { ContactInfo, Section, SocialLink } from '../types';
 import { DragEndEvent, DragStartEvent, useSensors } from '@dnd-kit/core';
-import { SectionType } from '../services/sectionService';
+import { SectionType, ChangeableSectionType } from '../services/sectionService';
 import { InsertPosition } from '../components/SectionTypeModal';
 
 // --- Editor State Types ---
@@ -188,6 +188,7 @@ export interface UseSectionManagementReturn {
   handleDeleteSection: (index: number) => void;
   handleDeleteEntry: (sectionIndex: number, entryIndex: number) => void;
   handleReorderEntry: (sectionIndex: number, oldIndex: number, newIndex: number) => void;
+  handleChangeSectionType: (index: number, targetType: ChangeableSectionType) => void;
   confirmDelete: () => void;
 
   // Title editing


### PR DESCRIPTION
## Summary

- Add a **"Change Type" button** to each section header in the editor for changeable section types (text, bulleted-list, inline-list, dynamic-column-list)
- Clicking the button opens a **compact popover with visual preview cards** showing the available target types
- Content is **converted intelligently** on type switch (text split/joined by newlines, list-to-list preserves content as-is)
- Experience, education, and icon-list sections are **excluded** from type switching (structured data that doesn't convert cleanly)
- Extracted shared `sectionTypeConfig.ts` to eliminate duplication between `SectionTypeModal` and `SectionTypePopover`

### Conversion logic

| From → To | Strategy |
|-----------|----------|
| `string[]` ↔ `string[]` | Keep content, change type only |
| `string` → `string[]` | Split by newlines, filter empties |
| `string[]` → `string` | Join with newlines |

### Files changed

| File | Change |
|------|--------|
| `services/sectionService.ts` | `ChangeableSectionType`, `convertSectionType()`, helpers |
| `types/editor.ts` | `handleChangeSectionType` on return type |
| `hooks/editor/useSectionManagement.ts` | Handler + toast |
| `components/sectionTypeConfig.ts` | **NEW** — shared type metadata (DRY) |
| `components/SectionTypePopover.tsx` | **NEW** — compact popover |
| `components/SectionHeader.tsx` | Change Type button + popover trigger |
| `components/GenericSection.tsx` | Forward new props |
| `components/editor/SectionRenderer.tsx` | Thread handler |
| `components/editor/EditorContent.tsx` | Thread handler |
| `components/SectionTypeModal.tsx` | Use shared config |
| `services/__tests__/sectionConversion.test.ts` | **NEW** — 45 tests |

## Test plan

### Automated (45 tests)
- [x] `npx vitest run` — all 1457 tests pass (0 failures)

### Manual testing checklist

**Change Type button visibility:**
- [ ] "Change Type" button appears on **text** sections
- [ ] "Change Type" button appears on **bulleted-list** sections
- [ ] "Change Type" button appears on **inline-list** sections
- [ ] "Change Type" button appears on **dynamic-column-list** (Smart Table) sections
- [ ] "Change Type" button does **NOT** appear on **experience** sections
- [ ] "Change Type" button does **NOT** appear on **education** sections
- [ ] "Change Type" button does **NOT** appear on **icon-list** (Certifications) sections

**Popover behavior:**
- [ ] Clicking "Change Type" opens the popover below the button
- [ ] Popover shows only the other 3 types (excludes the current type)
- [ ] Each option shows the correct visual preview, title, and description
- [ ] Clicking outside the popover closes it
- [ ] Pressing Escape closes the popover
- [ ] Clicking "Change Type" again toggles the popover closed

**Content conversion — text → list:**
- [ ] Create a text section, type multi-line content, switch to bulleted-list → each line becomes a bullet
- [ ] Switch text to inline-list → each line becomes a tag
- [ ] Switch text to dynamic-column-list → each line becomes a column item
- [ ] Empty text section → converts to empty list (no crash)

**Content conversion — list → text:**
- [ ] Create a bulleted-list with items, switch to text → items joined by newlines
- [ ] Empty list → converts to empty text (no crash)

**Content conversion — list → list:**
- [ ] Switch bulleted-list to inline-list → all items preserved
- [ ] Switch inline-list to dynamic-column-list → all items preserved
- [ ] Switch dynamic-column-list to bulleted-list → all items preserved

**Round-trip:**
- [ ] text → bulleted-list → text → content matches original
- [ ] bulleted-list → inline-list → bulleted-list → content matches original

**Preservation:**
- [ ] Section **title** is unchanged after type switch
- [ ] Section **position** in the resume is unchanged after type switch

**Toast notification:**
- [ ] Toast appears on successful type change (e.g., "Changed to Bulleted List")

**Add Section modal (regression):**
- [ ] "Add New Section" modal still works correctly (no visual/behavioral changes)
- [ ] All 7 section types are still available in the modal
- [ ] Position selection (top/bottom/after) still works

**Responsive:**
- [ ] On mobile: "Change Type" button shows icon only (label hidden)
- [ ] On desktop: "Change Type" button shows icon + label
- [ ] Popover doesn't overflow viewport on small screens