### PR TITLE
⚡ Bolt: [performance improvement] Parallelize icon base64 conversions in useIconRegistry

### DIFF
--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,20 +169,33 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
+    // Use Promise.all to parallelize independent asynchronous file conversions
+    const exportPromises = targetFilenames.map(async (filename) => {
       const entry = registry[filename];
       if (entry) {
         try {
           const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
+          return {
+            filename,
+            data: {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            }
           };
         } catch (error) {
           console.warn(`Failed to export icon ${filename}:`, error);
         }
+      }
+      return null;
+    });
+
+    const results = await Promise.all(exportPromises);
+
+    for (const result of results) {
+      if (result) {
+        exportData[result.filename] = result.data;
       }
     }
 


### PR DESCRIPTION
💡 **What**: The `exportIconsForYAML` function in `useIconRegistry.ts` has been refactored to use `Promise.all` alongside `.map()` instead of a sequential `for...of` loop when converting file objects to Base64 strings.

🎯 **Why**: Previously, when exporting a resume with multiple icons, each icon was read into memory and converted to a base64 string sequentially, blocking the export process until the current file finished. This created an O(N) time complexity bottleneck bound by I/O.

📊 **Impact**: Reduces total export time for the icon registry from the sum of all individual file processing times to roughly the time of the longest single file operation. This will make cloud saving and YAML exporting measurably faster and more responsive for users with many icons in their resume.

🔬 **Measurement**: Verify by creating a resume with multiple custom icons and monitoring the time taken to trigger an auto-save or YAML export in the browser's Network/Performance tab. The individual Base64 conversions will execute concurrently without blocking each other.

---
*PR created automatically by Jules for task [14696179935633898018](https://jules.google.com/task/14696179935633898018) started by @aafre*