### PR TITLE
🎨 Palette: Improve keyboard accessibility for UploadResumeModal

### DIFF
--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-lg p-1"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -208,12 +209,12 @@ export function UploadResumeModal({
                 accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 onChange={handleFileInput}
                 disabled={parsing}
-                className="hidden"
+                className="sr-only peer"
                 id="resume-file-input"
               />
               <label
                 htmlFor="resume-file-input"
-                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-accent"
               >
                 <DocumentArrowUpIcon className="w-5 h-5" />
                 {parsing ? 'Parsing...' : 'Choose File'}


### PR DESCRIPTION
### 💡 What
Improved the accessibility of the `UploadResumeModal` component by addressing two issues:
1.  **Close Button:** Added an `aria-label="Close modal"` and explicit `:focus-visible` styling to the `XMarkIcon` button.
2.  **File Input:** Replaced the `className="hidden"` on the `<input type="file">` with `className="sr-only peer"`, and added `peer-focus-visible` styling to its adjacent `<label>` button.

### 🎯 Why
- The close button previously had no text or `aria-label`, meaning screen reader users wouldn't know what the button did. It also lacked a visible focus indicator on the dark background.
- Using `display: none` or Tailwind's `hidden` on an input element completely removes it from the accessibility tree and keyboard tab order. Users navigating via keyboard could not focus the "Choose File" button.

### 📸 Before/After
*Before:* Keyboard users could not tab to the "Choose File" button. The close button had no visual indication when focused, and screen readers read it as a blank button.
*After:* Keyboard users can smoothly tab to the "Choose File" button, which now displays a focus ring when focused. The close button is clearly read as "Close modal" and displays a white focus ring when tabbed to.

### ♿ Accessibility
- Ensured keyboard navigability for the primary action (file upload).
- Added screen-reader context to an icon-only control.
- Improved visual focus indicators for keyboard users.

---
*PR created automatically by Jules for task [7822397832208867963](https://jules.google.com/task/7822397832208867963) started by @aafre*