### PR TITLE
🎨 Palette: Add keyboard accessibility to resume cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Custom Clickable Cards Require Keyboard Accessibility
+**Learning:** Custom interactive elements designed as cards or clickable block areas (such as `GhostCard`'s "Create New Resume" or `ResumeCard`'s thumbnail preview) often implement only `onClick` handlers. This creates a critical accessibility gap for keyboard navigation, as users cannot tab to or activate the action without a mouse, and screen readers fail to identify the element correctly.
+**Action:** Always convert custom interactive components to accessible buttons by adding `role="button"`, `tabIndex={0}`, an `onKeyDown` handler for `Enter` and `Space` keys, and explicit focus indicators (e.g., `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2`).

--- a/resume-builder-ui/src/components/GhostCard.tsx
+++ b/resume-builder-ui/src/components/GhostCard.tsx
@@ -71,7 +71,15 @@ export function GhostCard({ isAtLimit, resumeCount, onCreateNew }: GhostCardProp
   return (
     <div
       onClick={onCreateNew}
-      className="h-full min-h-[320px] border-2 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06]/20 transition-all duration-200 group"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onCreateNew();
+        }
+      }}
+      className="h-full min-h-[320px] border-2 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06]/20 transition-all duration-200 group focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
     >
       <PlusCircle className="w-16 h-16 text-gray-400 mb-4 group-hover:text-accent group-hover:scale-110 transition-all duration-200" />
 

--- a/resume-builder-ui/src/components/ResumeCard.tsx
+++ b/resume-builder-ui/src/components/ResumeCard.tsx
@@ -101,7 +101,7 @@ export function ResumeCard({
     try {
       await onRename(resume.id, trimmedTitle);
       setIsEditing(false);
-    } catch (error) {
+    } catch {
       // Revert on error
       setEditedTitle(resume.title);
       setIsEditing(false);
@@ -126,7 +126,7 @@ export function ResumeCard({
             e.currentTarget.click();
           }
         }}
-        className={`relative bg-gray-100 h-48 overflow-hidden rounded-t-lg ${
+        className={`relative bg-gray-100 h-48 overflow-hidden rounded-t-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
           isPreviewLoading ? 'cursor-wait' : 'cursor-pointer'
         }`}
         onClick={() => !isPreviewLoading && onPreview(resume.id)}


### PR DESCRIPTION
**What:**
- Converted the "Create New Resume" `GhostCard` to act as an accessible button, complete with keyboard event handlers (`Enter` and `Space`) and proper ARIA roles.
- Added explicit keyboard focus rings (`focus-visible:ring-accent`) to both the `GhostCard` and the `ResumeCard` thumbnail preview containers.
- Cleaned up an unused `error` variable in `ResumeCard.tsx`'s rename handler.
- Documented learnings about custom interactive block elements in `.Jules/palette.md`.

**Why:**
Custom elements relying solely on `onClick` exclude users navigating via keyboard. Without explicit `tabIndex`, event handlers, and `focus-visible` states, these primary actions were completely inaccessible and invisible to non-mouse users.

**Before/After:**
- **Before:** Tabbing through the "My Resumes" page bypassed the `GhostCard` and provided no visual focus state when tabbing onto the `ResumeCard` preview container. Pressing Enter/Space on focused elements did nothing.
- **After:** The `GhostCard` is included in the natural tab order, shows a clear green focus ring (`#10b981`), and activates on `Enter`/`Space`. `ResumeCard` thumbnails now also show clear focus outlines.

**Accessibility:**
- Added `role="button"` and `tabIndex={0}` to custom `div` click targets.
- Added `onKeyDown` handlers for `Enter` and `Space` keys (with `preventDefault()` on Space to stop page scrolling).
- Implemented `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent` to clearly delineate focus state.

---
*PR created automatically by Jules for task [10133055757478708374](https://jules.google.com/task/10133055757478708374) started by @aafre*