### PR TITLE
🎨 Palette: [Add keyboard focus states to Confirm Dialog]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-01-01 - Add keyboard focus rings to custom modals
+**Learning:** Custom interactive components like `ResponsiveConfirmDialog` may overlook native-like keyboard focus indicators (`focus-visible`) despite having mouse hover states. Specifically, buttons handling destructive actions didn't offer a visual indication to keyboard-navigating users.
+**Action:** When creating or refining custom modals/dialogs, enforce adding explicit `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2` (or red ring for destructive confirm actions) to all clickable targets (Close icons, Cancel/Confirm buttons) to guarantee screen-reader and keyboard accessibility parity.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -42,8 +42,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2"
+    : "bg-accent hover:bg-accent/90 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +123,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}

--- a/resume-builder-ui/src/components/__tests__/ResponsiveConfirmDialog.test.tsx
+++ b/resume-builder-ui/src/components/__tests__/ResponsiveConfirmDialog.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ResponsiveConfirmDialog from '../ResponsiveConfirmDialog';
+
+describe('ResponsiveConfirmDialog', () => {
+  it('renders correctly and buttons are accessible', () => {
+    const handleClose = vi.fn();
+    const handleConfirm = vi.fn();
+
+    render(
+      <ResponsiveConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onClose={handleClose}
+        onConfirm={handleConfirm}
+      />
+    );
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+  });
+
+  it('buttons have focus-visible styles', () => {
+    const handleClose = vi.fn();
+    const handleConfirm = vi.fn();
+
+    render(
+      <ResponsiveConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onClose={handleClose}
+        onConfirm={handleConfirm}
+      />
+    );
+
+    const closeBtn = screen.getByRole('button', { name: 'Close dialog' });
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+
+    // Ensure buttons have focus-visible classes
+    expect(closeBtn.className).toMatch(/focus-visible:ring/);
+    expect(cancelBtn.className).toMatch(/focus-visible:ring/);
+    expect(confirmBtn.className).toMatch(/focus-visible:ring/);
+  });
+});


### PR DESCRIPTION
**💡 What**: Added `focus-visible` states to buttons inside `ResponsiveConfirmDialog`.
**🎯 Why**: The buttons previously lacked keyboard focus indicators, making the modal inaccessible to keyboard users and violating project accessibility standards.
**♿ Accessibility**: Interactive buttons (Close, Cancel, Confirm/Delete) now have explicit visual indicators (`ring-accent` or `ring-red-600`) when focused via keyboard navigation, aiding visibility. Added testing to prevent regression. Recorded UX accessibility learning in journal.

---
*PR created automatically by Jules for task [5933382755517005727](https://jules.google.com/task/5933382755517005727) started by @aafre*