### PR TITLE
🎨 Palette: Add ARIA label and focus state to close button in UploadResumeModal

### DIFF
--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-lg p-1 -m-1"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label="Close modal"` and `focus-visible` styling to the `XMarkIcon` close button in the `UploadResumeModal` component.
🎯 Why: The icon-only button lacked an accessible name, making it difficult for screen reader users to understand its purpose. It also lacked a clear visual indicator for keyboard navigation.
📸 Before/After: Verified via Playwright that keyboard navigation now triggers a clear white focus ring on the close button.
♿ Accessibility: Improved screen reader experience by providing an explicit ARIA label and enhanced keyboard accessibility with clear focus states.

---
*PR created automatically by Jules for task [5950397645050069236](https://jules.google.com/task/5950397645050069236) started by @aafre*