### PR TITLE
fix(seo): post-v3.24.0 CTR optimizations for high-impression pages

### DIFF
--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -4,8 +4,8 @@ import BlogLayout from '../BlogLayout';
 export default function BestFreeResumeBuilders2026() {
   return (
     <BlogLayout
-      title="9 Best Free Resume Builders in 2026 (Honestly Reviewed)"
-      description="We tested 9 free resume builders so you don't have to. Real pricing, actual free tiers, ATS compatibility, and export formats — no affiliate bias."
+      title="9 Best Free Resume Builders in 2026 (We Tested Every One)"
+      description="We built the same resume on 9 'free' builders and documented what actually costs money. See which ones are truly free to download as PDF, no paywall."
       publishDate="2026-03-05"
       readTime="14 min"
       keywords={[

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -7,6 +7,7 @@ export default function BestFreeResumeBuilders2026() {
       title="9 Best Free Resume Builders in 2026 (We Tested Every One)"
       description="We built the same resume on 9 'free' builders and documented what actually costs money. See which ones are truly free to download as PDF, no paywall."
       publishDate="2026-03-05"
+      lastUpdated="2026-04-11"
       readTime="14 min"
       keywords={[
         'best free resume builder',

--- a/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
@@ -35,7 +35,7 @@ export default function FlowCVVsEasyFreeResume() {
   const schema = generateComparisonSchema(
     EASY_FREE_RESUME_PRODUCT,
     { name: "FlowCV", price: "0", description: "Free online resume builder with customizable templates and a Pro plan for additional features." },
-    "2026-02-04"
+    "2026-04-11"
   );
 
   return (
@@ -44,10 +44,10 @@ export default function FlowCVVsEasyFreeResume() {
         <script type="application/ld+json">{JSON.stringify(schema)}</script>
       </Helmet>
       <BlogLayout
-      title="FlowCV Review 2026: Is It Really Free? (Honest Look)"
-      description="Both FlowCV and EasyFreeResume offer free resume building. Compare features, privacy, and templates to see which free option is truly better for your job search."
+      title="FlowCV vs EasyFreeResume (2026): Features, Pricing & Privacy Compared"
+      description="FlowCV requires sign-up and limits free exports. Compare FlowCV and EasyFreeResume side-by-side on templates, ATS compatibility, pricing, and privacy."
       publishDate="2026-01-21"
-      lastUpdated="2026-02-04"
+      lastUpdated="2026-04-11"
       readTime="7 min"
       keywords={[
         "flowcv review",

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -112,7 +112,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/novoresume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   { loc: '/blog/enhancv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-04' },
   { loc: '/blog/canva-resume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
-  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-04' },
+  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
   { loc: '/easyfreeresume-vs-indeed-resume-builder', priority: 0.7, changefreq: 'monthly', lastmod: '2026-02-10' },
 
   // Static Pages (0.3)

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -80,7 +80,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/behavioral-interview-questions', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/introducing-prepai-ai-interview-coach', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/how-to-write-a-resume-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
+  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
   { loc: '/blog/resume-action-verbs', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/how-to-use-resume-keywords', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   // /resume-keywords/software-engineer is auto-generated from JOBS_DATABASE (priority 0.9)

--- a/resume-builder-ui/src/utils/seoHelpers.ts
+++ b/resume-builder-ui/src/utils/seoHelpers.ts
@@ -3,21 +3,21 @@ import { getTotalKeywordCount } from './jobKeywordHelpers';
 
 /**
  * Generate standardized SEO title for job keywords pages
- * Formula: "Free {Job Title} Resume Keywords & Skills List ({current_year}) - ATS Friendly"
+ * Formula: "{Job Title} Resume Keywords That Pass ATS Filters ({current_year})"
  */
 export function generateJobPageTitle(job: JobKeywordsData): string {
   const year = new Date().getFullYear();
-  return `Free ${job.title} Resume Keywords & Skills List (${year}) - ATS Friendly`;
+  return `${job.title} Resume Keywords That Pass ATS Filters (${year})`;
 }
 
 /**
  * Generate dynamic meta description including top 3 technical skills
- * Formula: "Free {job} resume keywords including {skill1}, {skill2}, {skill3}, and {count}+ more ATS-optimized skills. Updated for {year}."
+ * Formula: "{count}+ proven {job} resume keywords including {skill1}, {skill2}, {skill3}. Copy-paste ready skills organized by category to beat ATS screening. Updated {year}."
  */
 export function generateJobPageDescription(job: JobKeywordsData): string {
   const year = new Date().getFullYear();
   const topSkills = job.keywords.technical.slice(0, 3);
   const totalCount = getTotalKeywordCount(job);
 
-  return `Free ${job.title.toLowerCase()} resume keywords${topSkills.length > 0 ? ` including ${topSkills.join(', ')}` : ''}. Get ${totalCount}+ ATS-optimized skills. Updated for ${year}.`;
+  return `${totalCount}+ proven ${job.title.toLowerCase()} resume keywords${topSkills.length > 0 ? ` including ${topSkills.join(', ')}` : ''}. Copy-paste ready skills organized by category to beat ATS screening. Updated ${year}.`;
 }


### PR DESCRIPTION
## Context

Post-v3.24.0 GSC analysis shows **breakout growth** — daily clicks went from ~16/day to 56/day (3.5x). The meta tag dedup fix (v3.24.0) and content enrichment (v3.23.0) are clearly working together.

However, several high-impression pages have near-zero CTR — meta title/description optimization to capitalize on the momentum.

## Changes

### 1. FlowCV comparison meta rewrite
- **File:** `FlowCVVsEasyFreeResume.tsx`, `sitemapUrls.ts`
- **GSC before:** 14,792 impressions, pos 6.9, CTR **0.14%** (20 clicks/12d)
- **Problem:** Title "FlowCV Review 2026: Is It Really Free?" doesn't match "flowcv" branded search intent (10,212 impressions for just that query)
- Title → "FlowCV vs EasyFreeResume (2026): Features, Pricing & Privacy Compared"
- Description → highlights sign-up requirement and side-by-side comparison
- Updated `dateModified`, `lastUpdated`, sitemap `lastmod`

### 2. Best Free Resume Builders meta rewrite
- **File:** `BestFreeResumeBuilders2026.tsx`, `sitemapUrls.ts`
- **GSC before:** 1,585 impressions, pos 9.8, CTR **0%** (0 clicks/12d)
- **Problem:** Title "Honestly Reviewed" is generic and indistinguishable from competitor roundups
- Title → "9 Best Free Resume Builders in 2026 (We Tested Every One)"
- Description → leads with the paywall discovery angle

### 3. Keyword page meta template optimization
- **File:** `seoHelpers.ts`
- **GSC before:** devops-engineer pos 9.4, software-engineer pos 13.3, customer-service pos 16.9 — all **0 clicks**
- **Problem:** Title started with "Free" (noise) and description read like a template
- Title → `{Job Title} Resume Keywords That Pass ATS Filters ({year})`
- Description → "{count}+ proven ... Copy-paste ready skills organized by category to beat ATS screening"
- Affects all 20+ `/resume-keywords/*` pages

## Risk
- **Low** — meta-only changes, no content/structural/URL changes
- No Tier 1 pages modified
- FlowCV page is Tier 2 candidate (being added)

## Test plan
- [x] `npx vitest run` — 1,437 tests pass, 0 failures
- [x] Sitemap lastmod dates verified
- [ ] Post-deploy: GSC snapshot at ~April 25 (2 weeks) — compare CTR on modified pages
- [ ] Monitor FlowCV CTR specifically — target 1%+ (from 0.14%)
- [ ] Monitor keyword page positions — ensure no regression from title change