### PR TITLE
⚡ Bolt: [performance improvement] Memoize resumeData in useSaveIntegration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-06-25 - Prevent deep dependency re-evaluations with useMemo
+
+**Learning:** Inline object literals passed to custom hooks (like `useCloudSave`) cause reference inequality on every render. This bypasses React's default shallow equality checks and can trigger expensive operations inside the hook, such as `JSON.stringify` used for deep dependency tracking and comparisons.
+
+**Action:** Always wrap object literals passed as hook dependencies or props in `useMemo` to maintain referential equality when the underlying values haven't actually changed.

--- a/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
+++ b/resume-builder-ui/src/hooks/editor/useSaveIntegration.ts
@@ -68,6 +68,16 @@ export const useSaveIntegration = ({
     return iconsObj;
   }, [iconRegistry.getRegisteredFilenames().join(',')]);
 
+  const resumeData = useMemo(() => {
+    return contactInfo && templateId
+      ? {
+          contact_info: contactInfo,
+          sections: sections,
+          template_id: templateId,
+        }
+      : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' };
+  }, [contactInfo, sections, templateId]);
+
   const {
     saveStatus,
     lastSaved,
@@ -75,14 +85,7 @@ export const useSaveIntegration = ({
     resumeId: savedResumeId,
   } = useCloudSave({
     resumeId: cloudResumeId,
-    resumeData:
-      contactInfo && templateId
-        ? {
-            contact_info: contactInfo,
-            sections: sections,
-            template_id: templateId,
-          }
-        : { contact_info: { name: '', location: '', email: '', phone: '' }, sections: [], template_id: '' },
+    resumeData: resumeData,
     icons: iconsForCloudSave,
     enabled: !!templateId && !!contactInfo && !isLoadingFromUrl && !authLoading,
     session: session,


### PR DESCRIPTION
💡 What: Wrapped the inline `resumeData` object literal in `useSaveIntegration.ts` with `useMemo` before passing it to `useCloudSave`.

🎯 Why: Inline object literals passed to custom hooks cause reference inequality on every render. This forced `useCloudSave` to continuously re-evaluate its deep dependency checks using `JSON.stringify`, which is an expensive operation that runs needlessly on every keypress when the underlying structural dependencies (`contactInfo`, `sections`, `templateId`) haven't actually changed.

📊 Impact: Reduces unnecessary React re-evaluations and expensive `JSON.stringify` calls on every render, resulting in smoother editor performance during rapid typing.

🔬 Measurement: Verified that the fix maintains identical logic structure while preventing referential inequality. You can profile the editor performance during typing to observe fewer deep effect re-evaluations inside `useCloudSave`. Added a journal entry documenting this anti-pattern.

---
*PR created automatically by Jules for task [4756760710737136115](https://jules.google.com/task/4756760710737136115) started by @aafre*