### PR TITLE
⚡ Bolt: [performance improvement] Parallelize FileReader conversions

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-24 - Parallelizing FileReader Conversions
+**Learning:** Sequential `await` loops for independent asynchronous tasks (e.g., `FileReader` conversions in `useIconRegistry.ts`) are inefficient for I/O-bound tasks and cause unnecessary delays.
+**Action:** Refactor sequential `await` loops for independent tasks into concurrent operations using `Promise.all` and `Array.prototype.map`. Always maintain individual `try/catch` blocks within the map callback to prevent a single failure from aborting the entire batch.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,27 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
-      const entry = registry[filename];
-      if (entry) {
-        try {
-          const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
-          };
-        } catch (error) {
-          console.warn(`Failed to export icon ${filename}:`, error);
+    // ⚡ Bolt Performance Optimization:
+    // Parallelize independent I/O-bound tasks (FileReader conversions) using Promise.all
+    // instead of sequential await loops. This significantly reduces total conversion time for multiple icons.
+    await Promise.all(
+      targetFilenames.map(async (filename) => {
+        const entry = registry[filename];
+        if (entry) {
+          try {
+            const base64Data = await fileToBase64(entry.file);
+            exportData[filename] = {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            };
+          } catch (error) {
+            console.warn(`Failed to export icon ${filename}:`, error);
+          }
         }
-      }
-    }
+      })
+    );
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
💡 What: Refactored the sequential `await` loop in `useIconRegistry.ts`'s `exportIconsForYAML` function to use `Promise.all` with a concurrent `.map()`.
🎯 Why: `FileReader` operations are I/O-bound. Processing them sequentially adds unnecessary delay, especially for users with numerous icons. This acts as a bottleneck when exporting registry data.
📊 Impact: Expected to significantly reduce total conversion time for batches of icons by taking advantage of asynchronous I/O parallelization, resulting in faster export and storage operations.
🔬 Measurement: Verify by executing an export via `useIconRegistry` with multiple mock icons and measuring execution time or observing faster UI resolution when generating payload data for YAML or storage.

---
*PR created automatically by Jules for task [13902053794740086724](https://jules.google.com/task/13902053794740086724) started by @aafre*