### PR TITLE
⚡ Bolt: Prevent redundant auto-save processing via memoized resume data

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Memoizing objects passed to auto-save hooks
+**Learning:** Passing inline object literals to custom hooks like `useCloudSave` causes reference inequality on every render. This forces `useCallback` and `useEffect` dependencies inside the hook to update continuously, resulting in expensive operations (like `JSON.stringify` for deep diffing) running unnecessarily on every component re-render.
+**Action:** Always `useMemo` object parameters that are passed into hooks with deep dependency tracking, or structure the hook to accept primitives and stable references.

--- a/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
+++ b/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
@@ -68,6 +68,18 @@ export const useSaveIntegration = ({
     return iconsObj;
   }, [iconRegistry.getRegisteredFilenames().join(',')]);
 
+  // Memoize resumeData to prevent useCloudSave effect from running on every render
+  // This avoids expensive JSON.stringify serialization on keystrokes
+  const memoizedResumeData = useMemo(() => {
+    return contactInfo && templateId
+      ? {
+          contact_info: contactInfo,
+          sections: sections,
+          template_id: templateId,
+        }
+      : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' };
+  }, [contactInfo, sections, templateId]);
+
   const {
     saveStatus,
     lastSaved,
@@ -75,14 +87,7 @@ export const useSaveIntegration = ({
     resumeId: savedResumeId,
   } = useCloudSave({
     resumeId: cloudResumeId,
-    resumeData:
-      contactInfo && templateId
-        ? {
-            contact_info: contactInfo,
-            sections: sections,
-            template_id: templateId,
-          }
-        : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' },
+    resumeData: memoizedResumeData,
     icons: iconsForCloudSave,
     enabled: !!templateId && !!contactInfo && !isLoadingFromUrl && !authLoading,
     session: session,


### PR DESCRIPTION
💡 What: Wrapped the inline `resumeData` object passed from `useSaveIntegration.ts` to `useCloudSave` with a `useMemo` block.

🎯 Why: Passing an inline object literal caused it to be a new reference on every single render of the `useSaveIntegration` hook. This in turn forced the `useEffect` block inside `useCloudSave` to continuously track a "changed" dependency and unnecessarily execute `JSON.stringify` on the entire resume on every component render, even when the data itself had not mutated.

📊 Impact: Reduces CPU blocking by eliminating redundant O(N) serialization sweeps inside the auto-save loop, creating a much smoother typing and interaction experience for the user on large resumes.

🔬 Measurement: Verify via React Profiler that internal effects in `useCloudSave` now only run when the actual deep properties change, avoiding rapid re-evaluations during unrelated re-renders (like user idle updates or polling).

---
*PR created automatically by Jules for task [340806267519828884](https://jules.google.com/task/340806267519828884) started by @aafre*