### PR TITLE
🎨 Palette: [UX improvement] Make UploadResumeModal fully accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Custom File Input Keyboard Accessibility
+**Learning:** Using `display: none` or Tailwind's `hidden` on a `<input type="file">` element completely removes it from the browser's accessibility tree and keyboard tab order, breaking keyboard navigation for file uploads.
+**Action:** When styling custom file inputs, always place the `<input type="file">` before the visual `<label>` wrapper in the DOM, style it with `sr-only peer` to keep it focusable but visually hidden, and add `peer-focus-visible` styling (like `peer-focus-visible:ring-2`) to the subsequent `<label>` to visually indicate keyboard focus.

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -88,18 +88,24 @@ export function UploadResumeModal({
 
   const modalContent = (
     <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden">
+      <div
+        className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="upload-modal-title"
+      >
         {/* Header */}
         <div className="bg-ink px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="bg-white/20 p-2 rounded-lg">
               <DocumentArrowUpIcon className="w-6 h-6 text-white" />
             </div>
-            <h2 className="text-xl font-bold text-white">Upload Resume</h2>
+            <h2 id="upload-modal-title" className="text-xl font-bold text-white">Upload Resume</h2>
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-lg"
+            aria-label="Close dialog"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -208,12 +214,12 @@ export function UploadResumeModal({
                 accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 onChange={handleFileInput}
                 disabled={parsing}
-                className="hidden"
+                className="sr-only peer"
                 id="resume-file-input"
               />
               <label
                 htmlFor="resume-file-input"
-                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:ring-offset-2"
               >
                 <DocumentArrowUpIcon className="w-5 h-5" />
                 {parsing ? 'Parsing...' : 'Choose File'}


### PR DESCRIPTION
### 💡 What
This PR updates the `UploadResumeModal` component to significantly improve its keyboard and screen-reader accessibility. 

### 🎯 Why
Custom styled file uploads (which hide the original `input type="file"`) often break keyboard navigation if they are completely hidden from the DOM (e.g., via `display: none` or Tailwind's `hidden`). Users navigating by keyboard cannot "tab" to the input to trigger the file dialog. Furthermore, the modal lacked appropriate semantic `dialog` roles and ARIA labels.

### ♿ Accessibility
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to properly announce the modal to screen readers.
- Removed the `hidden` class from the file `<input>` and applied `sr-only peer`, keeping the element visually hidden but explicitly within the keyboard tab sequence.
- Added `peer-focus-visible` classes to the "Choose File" label, creating a clear blue focus ring when a user tabs into the hidden file input.
- Added an `aria-label="Close dialog"` to the close icon `button`, and added high-contrast `focus-visible` styling for keyboard navigation.
- Added a journal entry to `.Jules/palette.md` to ensure this accessible custom file input pattern is standardized across the codebase.

---
*PR created automatically by Jules for task [2822450963525978763](https://jules.google.com/task/2822450963525978763) started by @aafre*