### PR TITLE
🎨 Palette: [UX improvement] Add accessibility to UploadResumeModal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-04-19 - Accessible Close Buttons on Modals
+**Learning:** Icon-only close buttons in custom modals (like `UploadResumeModal`) often lack accessible names for screen readers and lack visible focus states for keyboard users, making modal dismissal difficult for some users.
+**Action:** When adding or updating custom modal close buttons (e.g., using `XMarkIcon`), explicitly add an `aria-label` and utilize explicit focus states (like `focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-md`) to ensure proper keyboard navigation visibility and accessibility.

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-md"
+            aria-label="Close upload resume modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `focus-visible` styling to the icon-only close button in `UploadResumeModal`.

**🎯 Why:** To ensure screen reader users understand the button's purpose and to provide a clear visual indicator for keyboard navigation users.

**♿ Accessibility:**
- Added `aria-label="Close upload resume modal"` to the `<button>`.
- Added Tailwind classes `focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-md` for a clear focus ring.

---
*PR created automatically by Jules for task [11736001868483166360](https://jules.google.com/task/11736001868483166360) started by @aafre*