### PR TITLE
🎨 Palette: [UX improvement] Fix file input keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-05 - File Input Accessibility
+**Learning:** Using `display: none` or Tailwind's `hidden` on custom `<input type="file">` elements removes them from the keyboard tab order and screen readers, making file uploads inaccessible.
+**Action:** Always use `sr-only peer` on the `<input type="file">` element (ensuring it is placed *before* its visual wrapper/label in the DOM) and apply `peer-focus-visible` styling (like `peer-focus-visible:ring-2 peer-focus-visible:ring-accent`) on the subsequent sibling element to maintain keyboard accessibility and visual focus states.

--- a/resume-builder-ui/src/components/IconManager.tsx
+++ b/resume-builder-ui/src/components/IconManager.tsx
@@ -154,7 +154,15 @@ const IconManager: React.FC<IconManagerProps> = ({
   return (
     <div className={`icon-manager relative w-12 h-12 ${className}`}>
       <label className={`cursor-pointer relative group ${disabled ? 'pointer-events-none opacity-50' : ''}`}>
-        <div className="w-12 h-12 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center overflow-hidden bg-gray-50 group-hover:border-accent group-hover:bg-accent/[0.06] transition-all duration-200">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="sr-only peer"
+          onChange={handleFileChange}
+          disabled={disabled || isUploading}
+        />
+        <div className="w-12 h-12 rounded-lg border-2 border-dashed border-gray-300 flex items-center justify-center overflow-hidden bg-gray-50 group-hover:border-accent group-hover:bg-accent/[0.06] transition-all duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:border-transparent">
           {isUploading ? (
             <div className="animate-spin w-4 h-4 border-2 border-accent border-t-transparent rounded-full" />
           ) : iconPreview ? (
@@ -173,15 +181,6 @@ const IconManager: React.FC<IconManagerProps> = ({
             </div>
           )}
         </div>
-        
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handleFileChange}
-          disabled={disabled || isUploading}
-        />
       </label>
 
       {/* Clear button */}

--- a/resume-builder-ui/src/components/TemplateStartModal.tsx
+++ b/resume-builder-ui/src/components/TemplateStartModal.tsx
@@ -176,23 +176,23 @@ export const TemplateStartModal: React.FC<TemplateStartModalProps> = ({
                 <p className="text-xs text-gray-500 mb-3">
                   We'll extract your data automatically
                 </p>
-                <button
-                  type="button"
-                  className="btn-primary px-4 py-2 text-sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    fileInputRef.current?.click();
-                  }}
-                >
-                  Browse Files
-                </button>
                 <input
+                  id="template-start-file-input"
                   ref={fileInputRef}
                   type="file"
                   accept=".pdf,.docx"
-                  className="hidden"
+                  className="sr-only peer"
                   onChange={handleFileInput}
                 />
+                <label
+                  htmlFor="template-start-file-input"
+                  className="btn-primary px-4 py-2 text-sm cursor-pointer peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-accent"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  Browse Files
+                </label>
                 <p className="text-xs text-gray-400 mt-2">Max 10MB • PDF or DOCX</p>
               </div>
             )}

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -208,12 +208,12 @@ export function UploadResumeModal({
                 accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 onChange={handleFileInput}
                 disabled={parsing}
-                className="hidden"
+                className="sr-only peer"
                 id="resume-file-input"
               />
               <label
                 htmlFor="resume-file-input"
-                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-accent"
               >
                 <DocumentArrowUpIcon className="w-5 h-5" />
                 {parsing ? 'Parsing...' : 'Choose File'}


### PR DESCRIPTION
💡 **What:** Refactored custom file input components to use screen-reader friendly styling instead of `display: none` and added explicit keyboard focus states to their labels.
🎯 **Why:** Previously, using Tailwind's `hidden` class completely removed the file inputs from the DOM's accessibility tree, meaning users navigating with keyboards (tabbing) or screen readers could not interact with the file upload functionality.
📸 **Before/After:** No visual changes for mouse users, but keyboard users will now see a bright focus ring when tabbing onto the file upload areas.
♿ **Accessibility:** Replaced `hidden` with `sr-only peer` on inputs and added `peer-focus-visible:ring-2` to the corresponding labels, ensuring full keyboard navigation and screen reader support for file uploads.

---
*PR created automatically by Jules for task [10385395827234519467](https://jules.google.com/task/10385395827234519467) started by @aafre*