### PR TITLE
⚡ Bolt: Parallelize exportIconsForYAML execution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2025-02-18 - Parallelize Independent Async Operations
+
+**Learning:** Sequential `await` statements inside loops for independent asynchronous operations (like `FileReader` calls to convert multiple files to base64) create a performance bottleneck, taking $O(N)$ time instead of $O(1)$ concurrent time. This is especially impactful for I/O-bound tasks in a browser environment.
+
+**Action:** Refactor sequential `await` loops for independent tasks into concurrent operations using `Promise.all`. When mapping these tasks, ensure each promise handles its own errors using an internal `try/catch` block so that a single failure doesn't reject the entire `Promise.all` set.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,28 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
-      const entry = registry[filename];
-      if (entry) {
-        try {
-          const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
-          };
-        } catch (error) {
-          console.warn(`Failed to export icon ${filename}:`, error);
+    // ⚡ Bolt: Parallelize independent async operations
+    // Refactored sequential await loop into Promise.all for concurrent execution.
+    // This reduces the time complexity from O(N) to O(1) concurrent time for I/O-bound FileReader tasks.
+    await Promise.all(
+      targetFilenames.map(async (filename) => {
+        const entry = registry[filename];
+        if (entry) {
+          try {
+            const base64Data = await fileToBase64(entry.file);
+            // Safe to mutate exportData here because each filename is unique
+            exportData[filename] = {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            };
+          } catch (error) {
+            console.warn(`Failed to export icon ${filename}:`, error);
+          }
         }
-      }
-    }
+      })
+    );
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
**💡 What:** Refactored the sequential `await` loop in `exportIconsForYAML` inside `useIconRegistry.ts` into a concurrent operation using `Promise.all`.
**🎯 Why:** Iterating sequentially over file-to-base64 conversions creates an unnecessary I/O bottleneck in a browser environment.
**📊 Impact:** Reduces the time complexity of exporting icons from $O(N)$ (where N is the number of icons) down to $O(1)$ concurrent time.
**🔬 Measurement:** Benchmark the execution time of `exportIconsForYAML` with multiple large icons before and after the change; execution time should be significantly shorter.

---
*PR created automatically by Jules for task [7174445815014564080](https://jules.google.com/task/7174445815014564080) started by @aafre*