### PR TITLE
perf: optimize Docker build from ~15min to ~2-4min

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
 FROM node:25-slim AS react-build
 
-# Build-time arguments for Vite (frontend environment variables)
-# These get embedded into the JavaScript bundle during build
+WORKDIR /app/react
+COPY resume-builder-ui/package*.json ./
+
+# Dependencies — cached unless package.json changes
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --prefer-offline
+
+# Playwright browser — cached unless @playwright/test version changes
+RUN --mount=type=cache,target=/root/.cache/ms-playwright \
+    npx playwright install --with-deps chromium
+
+# Build args declared AFTER dependency layers so changing them
+# (e.g. VITE_APP_VERSION with git hash) doesn't bust npm/playwright cache.
+# COPY below uses content hashing — any source file change triggers a rebuild.
 ARG VITE_SUPABASE_URL
 ARG VITE_SUPABASE_PUBLISHABLE_KEY
 ARG VITE_APP_URL
@@ -11,8 +23,6 @@ ARG VITE_AFFILIATE_RESUME_REVIEW_ENABLED
 ARG VITE_AFFILIATE_RESUME_REVIEW_URL
 ARG VITE_APP_VERSION
 ARG VITE_POSTHOG_KEY
-
-# Set as environment variables for Vite build process
 ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
 ENV VITE_SUPABASE_PUBLISHABLE_KEY=$VITE_SUPABASE_PUBLISHABLE_KEY
 ENV VITE_APP_URL=$VITE_APP_URL
@@ -23,20 +33,12 @@ ENV VITE_AFFILIATE_RESUME_REVIEW_URL=$VITE_AFFILIATE_RESUME_REVIEW_URL
 ENV VITE_APP_VERSION=$VITE_APP_VERSION
 ENV VITE_POSTHOG_KEY=$VITE_POSTHOG_KEY
 
-WORKDIR /app/react
-COPY resume-builder-ui/package*.json ./
-
-# Use cache mount for npm to speed up subsequent builds
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --prefer-offline
-
+# Source code — content-hashed, rebuilds on ANY file change
 COPY resume-builder-ui/ ./
 
 # Build React app with embedded environment variables and prerender
 # SEO-critical routes to static HTML for bot user-agents (Googlebot, etc.)
-RUN --mount=type=cache,target=/root/.cache/ms-playwright \
-    npx playwright install --with-deps chromium && \
-    npm run build:prerender
+RUN npm run build:prerender
 
 
 # Step 2: Set up Flask with Python 3.13 on Bookworm (LaTeX-friendly)
@@ -63,7 +65,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         fonts-liberation \
         curl \
         poppler-utils && \
-    fc-cache -f && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ COPY resume-builder-ui/ ./
 
 # Build React app with embedded environment variables and prerender
 # SEO-critical routes to static HTML for bot user-agents (Googlebot, etc.)
-RUN npm run build:prerender
+# .build-version is read by build scripts to verify freshness after build
+RUN npm run build:prerender && echo "$VITE_APP_VERSION" > dist/.build-version
 
 
 # Step 2: Set up Flask with Python 3.13 on Bookworm (LaTeX-friendly)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ COPY resume-builder-ui/package*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --prefer-offline
 
-# Playwright browser — cached unless @playwright/test version changes
-RUN --mount=type=cache,target=/root/.cache/ms-playwright \
-    npx playwright install --with-deps chromium
+# Playwright browser — cached unless @playwright/test version changes.
+# No cache mount here: the binary must persist in the layer for later RUN steps.
+RUN npx playwright install --with-deps chromium
 
 # Build args declared AFTER dependency layers so changing them
 # (e.g. VITE_APP_VERSION with git hash) doesn't bust npm/playwright cache.

--- a/resume-builder-ui/scripts/prerender.ts
+++ b/resume-builder-ui/scripts/prerender.ts
@@ -196,10 +196,16 @@ async function prerender() {
     }
   );
 
+  const concurrency = parseInt(process.env.PRERENDER_CONCURRENCY || '5', 10);
+  console.log(`  Concurrency: ${concurrency} page${concurrency > 1 ? 's' : ''}`);
+
   let successCount = 0;
   let failCount = 0;
 
-  for (const route of ROUTES_TO_PRERENDER) {
+  /**
+   * Render a single route: navigate, wait for hydration, extract HTML, save.
+   */
+  async function renderRoute(route: string): Promise<void> {
     const page = await context.newPage();
 
     try {
@@ -258,6 +264,20 @@ async function prerender() {
       await page.close();
     }
   }
+
+  // Process routes with a concurrency-limited worker pool.
+  // Each worker pulls the next unprocessed route from a shared index.
+  let nextIndex = 0;
+  async function worker(): Promise<void> {
+    while (nextIndex < ROUTES_TO_PRERENDER.length) {
+      const route = ROUTES_TO_PRERENDER[nextIndex++];
+      await renderRoute(route);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, ROUTES_TO_PRERENDER.length) }, () => worker())
+  );
 
   await browser.close();
   server.close();

--- a/resume-builder-ui/scripts/prerender.ts
+++ b/resume-builder-ui/scripts/prerender.ts
@@ -196,7 +196,7 @@ async function prerender() {
     }
   );
 
-  const concurrency = parseInt(process.env.PRERENDER_CONCURRENCY || '5', 10);
+  const concurrency = parseInt(process.env.PRERENDER_CONCURRENCY || '5', 10) || 5;
   console.log(`  Concurrency: ${concurrency} page${concurrency > 1 ? 's' : ''}`);
 
   let successCount = 0;

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -62,7 +62,7 @@ Write-Host "  VITE_AFFILIATE_RESUME_REVIEW_ENABLED: $VITE_AFFILIATE_RESUME_REVIE
 Write-Host "  VITE_APP_VERSION: $VITE_APP_VERSION"
 Write-Host "  VITE_POSTHOG_KEY: $(if ($VITE_POSTHOG_KEY) { $VITE_POSTHOG_KEY.Substring(0,8) + '...' } else { '(not set)' })"
 
-docker build --no-cache `
+docker build `
     --build-arg VITE_SUPABASE_URL="$VITE_SUPABASE_URL" `
     --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="$VITE_SUPABASE_PUBLISHABLE_KEY" `
     --build-arg VITE_APP_URL="$VITE_APP_URL" `
@@ -84,6 +84,17 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host ""
 Write-Host "Build complete!"
+Write-Host ""
+
+# Verify build freshness — confirms code changes were picked up
+Write-Host "Verifying build freshness..."
+$baked = docker run --rm "${IMAGE_NAME}:${TAG}" python -c "import os; print(os.environ.get('VITE_APP_VERSION','unknown'))"
+Write-Host "  Baked version : $baked"
+Write-Host "  Expected      : $VITE_APP_VERSION"
+if ($baked.Trim() -ne $VITE_APP_VERSION) {
+    Write-Warning "Version mismatch — build may have used stale cache. Re-run with: docker build --no-cache ..."
+}
+Write-Host ""
 Write-Host "To push: docker push ${REGISTRY}/${IMAGE_NAME}:${TAG}"
 Write-Host ""
 Write-Host "To test locally:"
@@ -93,3 +104,6 @@ Write-Host "    -e SUPABASE_SECRET_KEY=$SUPABASE_SECRET_KEY ``"
 Write-Host "    -e ADZUNA_APP_ID=`$ADZUNA_APP_ID ``"
 Write-Host "    -e ADZUNA_APP_KEY=`$ADZUNA_APP_KEY ``"
 Write-Host "    ${IMAGE_NAME}:${TAG}"
+Write-Host ""
+Write-Host "If cache seems stale, re-run with: docker build --no-cache ..."
+Write-Host "To clear all build cache: docker builder prune"

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -88,10 +88,10 @@ Write-Host ""
 
 # Verify build freshness -- confirms code changes were picked up
 Write-Host "Verifying build freshness..."
-$baked = docker run --rm "${IMAGE_NAME}:${TAG}" python -c 'import os; print(os.environ.get("VITE_APP_VERSION","unknown"))'
+$baked = docker run --rm "${IMAGE_NAME}:${TAG}" cat /app/static/.build-version
 Write-Host "  Baked version : $baked"
 Write-Host "  Expected      : $VITE_APP_VERSION"
-if ($baked.Trim() -ne $VITE_APP_VERSION) {
+if (-not $baked -or $baked.Trim() -ne $VITE_APP_VERSION) {
     Write-Warning "Version mismatch -- build may have used stale cache. Re-run with: docker build --no-cache ..."
 }
 Write-Host ""

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -86,13 +86,13 @@ Write-Host ""
 Write-Host "Build complete!"
 Write-Host ""
 
-# Verify build freshness — confirms code changes were picked up
+# Verify build freshness -- confirms code changes were picked up
 Write-Host "Verifying build freshness..."
-$baked = docker run --rm "${IMAGE_NAME}:${TAG}" python -c "import os; print(os.environ.get('VITE_APP_VERSION','unknown'))"
+$baked = docker run --rm "${IMAGE_NAME}:${TAG}" python -c 'import os; print(os.environ.get("VITE_APP_VERSION","unknown"))'
 Write-Host "  Baked version : $baked"
 Write-Host "  Expected      : $VITE_APP_VERSION"
 if ($baked.Trim() -ne $VITE_APP_VERSION) {
-    Write-Warning "Version mismatch — build may have used stale cache. Re-run with: docker build --no-cache ..."
+    Write-Warning "Version mismatch -- build may have used stale cache. Re-run with: docker build --no-cache ..."
 }
 Write-Host ""
 Write-Host "To push: docker push ${REGISTRY}/${IMAGE_NAME}:${TAG}"

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -58,7 +58,7 @@ echo ""
 
 # Verify build freshness — confirms code changes were picked up
 echo "Verifying build freshness..."
-BAKED=$(docker run --rm "$IMAGE_NAME:$TAG" python -c "import os; print(os.environ.get('VITE_APP_VERSION','unknown'))")
+BAKED=$(docker run --rm "$IMAGE_NAME:$TAG" cat /app/static/.build-version)
 echo "  Baked version : $BAKED"
 echo "  Expected      : $VITE_APP_VERSION"
 if [ "$BAKED" != "$VITE_APP_VERSION" ]; then

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -36,7 +36,7 @@ echo "  VITE_AFFILIATE_RESUME_REVIEW_ENABLED: $VITE_AFFILIATE_RESUME_REVIEW_ENAB
 echo "  VITE_APP_VERSION: $VITE_APP_VERSION"
 if [ -n "$VITE_POSTHOG_KEY" ]; then echo "  VITE_POSTHOG_KEY: ${VITE_POSTHOG_KEY:0:8}..."; else echo "  VITE_POSTHOG_KEY: (not set)"; fi
 
-docker build  --no-cache \
+docker build \
   --build-arg VITE_SUPABASE_URL="$VITE_SUPABASE_URL" \
   --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="$VITE_SUPABASE_PUBLISHABLE_KEY" \
   --build-arg VITE_APP_URL="$VITE_APP_URL" \
@@ -54,6 +54,17 @@ docker tag "$IMAGE_NAME:$TAG" "$REGISTRY/$IMAGE_NAME:$TAG"
 
 echo ""
 echo "Build complete!"
+echo ""
+
+# Verify build freshness — confirms code changes were picked up
+echo "Verifying build freshness..."
+BAKED=$(docker run --rm "$IMAGE_NAME:$TAG" python -c "import os; print(os.environ.get('VITE_APP_VERSION','unknown'))")
+echo "  Baked version : $BAKED"
+echo "  Expected      : $VITE_APP_VERSION"
+if [ "$BAKED" != "$VITE_APP_VERSION" ]; then
+  echo "WARNING: Version mismatch — build may have used stale cache. Re-run with: docker build --no-cache ..."
+fi
+echo ""
 echo "To push: docker push $REGISTRY/$IMAGE_NAME:$TAG"
 echo ""
 echo "To test locally:"
@@ -63,3 +74,6 @@ echo "    -e SUPABASE_SECRET_KEY=$SUPABASE_SECRET_KEY \\"
 echo "    -e ADZUNA_APP_ID=\$ADZUNA_APP_ID \\"
 echo "    -e ADZUNA_APP_KEY=\$ADZUNA_APP_KEY \\"
 echo "    $IMAGE_NAME:$TAG"
+echo ""
+echo "If cache seems stale, re-run with: docker build --no-cache ..."
+echo "To clear all build cache: docker builder prune"


### PR DESCRIPTION
## Summary

- **Reorder Dockerfile layers** so `npm ci` + Playwright install run before `ARG/ENV` declarations — build-arg changes (e.g. git hash in `VITE_APP_VERSION`) no longer bust the dependency cache
- **Split Playwright install** into its own layer — source code changes no longer force Chromium reinstallation (~1-2 min saved)
- **Remove `--no-cache`** from build scripts — enables Docker layer caching. A post-build verification step prints the baked-in version from the image to confirm changes were picked up
- **Parallelize prerendering** — 122 routes now render with 5 concurrent Playwright pages instead of sequentially (~6-10 min → ~1.5-2.5 min). `PRERENDER_CONCURRENCY=1` falls back to sequential
- **Remove redundant `fc-cache`** — first call after `apt-get` is wasted since fonts are added later; only the second call (after font COPY) is needed

### Expected build times

| Scenario | Before | After |
|----------|--------|-------|
| No changes (re-run) | ~15 min | ~seconds |
| Python-only change | ~15 min | ~30s |
| React source code change | ~15 min | ~2-4 min |
| package.json change | ~15 min | ~5-7 min |

### Safety guarantees

- Docker `COPY` uses content hashing — any source file change invalidates the build layer
- Post-build verification prints baked version vs expected version, warns on mismatch
- Escape hatches documented in script output (`docker build --no-cache`, `docker builder prune`)
- Prerender concurrency uses isolated Playwright pages with unique output paths — no shared state

## Test plan

- [ ] Run `scripts/build-dev.ps1` — build completes, verification prints matching version
- [ ] Make a one-line React code change → rebuild → confirm `npm ci` and Playwright steps show `CACHED`, build step re-runs
- [ ] Rebuild with no changes → confirm all steps cached, completes in seconds
- [ ] Run container locally → landing page loads, PDF generation works
- [ ] Spot-check `dist/prerendered/` HTML output matches expected content
- [ ] Run with `PRERENDER_CONCURRENCY=1` to verify sequential fallback works
