### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-28 - Optimizing I/O Bound Tasks with Promise.all()
+**Learning:** Sequential `await` loops inside data processing/export functions (like `fileToBase64` in `useIconRegistry`) create unnecessary bottlenecks, as I/O-bound tasks like FileReader conversions can run concurrently. Processing them sequentially adds cumulative delay.
+**Action:** When executing independent asynchronous tasks over a collection (e.g., converting multiple files), refactor the sequential loop into an array of Promises and use `Promise.all()` to execute them concurrently. Maintain isolated `try/catch` blocks within the `map` callback to ensure a single failure doesn't abort the entire batch.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,37 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
+    // Performance optimization: Process multiple file reads concurrently using Promise.all()
+    // instead of sequentially awaiting each one in a loop. This significantly reduces
+    // export time for resumes with many icons.
+    const exportPromises = targetFilenames.map(async (filename) => {
       const entry = registry[filename];
       if (entry) {
         try {
           const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
+          return {
+            filename,
+            data: {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            }
           };
         } catch (error) {
           console.warn(`Failed to export icon ${filename}:`, error);
+          return null;
         }
       }
-    }
+      return null;
+    });
+
+    const results = await Promise.all(exportPromises);
+    results.forEach(result => {
+      if (result) {
+        exportData[result.filename] = result.data;
+      }
+    });
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
💡 What: Changed the sequential await loop in `exportIconsForYAML` to use `Promise.all` across concurrently mapped functions.
🎯 Why: I/O bound tasks like FileReader conversions block synchronously when awaited inside iterative loops. Refactoring to parallel map+Promise.all allows the browser to process file conversions concurrently.
📊 Impact: Significantly speeds up resume generation/export for users with dense icon usage. Reduces cumulative task processing delay.
🔬 Measurement: Verify export functionality via `pnpm test` and code review. Time `exportIconsForYAML` operations with 10+ icon assets to observe relative duration drops.

---
*PR created automatically by Jules for task [15059762609156276201](https://jules.google.com/task/15059762609156276201) started by @aafre*