### PR TITLE
⚡ Bolt: [performance improvement] Prevent referential inequality in useSaveIntegration

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Avoid Inline Object Literals in Hooks With Deep Dependency Tracking
+**Learning:** Passing inline object literals to custom hooks with deep dependency tracking (like `useCloudSave`) causes reference inequality on every render. Even though the actual content might be identical, the new object reference triggers the hook's `useEffect`, which in this case performs an expensive `JSON.stringify` operation to check for changes. This can cause significant main thread blocking on rapid keystrokes or minor state updates.
+**Action:** Always wrap object literal parameters passed to such hooks in a `useMemo`. This ensures referential equality is maintained as long as the underlying dependencies haven't actually changed.

--- a/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
+++ b/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
@@ -68,6 +68,19 @@ export const useSaveIntegration = ({
     return iconsObj;
   }, [iconRegistry.getRegisteredFilenames().join(',')]);
 
+  // Memoize resumeData to prevent reference inequality on every render.
+  // This prevents useCloudSave from needlessly running its internal effects
+  // and performing expensive JSON.stringify checks on unchanged data.
+  const resumeData = useMemo(() => {
+    return contactInfo && templateId
+      ? {
+          contact_info: contactInfo,
+          sections: sections,
+          template_id: templateId,
+        }
+      : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' };
+  }, [contactInfo, sections, templateId]);
+
   const {
     saveStatus,
     lastSaved,
@@ -75,14 +88,7 @@ export const useSaveIntegration = ({
     resumeId: savedResumeId,
   } = useCloudSave({
     resumeId: cloudResumeId,
-    resumeData:
-      contactInfo && templateId
-        ? {
-            contact_info: contactInfo,
-            sections: sections,
-            template_id: templateId,
-          }
-        : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' },
+    resumeData,
     icons: iconsForCloudSave,
     enabled: !!templateId && !!contactInfo && !isLoadingFromUrl && !authLoading,
     session: session,


### PR DESCRIPTION
💡 **What**: Extracted the inline object literal passed to `resumeData` inside `useSaveIntegration` into a `useMemo` hook.
🎯 **Why**: When an inline object literal is passed to a custom hook that performs deep dependency checks (like `useCloudSave` tracking its `resumeData` via `useEffect`), it creates referential inequality on every parent re-render. This was triggering the hook's effects and causing expensive synchronous `JSON.stringify` operations on unchanged data, unnecessarily eating into the main thread.
📊 **Impact**: Prevents redundant checks, reduces unneeded CPU cycles during rapid edits, and keeps the main thread smoother.
🔬 **Measurement**: Verified the logic using the test suite. Refer to the `.Jules/bolt.md` entry.

---
*PR created automatically by Jules for task [7856816318247420050](https://jules.google.com/task/7856816318247420050) started by @aafre*