### PR TITLE
🎨 Palette: [UX improvement] Add focus indicator to ResumeCard download button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-04-05 - Keyboard Focus Visibility on Icon Buttons
+**Learning:** Custom inline icon buttons within mapped card components (like the Download PDF button on `ResumeCard`) often miss explicit keyboard focus indicators if they only use `hover` state classes, making them invisible to keyboard-only users navigating the card actions.
+**Action:** Always verify keyboard focus states and explicitly add `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent` (or similar design system focus tokens) to custom icon-only buttons to ensure they remain accessible and highly visible during keyboard navigation.

--- a/resume-builder-ui/src/components/ResumeCard.tsx
+++ b/resume-builder-ui/src/components/ResumeCard.tsx
@@ -243,7 +243,7 @@ export function ResumeCard({
               e.stopPropagation();
               onDownload(resume.id);
             }}
-            className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             title="Download PDF"
             aria-label="Download PDF"
           >


### PR DESCRIPTION
💡 **What:** Added `focus-visible` styling (`focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`) to the `Download PDF` icon button in the `ResumeCard` component.

🎯 **Why:** Custom inline icon buttons that only rely on `hover` states are effectively invisible to users navigating the site via keyboard. This prevents keyboard-only users from easily knowing when they are focused on the download action. 

♿ **Accessibility:** This specific improvement ensures that keyboard users will see a clear, distinct visual focus ring (matching the existing design system accent color) when tabbing to the download button, vastly improving the usability of the primary user dashboard.

---
*PR created automatically by Jules for task [6681330511850818057](https://jules.google.com/task/6681330511850818057) started by @aafre*