### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus styles to icon-only buttons

### DIFF
--- a/resume-builder-ui/src/components/IconManager.tsx
+++ b/resume-builder-ui/src/components/IconManager.tsx
@@ -189,8 +189,10 @@ const IconManager: React.FC<IconManagerProps> = ({
         <button
           type="button"
           onClick={handleClear}
-          className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs shadow-lg transition-colors duration-200"
+          className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs shadow-lg transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-accent"
           disabled={isUploading}
+          aria-label="Remove icon"
+          title="Remove icon"
         >
           <FaTimes />
         </button>

--- a/resume-builder-ui/src/components/SectionEditor.tsx
+++ b/resume-builder-ui/src/components/SectionEditor.tsx
@@ -47,15 +47,17 @@ const SectionEditor: React.FC<{
               />
               <button
                 onClick={handleSaveName}
-                className="ml-2 text-green-500 hover:text-green-600"
+                className="ml-2 p-1 rounded-md text-green-500 hover:text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 title="Save Section Name"
+                aria-label="Save section name"
               >
                 💾
               </button>
               <button
                 onClick={handleCancelEdit}
-                className="ml-2 text-red-500 hover:text-red-600"
+                className="ml-2 p-1 rounded-md text-red-500 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 title="Cancel Edit"
+                aria-label="Cancel edit"
               >
                 ❌
               </button>
@@ -66,8 +68,9 @@ const SectionEditor: React.FC<{
               {!isFixedSection && (
                 <button
                   onClick={() => setIsEditingName(true)}
-                  className="ml-2 text-accent hover:text-accent"
+                  className="ml-2 p-1 rounded-md text-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   aria-label="Edit Section Name"
+                  title="Edit Section Name"
                 >
                   ✏️
                 </button>


### PR DESCRIPTION
**💡 What:** 
Added explicit `aria-label` attributes, tooltips (`title`), and explicit keyboard focus indicator styling to several icon-only action buttons.
- Cancel Edit (❌) and Save Name (💾) buttons in `SectionEditor.tsx`.
- Clear icon button (FaTimes) in `IconManager.tsx`.

**🎯 Why:**
Icon-only buttons present severe accessibility barriers. Without explicit labeling, screen readers cannot identify their purpose to users. In addition, keyboard users require distinct, visible focus indicators to confidently navigate the user interface, which these specific buttons were lacking.

**♿ Accessibility:**
- Resolved missing accessible names on icon buttons.
- Re-established `focus-visible` ring visibility when navigating via `Tab`, aligning with the existing UI conventions for accessible interactive elements.

**📸 Before/After:**
- **Before:** A screen reader encountering the clear icon would announce nothing or generic button text. Tabbing through the section editor provided no distinct visual focus on the save/cancel actions.
- **After:** Screen readers announce "Save section name", "Cancel edit", and "Remove icon". Keyboard tab targets display a distinct interactive ring.

---
*PR created automatically by Jules for task [15092545922592517633](https://jules.google.com/task/15092545922592517633) started by @aafre*