### PR TITLE
🎨 Palette: Add accessible close button to UploadResumeModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-04-07 - Accessible Modal Close Buttons on Dark Backgrounds
+**Learning:** In modals with dark headers (e.g. `bg-ink`), default focus rings (which are often blue or black) have poor contrast and fail accessibility standards for keyboard users. Furthermore, icon-only buttons (like `XMarkIcon`) often miss `aria-label`s, preventing screen readers from communicating their purpose.
+**Action:** When adding close buttons or any icon-only actions on dark backgrounds, explicitly define `focus-visible:ring-white` alongside `focus:outline-none` and `rounded-md`, and always include a descriptive `aria-label` (e.g. "Close modal").

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-md"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Close modal"` and a high-contrast focus ring (`focus-visible:ring-2 focus-visible:ring-white rounded-md`) to the close button (`XMarkIcon`) in the `UploadResumeModal`.

🎯 **Why:** The close button is an icon-only button sitting on a dark header (`bg-ink`). Without an `aria-label`, screen readers cannot announce its purpose. Additionally, the default focus indicator has poor contrast against the dark background, making it difficult for keyboard users to see when the button is focused.

📸 **Before/After:** The button now has an explicit white focus ring when navigated via keyboard.

♿ **Accessibility:**
- Added `aria-label` for screen reader support.
- Added explicit `focus-visible` ring with `ring-white` for proper color contrast against the dark background.

---
*PR created automatically by Jules for task [3266689154396301314](https://jules.google.com/task/3266689154396301314) started by @aafre*