### PR TITLE
🎨 Palette: [UX improvement] Improve IconManager Keyboard Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-03-30 - Custom File Upload Accessibility
+**Learning:** When creating custom styled file upload zones, using `className="hidden"` on the actual `<input type="file">` removes it completely from the keyboard tab order, breaking accessibility for keyboard and screen reader users.
+**Action:** Always use Tailwind's `sr-only` class to visually hide the input while keeping it focusable. Pair this by adding the `peer` class to the input, and using `peer-focus-visible:ring-...` on the custom visible wrapper to ensure keyboard focus is clearly indicated to the user.

--- a/resume-builder-ui/src/components/IconManager.tsx
+++ b/resume-builder-ui/src/components/IconManager.tsx
@@ -153,8 +153,16 @@ const IconManager: React.FC<IconManagerProps> = ({
 
   return (
     <div className={`icon-manager relative w-12 h-12 ${className}`}>
-      <label className={`cursor-pointer relative group ${disabled ? 'pointer-events-none opacity-50' : ''}`}>
-        <div className="w-12 h-12 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center overflow-hidden bg-gray-50 group-hover:border-accent group-hover:bg-accent/[0.06] transition-all duration-200">
+      <label className={`cursor-pointer relative block group ${disabled ? 'pointer-events-none opacity-50' : ''}`}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="sr-only peer"
+          onChange={handleFileChange}
+          disabled={disabled || isUploading}
+        />
+        <div className="w-12 h-12 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center overflow-hidden bg-gray-50 group-hover:border-accent group-hover:bg-accent/[0.06] transition-all duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:ring-offset-2">
           {isUploading ? (
             <div className="animate-spin w-4 h-4 border-2 border-accent border-t-transparent rounded-full" />
           ) : iconPreview ? (
@@ -173,23 +181,15 @@ const IconManager: React.FC<IconManagerProps> = ({
             </div>
           )}
         </div>
-        
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handleFileChange}
-          disabled={disabled || isUploading}
-        />
       </label>
 
       {/* Clear button */}
       {iconPreview && !disabled && (
         <button
           type="button"
+          aria-label="Remove icon"
           onClick={handleClear}
-          className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs shadow-lg transition-colors duration-200"
+          className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs shadow-lg transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
           disabled={isUploading}
         >
           <FaTimes />


### PR DESCRIPTION
💡 **What:**
Improved the accessibility of the `IconManager` component. The underlying file `<input>` was previously styled with `hidden`, which removed it from the keyboard tab order entirely. It is now styled with `sr-only peer`, keeping it focusable by screen readers and keyboards while remaining visually hidden. The visible dropzone container now correctly displays a focus ring when the input receives focus. Additionally, the "Clear" icon button now has a proper `aria-label` and visible focus states.

🎯 **Why:**
Using `display: none` or Tailwind's `hidden` on file inputs breaks accessibility for keyboard navigators and screen readers. Users couldn't tab to the icon upload field or use the clear button efficiently. This change restores standard keyboard navigation flow and provides vital feedback for screen reader users.

📸 **Before/After:**
*(See attached automated verification screenshot)*
- Before: Tabbing skipped the file upload entirely. Tabbing to the "x" clear button showed no focus ring.
- After: Tabbing focuses the dropzone with a clear accent-colored ring. Tabbing to the "x" clear button shows a red focus ring.

♿ **Accessibility:**
- Replaced `hidden` with `sr-only` on file input.
- Leveraged `peer-focus-visible` to project focus styles.
- Added `aria-label` to the clear button.
- Added `focus-visible` states to the clear button.

---
*PR created automatically by Jules for task [3834906687424074526](https://jules.google.com/task/3834906687424074526) started by @aafre*