### PR TITLE
feat(templates): unify /templates UX + accuracy pass on registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ seo-tracking/
 linkedin-content/
 docs/templates/examples/
 pnpm-lock.yaml
+.worktrees/

--- a/resume-builder-ui/scripts/prerender.ts
+++ b/resume-builder-ui/scripts/prerender.ts
@@ -123,10 +123,10 @@ function createStaticServer(distDir: string, port: number): Promise<http.Server>
         res.end(JSON.stringify({
           success: true,
           templates: [
-            { id: 'classic-alex-rivera', name: 'Professional', description: 'Clean, structured layout with traditional formatting and excellent space utilization.', image_url: '/docs/templates/alex_rivera.png' },
-            { id: 'classic-jane-doe', name: 'Elegant', description: 'Refined design with sophisticated typography and organized section layout.', image_url: '/docs/templates/jane_doe.png' },
-            { id: 'modern-no-icons', name: 'Minimalist', description: 'Clean and simple design focused on content clarity and easy readability.', image_url: '/docs/templates/modern-no-icons.png' },
-            { id: 'modern-with-icons', name: 'Modern', description: 'Contemporary design enhanced with visual icons and dynamic styling elements.', image_url: '/docs/templates/modern-with-icons.png' },
+            { id: 'classic-alex-rivera', name: 'Professional Resume', description: 'Single-column LaTeX layout with section dividers. Best for finance, law, and corporate analytics roles.', image_url: '/docs/templates/alex_rivera.png' },
+            { id: 'classic-jane-doe', name: 'Creative Resume', description: 'Refined LaTeX layout with sophisticated typography. Best for marketing, design, and client-facing creative roles.', image_url: '/docs/templates/jane_doe.png' },
+            { id: 'modern-no-icons', name: 'Minimalist Resume', description: 'Same modern layout, icon-free — safest bet for strict ATS parsers and traditional industries.', image_url: '/docs/templates/modern-no-icons.png' },
+            { id: 'modern-with-icons', name: 'Modern Resume', description: 'Contemporary single-column design with visual contact icons and clean skill sections.', image_url: '/docs/templates/modern-with-icons.png' },
           ]
         }));
         return;

--- a/resume-builder-ui/src/components/JobExampleCard.tsx
+++ b/resume-builder-ui/src/components/JobExampleCard.tsx
@@ -1,11 +1,13 @@
 /**
  * JobExampleCard Component
  * Displays a job-specific resume example as an image-dominant link card.
- * Links to /examples/{slug} for full example pages.
+ * Card body navigates to /examples/{slug}. If onImageClick is provided,
+ * clicking the image area opens a preview modal instead of navigating.
  */
 
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { MagnifyingGlassPlusIcon } from '@heroicons/react/24/outline';
 import type { JobExampleInfo } from '../data/jobExamples';
 
 const PREVIEW_BASE_URL = import.meta.env.VITE_SUPABASE_URL
@@ -14,12 +16,35 @@ const PREVIEW_BASE_URL = import.meta.env.VITE_SUPABASE_URL
 
 interface JobExampleCardProps {
   job: JobExampleInfo;
-  /** Show a "Example" badge in the top-left corner */
+  /** Show an "Example" badge in the top-left corner */
   showBadge?: boolean;
+  /** If provided, clicking the image area invokes this instead of navigating */
+  onImageClick?: (job: JobExampleInfo) => void;
 }
 
-export default function JobExampleCard({ job, showBadge = false }: JobExampleCardProps) {
+export default function JobExampleCard({ job, showBadge = false, onImageClick }: JobExampleCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false);
+
+  const handleImageClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+    if (!onImageClick) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onImageClick(job);
+  };
+
+  const imageInteractiveProps = onImageClick
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: handleImageClick,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            handleImageClick(e);
+          }
+        },
+        'aria-label': `Preview ${job.title} example`,
+      }
+    : {};
 
   return (
     <Link
@@ -37,7 +62,12 @@ export default function JobExampleCard({ job, showBadge = false }: JobExampleCar
       )}
 
       {/* Image area */}
-      <div className="relative overflow-hidden rounded-t-3xl bg-chalk-dark">
+      <div
+        {...imageInteractiveProps}
+        className={`relative overflow-hidden rounded-t-3xl bg-chalk-dark ${
+          onImageClick ? 'cursor-zoom-in' : ''
+        }`}
+      >
         {!imgLoaded && (
           <div className="absolute inset-0 animate-pulse bg-gray-200" />
         )}
@@ -60,6 +90,14 @@ export default function JobExampleCard({ job, showBadge = false }: JobExampleCar
             group-hover:scale-[1.02] transition-all duration-500
             ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
         />
+
+        {onImageClick && (
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/[0.04] transition-all duration-300 flex items-center justify-center pointer-events-none">
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-white/90 backdrop-blur-sm rounded-full p-3 shadow-lg">
+              <MagnifyingGlassPlusIcon className="h-5 w-5 text-ink" />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Footer */}

--- a/resume-builder-ui/src/components/JobExampleCard.tsx
+++ b/resume-builder-ui/src/components/JobExampleCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * JobExampleCard Component
+ * Displays a job-specific resume example as an image-dominant link card.
+ * Links to /examples/{slug} for full example pages.
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { JobExampleInfo } from '../data/jobExamples';
+
+const PREVIEW_BASE_URL = import.meta.env.VITE_SUPABASE_URL
+  ? `${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/template-previews`
+  : '';
+
+interface JobExampleCardProps {
+  job: JobExampleInfo;
+  /** Show a "Example" badge in the top-left corner */
+  showBadge?: boolean;
+}
+
+export default function JobExampleCard({ job, showBadge = false }: JobExampleCardProps) {
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  return (
+    <Link
+      to={`/examples/${job.slug}`}
+      className="group relative flex flex-col bg-white rounded-3xl shadow-lg
+        hover:shadow-2xl hover:-translate-y-1 transition-all duration-300
+        overflow-hidden border-2 border-gray-200 hover:border-accent/30"
+    >
+      {/* Type badge */}
+      {showBadge && (
+        <span className="absolute top-3 left-3 z-10 rounded-full bg-white/90 backdrop-blur-sm
+          px-3 py-1 text-xs font-medium text-stone-warm shadow-sm">
+          Example
+        </span>
+      )}
+
+      {/* Image area */}
+      <div className="relative overflow-hidden rounded-t-3xl bg-chalk-dark">
+        {!imgLoaded && (
+          <div className="absolute inset-0 animate-pulse bg-gray-200" />
+        )}
+        <img
+          src={`${PREVIEW_BASE_URL}/${job.slug}.webp`}
+          srcSet={`${PREVIEW_BASE_URL}/${job.slug}-sm.webp 400w, ${PREVIEW_BASE_URL}/${job.slug}.webp 800w`}
+          sizes="(max-width: 768px) 400px, 380px"
+          alt={`${job.title} resume example`}
+          loading="lazy"
+          decoding="async"
+          width={400}
+          height={566}
+          onLoad={() => setImgLoaded(true)}
+          onError={(e) => {
+            const img = e.target as HTMLImageElement;
+            img.onerror = null;
+            img.src = '/docs/templates/modern-no-icons.png';
+          }}
+          className={`w-full object-contain h-60 md:h-72 p-2
+            group-hover:scale-[1.02] transition-all duration-500
+            ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
+        />
+      </div>
+
+      {/* Footer */}
+      <div className="p-4">
+        <h3 className="font-display text-lg font-bold text-ink leading-tight group-hover:text-accent transition-colors">
+          {job.title}
+        </h3>
+        <p className="text-sm text-stone-warm mt-1 line-clamp-2">
+          {job.metaDescription}
+        </p>
+        <span
+          className="mt-3 w-full inline-flex items-center justify-center gap-2
+            rounded-xl px-5 py-2.5 text-sm font-bold
+            bg-accent text-ink shadow-md group-hover:brightness-110 group-hover:shadow-lg
+            transition-all duration-300"
+        >
+          Use This Example
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/resume-builder-ui/src/components/JobExamplePreviewModal.tsx
+++ b/resume-builder-ui/src/components/JobExamplePreviewModal.tsx
@@ -1,0 +1,383 @@
+/**
+ * Job Example Preview Modal
+ *
+ * Image lightbox for browsing job example previews from the unified templates
+ * page. Mirrors TemplatePreviewModal's keyboard, focus, and swipe behaviour.
+ * Primary CTA routes to /examples/{slug} where the full flow lives.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import type { JobExampleInfo } from '../data/jobExamples';
+
+const PREVIEW_BASE_URL = import.meta.env.VITE_SUPABASE_URL
+  ? `${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/template-previews`
+  : '';
+
+const SWIPE_THRESHOLD = 50;
+
+export interface JobExamplePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  jobs: JobExampleInfo[];
+  initialIndex: number;
+}
+
+export const JobExamplePreviewModal: React.FC<JobExamplePreviewModalProps> = ({
+  isOpen,
+  onClose,
+  jobs,
+  initialIndex,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [animState, setAnimState] = useState<'open' | 'closed'>('closed');
+  const [imageKey, setImageKey] = useState(0);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const mobileModalRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const touchMoveRef = useRef<number>(0);
+  const closingRef = useRef(false);
+
+  const total = jobs.length;
+  const current = jobs[currentIndex] ?? null;
+
+  const goNext = useCallback(() => {
+    if (total <= 1) return;
+    setCurrentIndex((i) => (i + 1) % total);
+    setImageKey((k) => k + 1);
+  }, [total]);
+
+  const goPrev = useCallback(() => {
+    if (total <= 1) return;
+    setCurrentIndex((i) => (i - 1 + total) % total);
+    setImageKey((k) => k + 1);
+  }, [total]);
+
+  useEffect(() => {
+    setCurrentIndex(initialIndex);
+  }, [initialIndex]);
+
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      closingRef.current = false;
+      requestAnimationFrame(() => {
+        setAnimState('open');
+      });
+      document.body.style.overflow = 'hidden';
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && animState === 'open') {
+      modalRef.current?.focus();
+      mobileModalRef.current?.focus();
+    }
+  }, [isOpen, animState]);
+
+  const handleClose = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    setAnimState('closed');
+    setTimeout(() => {
+      document.body.style.overflow = '';
+      previousFocusRef.current?.focus();
+      onClose();
+    }, 300);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Escape':
+          handleClose();
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          goPrev();
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          goNext();
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleClose, goNext, goPrev]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      const container = modalRef.current?.offsetParent
+        ? modalRef.current
+        : mobileModalRef.current;
+      if (!container) return;
+
+      const focusableEls = container.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableEls.length === 0) return;
+
+      const first = focusableEls[0];
+      const last = focusableEls[focusableEls.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleTab);
+    return () => document.removeEventListener('keydown', handleTab);
+  }, [isOpen, currentIndex]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartRef.current = {
+      x: e.touches[0].clientX,
+      y: e.touches[0].clientY,
+    };
+    touchMoveRef.current = 0;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
+    const dx = e.touches[0].clientX - touchStartRef.current.x;
+    touchMoveRef.current = dx;
+    setSwipeOffset(dx * 0.4);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    const dx = touchMoveRef.current;
+    setSwipeOffset(0);
+    touchStartRef.current = null;
+
+    if (Math.abs(dx) >= SWIPE_THRESHOLD) {
+      if (dx < 0) goNext();
+      else goPrev();
+    }
+  }, [goNext, goPrev]);
+
+  if (!isOpen) return null;
+  if (!current) return null;
+
+  const imgSrc = `${PREVIEW_BASE_URL}/${current.slug}.webp`;
+  const fullExampleHref = `/examples/${current.slug}`;
+  const counter = `${currentIndex + 1} of ${total}`;
+
+  const modal = (
+    <div
+      data-state={animState}
+      className="fixed inset-0 z-[10000] flex items-center justify-center transition-all duration-300 data-[state=open]:opacity-100 data-[state=closed]:opacity-0"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Example preview: ${current.title}`}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      {/* Desktop */}
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        data-state={animState}
+        className="hidden md:flex relative z-10 bg-white rounded-2xl shadow-2xl overflow-hidden w-[80vw] max-w-6xl max-h-[85vh] flex-row outline-none transition-all duration-300 ease-out data-[state=open]:scale-100 data-[state=open]:opacity-100 data-[state=closed]:scale-95 data-[state=closed]:opacity-0"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="relative w-[60%] bg-chalk-dark flex items-center justify-center min-h-0">
+          <img
+            key={imageKey}
+            src={imgSrc}
+            alt={`Preview of ${current.title} example`}
+            className="w-full h-full object-contain p-6 tpm-img-fade"
+            onError={(e) => {
+              const img = e.target as HTMLImageElement;
+              img.onerror = null;
+              img.src = '/docs/templates/modern-no-icons.png';
+            }}
+            draggable={false}
+          />
+
+          {total > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={goPrev}
+                className="absolute left-3 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white rounded-full p-2 shadow-lg transition-all duration-300 hover:scale-110"
+                aria-label="Previous example"
+              >
+                <ChevronLeftIcon className="w-5 h-5 text-ink" />
+              </button>
+              <button
+                type="button"
+                onClick={goNext}
+                className="absolute right-3 top-1/2 -translate-y-1/2 bg-white/90 hover:bg-white rounded-full p-2 shadow-lg transition-all duration-300 hover:scale-110"
+                aria-label="Next example"
+              >
+                <ChevronRightIcon className="w-5 h-5 text-ink" />
+              </button>
+            </>
+          )}
+        </div>
+
+        <div className="w-[40%] flex flex-col min-h-0">
+          <div className="flex justify-end p-4 pb-0">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="text-stone-warm hover:text-ink rounded-full p-1.5 hover:bg-chalk-dark transition-all duration-300"
+              aria-label="Close preview"
+            >
+              <XMarkIcon className="w-6 h-6" />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-8 pb-6 pt-2">
+            <span className="inline-block rounded-full bg-chalk-dark px-3 py-1 text-xs text-stone-warm mb-4">
+              Resume example
+            </span>
+
+            <h2 className="font-display text-2xl font-bold text-ink mb-3">
+              {current.title}
+            </h2>
+
+            <p className="text-stone-warm font-extralight leading-relaxed text-base mb-6">
+              {current.metaDescription}
+            </p>
+
+            <p className="text-mist text-sm mb-6">{counter}</p>
+
+            <Link
+              to={fullExampleHref}
+              onClick={handleClose}
+              className="w-full btn-primary py-3.5 px-8 text-base font-semibold inline-flex items-center justify-center gap-2"
+            >
+              See Full Example →
+            </Link>
+
+            <p className="text-xs text-mist mt-4">
+              Includes the full resume, bullet-point bank, and FAQs.
+            </p>
+          </div>
+
+          <div className="px-8 pb-4 pt-2 border-t border-black/[0.06]">
+            <p className="text-xs text-mist text-center">
+              &larr; &rarr; to navigate &middot; Esc to close
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        ref={mobileModalRef}
+        tabIndex={-1}
+        data-state={animState}
+        className="md:hidden fixed inset-0 z-10 flex flex-col bg-white outline-none transition-all duration-300 ease-out data-[state=open]:opacity-100 data-[state=open]:translate-y-0 data-[state=closed]:opacity-0 data-[state=closed]:translate-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 bg-white/90 backdrop-blur-sm border-b border-black/[0.06]">
+          <button
+            type="button"
+            onClick={goPrev}
+            className="p-2 rounded-full hover:bg-chalk-dark transition-all duration-300"
+            aria-label="Previous example"
+            disabled={total <= 1}
+          >
+            <ChevronLeftIcon className="w-5 h-5 text-ink" />
+          </button>
+          <span className="text-sm text-stone-warm font-medium">
+            {currentIndex + 1} / {total}
+          </span>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="p-2 rounded-full hover:bg-chalk-dark transition-all duration-300"
+            aria-label="Close preview"
+          >
+            <XMarkIcon className="w-5 h-5 text-ink" />
+          </button>
+        </div>
+
+        <div
+          className="flex-1 bg-chalk-dark flex items-center justify-center overflow-hidden min-h-0"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <img
+            key={imageKey}
+            src={imgSrc}
+            alt={`Preview of ${current.title} example`}
+            className="max-w-full max-h-full object-contain p-4 tpm-img-fade"
+            style={{
+              transform: swipeOffset ? `translateX(${swipeOffset}px)` : undefined,
+              transition: swipeOffset ? 'none' : 'transform 0.3s ease-out',
+            }}
+            onError={(e) => {
+              const img = e.target as HTMLImageElement;
+              img.onerror = null;
+              img.src = '/docs/templates/modern-no-icons.png';
+            }}
+            draggable={false}
+          />
+        </div>
+
+        <div
+          className="bg-white rounded-t-3xl shadow-[0_-4px_24px_rgba(0,0,0,0.08)] relative"
+          style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
+        >
+          <div className="flex justify-center pt-3 pb-2">
+            <div className="w-10 h-1 rounded-full bg-black/10" />
+          </div>
+
+          <div className="px-5 pb-2">
+            <h2 className="font-display text-xl font-bold text-ink mb-2">
+              {current.title}
+            </h2>
+
+            <p className="text-stone-warm font-extralight text-sm leading-relaxed mb-4">
+              {current.metaDescription}
+            </p>
+
+            <Link
+              to={fullExampleHref}
+              onClick={handleClose}
+              className="w-full btn-primary py-3.5 px-8 text-base font-semibold inline-flex items-center justify-center gap-2"
+            >
+              See Full Example →
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+};
+
+export default JobExamplePreviewModal;

--- a/resume-builder-ui/src/components/TemplateCard.tsx
+++ b/resume-builder-ui/src/components/TemplateCard.tsx
@@ -13,8 +13,9 @@ export const TEMPLATE_BEST_FOR: Record<string, string> = {
   student: 'Best for students & first-time job seekers',
   executive: 'Best for senior leaders & C-suite',
   'classic-alex-rivera': 'Best for corporate, finance & law',
-  'classic-jane-doe': 'Best for creative professionals',
+  'classic-jane-doe': 'Best for marketing, design & client-facing creatives',
   'two-column': 'Best for tech roles with many skills',
+  'uk-cv': 'Best for UK jobs, international & visa applications',
 };
 
 /* ------------------------------------------------------------------ */

--- a/resume-builder-ui/src/components/TemplateFilterBar.tsx
+++ b/resume-builder-ui/src/components/TemplateFilterBar.tsx
@@ -17,6 +17,7 @@ export const FILTER_CATEGORIES = [
   { id: 'creative', label: 'Creative', tags: ['icons', 'visual', 'sophisticated'] },
   { id: 'student', label: 'Student', tags: ['entry-level', 'education-first', 'new-graduate'] },
   { id: 'executive', label: 'Executive', tags: ['premium', 'executive', 'senior'] },
+  { id: 'international', label: 'International', tags: ['uk-cv', 'british', 'international', 'a4'] },
 ] as const;
 
 export type FilterCategoryId = (typeof FILTER_CATEGORIES)[number]['id'];

--- a/resume-builder-ui/src/components/TemplatePreviewModal.tsx
+++ b/resume-builder-ui/src/components/TemplatePreviewModal.tsx
@@ -54,8 +54,9 @@ const TEMPLATE_BEST_FOR: Record<string, string> = {
   'student': 'Best for students & first-time job seekers',
   'executive': 'Best for senior leaders & C-suite',
   'classic-alex-rivera': 'Best for corporate, finance & law',
-  'classic-jane-doe': 'Best for creative professionals',
+  'classic-jane-doe': 'Best for marketing, design & client-facing creatives',
   'two-column': 'Best for tech roles with many skills',
+  'uk-cv': 'Best for UK jobs, international & visa applications',
 };
 
 const SWIPE_THRESHOLD = 50;

--- a/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
+++ b/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
@@ -51,13 +51,13 @@ interface Template {
 export default function UnifiedTemplateSection() {
   // URL state
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialView = (searchParams.get('view') as ViewMode) || 'all';
+  const initialView = (searchParams.get('view') as ViewMode) || 'templates';
   const initialFilter = searchParams.get('filter') || 'all';
   const initialCategory = (searchParams.get('category') as JobCategory | 'all') || 'all';
 
-  // View state
+  // View state — defaults to 'templates' to match the /templates URL intent
   const [activeView, setActiveView] = useState<ViewMode>(
-    ['all', 'templates', 'examples'].includes(initialView) ? initialView : 'all'
+    ['all', 'templates', 'examples'].includes(initialView) ? initialView : 'templates'
   );
   const [activeTemplateFilter, setActiveTemplateFilter] = useState(initialFilter);
   const [activeJobCategory, setActiveJobCategory] = useState<JobCategory | 'all'>(initialCategory);
@@ -126,7 +126,8 @@ export default function UnifiedTemplateSection() {
   // URL sync
   useEffect(() => {
     const params = new URLSearchParams();
-    if (activeView !== 'all') params.set('view', activeView);
+    // 'templates' is the default view — omit from URL to keep /templates canonical
+    if (activeView !== 'templates') params.set('view', activeView);
     if (activeView === 'templates' && activeTemplateFilter !== 'all') params.set('filter', activeTemplateFilter);
     if (activeView === 'examples' && activeJobCategory !== 'all') params.set('category', activeJobCategory);
 

--- a/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
+++ b/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
@@ -1,0 +1,487 @@
+/**
+ * UnifiedTemplateSection Component
+ *
+ * Combines the template carousel and job examples into one filterable section.
+ * Uses a ViewSwitcher (All / Design Templates / By Job Title) with contextual
+ * sub-filters for each view.
+ *
+ * Used only on TemplatesPage (/templates). TemplateCarousel remains unchanged
+ * for all other pages that embed it.
+ */
+
+import React, { useEffect, useState, useMemo, useRef, lazy, Suspense } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { fetchTemplates } from '../services/templates';
+import TemplateCard from './TemplateCard';
+import JobExampleCard from './JobExampleCard';
+import TemplateFilterBar, { FILTER_CATEGORIES } from './TemplateFilterBar';
+import TemplatePreviewModal from './TemplatePreviewModal';
+import TemplateStartModal from './TemplateStartModal';
+import ResumeRecoveryModal from './ResumeRecoveryModal';
+import AuthModal from './AuthModal';
+import ViewSwitcher, { type ViewMode } from './ViewSwitcher';
+import { InFeedAd, AD_CONFIG } from './ads';
+import { useTemplateActions } from '../hooks/useTemplateActions';
+import {
+  JOB_EXAMPLES_DATABASE,
+  JOB_CATEGORIES,
+  getJobExamplesByCategory,
+  getJobCountByCategory,
+} from '../data/jobExamples';
+import type { JobCategory } from '../data/jobExamples';
+
+const NotFound = lazy(() => import('./NotFound'));
+const ErrorPage = lazy(() => import('./ErrorPage'));
+
+const LoadingSpinner = () => (
+  <div className="flex items-center justify-center min-h-[200px]">
+    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
+  </div>
+);
+
+interface Template {
+  id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  tags?: string[];
+  supports_icons?: boolean;
+}
+
+export default function UnifiedTemplateSection() {
+  // URL state
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialView = (searchParams.get('view') as ViewMode) || 'all';
+  const initialFilter = searchParams.get('filter') || 'all';
+  const initialCategory = (searchParams.get('category') as JobCategory | 'all') || 'all';
+
+  // View state
+  const [activeView, setActiveView] = useState<ViewMode>(
+    ['all', 'templates', 'examples'].includes(initialView) ? initialView : 'all'
+  );
+  const [activeTemplateFilter, setActiveTemplateFilter] = useState(initialFilter);
+  const [activeJobCategory, setActiveJobCategory] = useState<JobCategory | 'all'>(initialCategory);
+
+  // Template data (async from API)
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Refs
+  const gridRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Job examples data (static)
+  const jobsByCategory = useMemo(() => getJobExamplesByCategory(), []);
+  const jobCategoryCounts = useMemo(() => getJobCountByCategory(), []);
+  const totalJobCount = JOB_EXAMPLES_DATABASE.length;
+
+  // Fetch templates
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchTemplates();
+        setTemplates(data);
+      } catch (err) {
+        setError('Failed to load templates. Please try again later.');
+        console.error('Error fetching templates:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadTemplates();
+  }, []);
+
+  // Filter templates
+  const filteredTemplates = useMemo(() => {
+    if (activeTemplateFilter === 'all') return templates;
+    const category = FILTER_CATEGORIES.find(c => c.id === activeTemplateFilter);
+    if (!category || category.tags.length === 0) return templates;
+    return templates.filter(t =>
+      t.tags?.some(tag => (category.tags as readonly string[]).includes(tag))
+    );
+  }, [templates, activeTemplateFilter]);
+
+  const templateCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: templates.length };
+    for (const cat of FILTER_CATEGORIES) {
+      if (cat.id === 'all') continue;
+      counts[cat.id] = templates.filter(t =>
+        t.tags?.some(tag => (cat.tags as readonly string[]).includes(tag))
+      ).length;
+    }
+    return counts;
+  }, [templates]);
+
+  // Filter job examples
+  const filteredJobs = useMemo(() => {
+    if (activeJobCategory === 'all') return JOB_EXAMPLES_DATABASE;
+    return jobsByCategory[activeJobCategory] || [];
+  }, [activeJobCategory, jobsByCategory]);
+
+  // Template actions (modals, auth, recovery)
+  const actions = useTemplateActions(templates, filteredTemplates);
+
+  // URL sync
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (activeView !== 'all') params.set('view', activeView);
+    if (activeView === 'templates' && activeTemplateFilter !== 'all') params.set('filter', activeTemplateFilter);
+    if (activeView === 'examples' && activeJobCategory !== 'all') params.set('category', activeJobCategory);
+
+    const newSearch = params.toString();
+    const currentSearch = searchParams.toString();
+    if (newSearch !== currentSearch) {
+      setSearchParams(params, { replace: true });
+    }
+  }, [activeView, activeTemplateFilter, activeJobCategory, searchParams, setSearchParams]);
+
+  // View change handler — reset sub-filters and scroll into view
+  const handleViewChange = (view: ViewMode) => {
+    setActiveView(view);
+    if (view !== 'templates') setActiveTemplateFilter('all');
+    if (view !== 'examples') setActiveJobCategory('all');
+
+    // Smooth scroll to grid if it's below viewport
+    if (gridRef.current) {
+      const rect = gridRef.current.getBoundingClientRect();
+      if (rect.top < 0 || rect.top > window.innerHeight * 0.5) {
+        gridRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+  };
+
+  // Recovery redirect states
+  if (actions.processingRecoveryRedirect || (actions.anonMigrationInProgress && localStorage.getItem('resume-recovery-intent'))) {
+    return (
+      <div className="min-h-[400px] bg-chalk flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
+          <p className="text-xl text-stone-warm">Redirecting to your resume...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[400px] bg-chalk flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
+          <p className="text-xl text-stone-warm">Loading templates...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Suspense fallback={<LoadingSpinner />}>
+        <ErrorPage />
+      </Suspense>
+    );
+  }
+
+  if (templates.length === 0) {
+    return (
+      <Suspense fallback={<LoadingSpinner />}>
+        <NotFound />
+      </Suspense>
+    );
+  }
+
+  const showTemplates = activeView === 'all' || activeView === 'templates';
+  const showExamples = activeView === 'all' || activeView === 'examples';
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 pb-12">
+      {/* View Switcher */}
+      <div className="flex justify-center mb-8">
+        <ViewSwitcher
+          activeView={activeView}
+          onViewChange={handleViewChange}
+          templateCount={templates.length}
+          exampleCount={totalJobCount}
+        />
+      </div>
+
+      {/* Contextual Sub-filters */}
+      {activeView === 'templates' && (
+        <div className="mb-8 md:mb-10">
+          <TemplateFilterBar
+            activeFilter={activeTemplateFilter}
+            onFilterChange={setActiveTemplateFilter}
+            templateCounts={templateCounts}
+          />
+        </div>
+      )}
+
+      {activeView === 'examples' && (
+        <div className="relative w-full mb-8 md:mb-10">
+          {/* Fade edges on mobile */}
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-gradient-to-r from-chalk to-transparent sm:hidden"
+            aria-hidden="true"
+          />
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-gradient-to-l from-chalk to-transparent sm:hidden"
+            aria-hidden="true"
+          />
+
+          <div
+            ref={scrollRef}
+            role="toolbar"
+            aria-label="Filter resume examples by job category"
+            className="flex gap-2.5 overflow-x-auto px-2 py-1 sm:flex-wrap sm:justify-center sm:overflow-x-visible sm:px-0 scrollbar-hide"
+            style={{ WebkitOverflowScrolling: 'touch' }}
+          >
+            {/* "All" pill */}
+            <button
+              type="button"
+              aria-pressed={activeJobCategory === 'all'}
+              onClick={() => setActiveJobCategory('all')}
+              className={`
+                flex-shrink-0 min-h-[44px] px-5 py-2.5
+                rounded-full font-display text-sm font-medium
+                transition-all duration-300
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+                active:scale-95 select-none whitespace-nowrap
+                ${
+                  activeJobCategory === 'all'
+                    ? 'bg-accent text-ink shadow-sm'
+                    : 'bg-white text-stone-warm border border-gray-200 hover:border-gray-300 hover:text-ink hover:shadow-sm'
+                }
+              `.trim().replace(/\s+/g, ' ')}
+            >
+              All
+              <span className={`ml-1.5 text-xs ${activeJobCategory === 'all' ? 'text-ink/60' : 'text-stone-warm/60'}`}>
+                ({totalJobCount})
+              </span>
+            </button>
+
+            {/* Category pills */}
+            {JOB_CATEGORIES.map((category) => {
+              const isActive = activeJobCategory === category.id;
+              const count = jobCategoryCounts[category.id];
+              const shortTitle = category.title.split(' & ')[0];
+
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => setActiveJobCategory(category.id)}
+                  className={`
+                    flex-shrink-0 min-h-[44px] px-5 py-2.5
+                    rounded-full font-display text-sm font-medium
+                    transition-all duration-300
+                    focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+                    active:scale-95 select-none whitespace-nowrap
+                    ${
+                      isActive
+                        ? 'bg-accent text-ink shadow-sm'
+                        : 'bg-white text-stone-warm border border-gray-200 hover:border-gray-300 hover:text-ink hover:shadow-sm'
+                    }
+                  `.trim().replace(/\s+/g, ' ')}
+                >
+                  <span className="mr-1.5" aria-hidden="true">{category.icon}</span>
+                  {shortTitle}
+                  <span className={`ml-1.5 text-xs ${isActive ? 'text-ink/60' : 'text-stone-warm/60'}`}>
+                    ({count})
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <style>{`
+            .scrollbar-hide::-webkit-scrollbar { display: none; }
+            .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+          `}</style>
+        </div>
+      )}
+
+      {/* Unified Card Grid */}
+      <div ref={gridRef}>
+        {/* Template Cards */}
+        {showTemplates && (
+          <>
+            {activeView === 'all' && (
+              <div className="mb-6">
+                <span className="block font-mono text-xs tracking-[0.15em] text-accent uppercase mb-1">
+                  Design Templates
+                </span>
+                <p className="text-sm text-stone-warm">
+                  Professional layouts — pick one and start building
+                </p>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+              {filteredTemplates.map((template, index) => {
+                const isSelected = actions.selectedTemplate?.id === template.id;
+                const isActionLoading = isSelected && (actions.creating || actions.checkingExistingResume);
+                const loadingText = actions.checkingExistingResume ? 'Checking...' : actions.creating ? 'Creating...' : undefined;
+
+                return (
+                  <React.Fragment key={template.id}>
+                    <TemplateCard
+                      template={template}
+                      isSelected={isSelected}
+                      onSelect={actions.handleSelectTemplate}
+                      onUseTemplate={actions.handleUseTemplate}
+                      onPreview={actions.handlePreview}
+                      isLoading={isActionLoading}
+                      loadingText={loadingText}
+                      eagerLoadImage={index < 3}
+                    />
+                    {(index + 1) % 6 === 0 && index >= 5 && (
+                      <div className="col-span-full">
+                        <InFeedAd
+                          adSlot={AD_CONFIG.slots.carouselInfeed}
+                          layout="row"
+                          className="rounded-3xl"
+                        />
+                      </div>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </div>
+
+            {/* Empty template filter state */}
+            {filteredTemplates.length === 0 && templates.length > 0 && (
+              <div className="text-center py-16">
+                <p className="text-lg text-stone-warm mb-4">No templates match this filter.</p>
+                <button
+                  onClick={() => setActiveTemplateFilter('all')}
+                  className="btn-secondary px-6 py-2.5"
+                >
+                  Show All Templates
+                </button>
+              </div>
+            )}
+
+            {/* Ad after templates if 4-5 templates shown */}
+            {filteredTemplates.length >= 4 && filteredTemplates.length < 6 && (
+              <div className="mt-8 lg:mt-12">
+                <InFeedAd
+                  adSlot={AD_CONFIG.slots.carouselInfeed}
+                  layout="row"
+                  className="rounded-3xl"
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Divider between templates and examples in "All" view */}
+        {activeView === 'all' && (
+          <div className="my-12 md:my-16 border-t border-gray-200" />
+        )}
+
+        {/* Job Example Cards */}
+        {showExamples && (
+          <>
+            <div className="mb-6">
+              <span className="block font-mono text-xs tracking-[0.15em] text-accent uppercase mb-1">
+                Resume Examples
+              </span>
+              <h2 className="font-display text-2xl md:text-3xl font-extrabold tracking-tight text-ink mb-2">
+                Resume Examples by Job Title
+              </h2>
+              <p className="text-sm md:text-base text-stone-warm max-w-3xl leading-relaxed">
+                Browse professional resume examples for your specific role. Each includes
+                pre-written content you can customize.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+              {filteredJobs.map((job) => (
+                <JobExampleCard
+                  key={job.slug}
+                  job={job}
+                  showBadge={activeView === 'all'}
+                />
+              ))}
+            </div>
+
+            {/* View All CTA */}
+            <div className="text-center mt-10">
+              <Link to="/examples" className="btn-secondary py-3 px-8 inline-block">
+                View All Resume Examples
+              </Link>
+            </div>
+          </>
+        )}
+
+        {/* SEO fallback: compact links when examples are hidden */}
+        {activeView === 'templates' && (
+          <div className="mt-12 md:mt-16 pt-8 border-t border-gray-200">
+            <h2 className="font-display text-xl md:text-2xl font-extrabold tracking-tight text-ink mb-3">
+              Resume Examples by Job Title
+            </h2>
+            <p className="text-sm text-stone-warm mb-4">
+              Browse real resume examples for your specific role:
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {JOB_EXAMPLES_DATABASE.map((job) => (
+                <Link
+                  key={job.slug}
+                  to={`/examples/${job.slug}`}
+                  className="text-sm text-stone-warm hover:text-accent transition-colors
+                    border border-gray-200 rounded-lg px-3 py-1.5 hover:border-accent/30"
+                >
+                  {job.title}
+                </Link>
+              ))}
+            </div>
+            <div className="mt-4">
+              <Link to="/examples" className="text-sm font-medium text-accent hover:underline">
+                View all resume examples &rarr;
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Modals */}
+      <TemplatePreviewModal
+        isOpen={actions.showPreviewModal}
+        onClose={() => actions.setShowPreviewModal(false)}
+        templates={filteredTemplates}
+        initialTemplateIndex={actions.previewTemplateIndex}
+        onUseTemplate={actions.handleUseTemplate}
+        isLoading={actions.creating || actions.checkingExistingResume}
+      />
+
+      <TemplateStartModal
+        isOpen={actions.showStartModal}
+        onClose={() => actions.setShowStartModal(false)}
+        onSelectEmpty={actions.handleModalSelectEmpty}
+        onSelectExample={actions.handleModalSelectExample}
+        onSelectImport={actions.handleModalSelectImport}
+        templateName={actions.selectedTemplateModalName}
+      />
+
+      <ResumeRecoveryModal
+        isOpen={actions.showRecoveryModal}
+        onClose={() => actions.setShowRecoveryModal(false)}
+        resumeId={actions.existingResumeId || ''}
+        resumeTitle={actions.existingResumeTitle}
+        templateName={actions.selectedTemplateModalName}
+        isAnonymous={actions.isAnonymous}
+        onContinueAsGuest={actions.handleContinueAsGuest}
+        onSignInToContinue={actions.handleSignInToContinue}
+        onCreateNew={actions.handleCreateNewFromRecovery}
+      />
+
+      <AuthModal
+        isOpen={actions.showAuthModal}
+        onClose={() => actions.setShowAuthModal(false)}
+        onSuccess={actions.handleAuthSuccess}
+      />
+    </div>
+  );
+}

--- a/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
+++ b/resume-builder-ui/src/components/UnifiedTemplateSection.tsx
@@ -14,6 +14,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { fetchTemplates } from '../services/templates';
 import TemplateCard from './TemplateCard';
 import JobExampleCard from './JobExampleCard';
+import JobExamplePreviewModal from './JobExamplePreviewModal';
 import TemplateFilterBar, { FILTER_CATEGORIES } from './TemplateFilterBar';
 import TemplatePreviewModal from './TemplatePreviewModal';
 import TemplateStartModal from './TemplateStartModal';
@@ -28,7 +29,7 @@ import {
   getJobExamplesByCategory,
   getJobCountByCategory,
 } from '../data/jobExamples';
-import type { JobCategory } from '../data/jobExamples';
+import type { JobCategory, JobExampleInfo } from '../data/jobExamples';
 
 const NotFound = lazy(() => import('./NotFound'));
 const ErrorPage = lazy(() => import('./ErrorPage'));
@@ -66,6 +67,10 @@ export default function UnifiedTemplateSection() {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Job example preview modal state
+  const [showExampleModal, setShowExampleModal] = useState(false);
+  const [exampleModalIndex, setExampleModalIndex] = useState(0);
 
   // Refs
   const gridRef = useRef<HTMLDivElement>(null);
@@ -137,6 +142,13 @@ export default function UnifiedTemplateSection() {
       setSearchParams(params, { replace: true });
     }
   }, [activeView, activeTemplateFilter, activeJobCategory, searchParams, setSearchParams]);
+
+  // Open the example preview modal at the clicked job's index
+  const handleExampleImageClick = (job: JobExampleInfo) => {
+    const index = filteredJobs.findIndex((j) => j.slug === job.slug);
+    setExampleModalIndex(index >= 0 ? index : 0);
+    setShowExampleModal(true);
+  };
 
   // View change handler — reset sub-filters and scroll into view
   const handleViewChange = (view: ViewMode) => {
@@ -404,6 +416,7 @@ export default function UnifiedTemplateSection() {
                   key={job.slug}
                   job={job}
                   showBadge={activeView === 'all'}
+                  onImageClick={handleExampleImageClick}
                 />
               ))}
             </div>
@@ -482,6 +495,13 @@ export default function UnifiedTemplateSection() {
         isOpen={actions.showAuthModal}
         onClose={() => actions.setShowAuthModal(false)}
         onSuccess={actions.handleAuthSuccess}
+      />
+
+      <JobExamplePreviewModal
+        isOpen={showExampleModal}
+        onClose={() => setShowExampleModal(false)}
+        jobs={filteredJobs}
+        initialIndex={exampleModalIndex}
       />
     </div>
   );

--- a/resume-builder-ui/src/components/ViewSwitcher.tsx
+++ b/resume-builder-ui/src/components/ViewSwitcher.tsx
@@ -1,0 +1,73 @@
+/**
+ * ViewSwitcher Component
+ * Segmented control for toggling between All / Design Templates / By Job Title views.
+ * Responsive labels: compact on mobile, full on desktop.
+ */
+
+export type ViewMode = 'all' | 'templates' | 'examples';
+
+interface ViewOption {
+  id: ViewMode;
+  shortLabel: string;
+  fullLabel: string;
+}
+
+interface ViewSwitcherProps {
+  activeView: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+  templateCount: number;
+  exampleCount: number;
+}
+
+export default function ViewSwitcher({
+  activeView,
+  onViewChange,
+  templateCount,
+  exampleCount,
+}: ViewSwitcherProps) {
+  const totalCount = templateCount + exampleCount;
+
+  const options: ViewOption[] = [
+    { id: 'all', shortLabel: `All (${totalCount})`, fullLabel: `All (${totalCount})` },
+    { id: 'templates', shortLabel: `Templates (${templateCount})`, fullLabel: `Design Templates (${templateCount})` },
+    { id: 'examples', shortLabel: `Examples (${exampleCount})`, fullLabel: `By Job Title (${exampleCount})` },
+  ];
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Browse by content type"
+      className="inline-flex w-full sm:w-auto rounded-full bg-chalk-dark p-1 shadow-inner"
+    >
+      {options.map((option) => {
+        const isActive = activeView === option.id;
+
+        return (
+          <button
+            key={option.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onViewChange(option.id)}
+            className={`
+              flex-1 sm:flex-initial min-h-[40px] px-4 sm:px-6 py-2
+              rounded-full font-display text-sm font-medium
+              transition-all duration-300
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+              select-none whitespace-nowrap
+              ${
+                isActive
+                  ? 'bg-accent text-ink shadow-sm'
+                  : 'text-stone-warm hover:text-ink'
+              }
+            `.trim().replace(/\s+/g, ' ')}
+          >
+            {/* Short label on mobile, full label on desktop */}
+            <span className="sm:hidden">{option.shortLabel}</span>
+            <span className="hidden sm:inline">{option.fullLabel}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/resume-builder-ui/src/components/seo/TemplatesPage.tsx
+++ b/resume-builder-ui/src/components/seo/TemplatesPage.tsx
@@ -10,8 +10,7 @@ import FeatureGrid from '../shared/FeatureGrid';
 import FAQSection from '../shared/FAQSection';
 import DownloadCTA from '../shared/DownloadCTA';
 import RevealSection from '../shared/RevealSection';
-import TemplateCarousel from '../TemplateCarousel';
-import JobExamplesSection from '../JobExamplesSection';
+import UnifiedTemplateSection from '../UnifiedTemplateSection';
 import { InContentAd, AD_CONFIG } from '../ads';
 import { usePageSchema } from '../../hooks/usePageSchema';
 import { SEO_PAGES } from '../../config/seoPages';
@@ -32,14 +31,12 @@ export default function TemplatesPage() {
     <SEOPageLayout seoConfig={config.seo} schemas={schemas}>
       <PageHero config={config.hero} />
 
-      {/* Template Gallery Section - Embedded TemplateCarousel */}
+      {/* Unified gallery: design templates + job examples with ViewSwitcher */}
       <section id="template-gallery" className="py-8 -mx-4 sm:-mx-6 md:-mx-8">
-        <TemplateCarousel showHeader={false} />
+        <UnifiedTemplateSection />
       </section>
 
       <InContentAd adSlot={AD_CONFIG.slots.templatesIncontent} marginY={32} />
-
-      <JobExamplesSection />
 
       {/* Why Our Templates Section */}
       <RevealSection variant="fade-up">

--- a/resume-builder-ui/src/hooks/useTemplateActions.ts
+++ b/resume-builder-ui/src/hooks/useTemplateActions.ts
@@ -1,0 +1,280 @@
+/**
+ * useTemplateActions Hook
+ *
+ * Encapsulates all modal, auth, and recovery logic for template interactions.
+ * Extracted from TemplateCarousel to enable reuse in UnifiedTemplateSection
+ * while keeping TemplateCarousel unchanged for other pages.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiClient } from '../lib/api-client';
+import { useAuth } from '../contexts/AuthContext';
+import { useResumeCreate } from './useResumeCreate';
+import toast from 'react-hot-toast';
+import yaml from 'js-yaml';
+
+interface Template {
+  id: string;
+  name: string;
+  description: string;
+  image_url: string;
+  tags?: string[];
+  supports_icons?: boolean;
+}
+
+export function useTemplateActions(templates: Template[], filteredTemplates: Template[]) {
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+  const [selectedTemplateForModal, setSelectedTemplateForModal] = useState<string | null>(null);
+  const [checkingExistingResume, setCheckingExistingResume] = useState(false);
+  const [showStartModal, setShowStartModal] = useState(false);
+  const [showRecoveryModal, setShowRecoveryModal] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
+  const [previewTemplateIndex, setPreviewTemplateIndex] = useState(0);
+  const [existingResumeId, setExistingResumeId] = useState<string | null>(null);
+  const [existingResumeTitle, setExistingResumeTitle] = useState<string>('');
+  const [processingRecoveryRedirect, setProcessingRecoveryRedirect] = useState(false);
+
+  const navigate = useNavigate();
+  const { session, isAnonymous, isAuthenticated, anonMigrationInProgress } = useAuth();
+  const { createResume, creating } = useResumeCreate();
+
+  // Select the first template once loaded
+  useEffect(() => {
+    if (templates.length > 0 && !selectedTemplate) {
+      setSelectedTemplate(templates[0]);
+    }
+  }, [templates, selectedTemplate]);
+
+  const handleSelectTemplate = useCallback((template: Template) => {
+    setSelectedTemplate(template);
+  }, []);
+
+  const handlePreview = useCallback((template: Template) => {
+    const index = filteredTemplates.findIndex(t => t.id === template.id);
+    setPreviewTemplateIndex(index >= 0 ? index : 0);
+    setShowPreviewModal(true);
+  }, [filteredTemplates]);
+
+  const handleUseTemplate = useCallback(async (templateId: string) => {
+    if (!session) {
+      toast.error("Please sign in to create a resume");
+      return;
+    }
+
+    try {
+      setCheckingExistingResume(true);
+
+      const data = await apiClient.get('/api/resumes?limit=50', { session });
+      const resumes = data.resumes || [];
+
+      const matchingResumes = resumes.filter(
+        (resume: any) => resume.template_id === templateId
+      );
+
+      if (matchingResumes.length > 0) {
+        const mostRecent = matchingResumes.sort(
+          (a: any, b: any) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        )[0];
+
+        setExistingResumeId(mostRecent.id);
+        setExistingResumeTitle(mostRecent.title);
+        setSelectedTemplateForModal(templateId);
+        setShowPreviewModal(false);
+        setShowRecoveryModal(true);
+      } else {
+        setSelectedTemplateForModal(templateId);
+        setShowPreviewModal(false);
+        setShowStartModal(true);
+      }
+    } catch (error) {
+      console.error('Error checking existing resumes:', error);
+      setSelectedTemplateForModal(templateId);
+      setShowPreviewModal(false);
+      setShowStartModal(true);
+    } finally {
+      setCheckingExistingResume(false);
+    }
+  }, [session]);
+
+  const handleModalSelectEmpty = useCallback(async () => {
+    if (!selectedTemplateForModal) return;
+    setShowStartModal(false);
+    await createResume({
+      templateId: selectedTemplateForModal,
+      loadExample: false,
+    });
+  }, [selectedTemplateForModal, createResume]);
+
+  const handleModalSelectExample = useCallback(async () => {
+    if (!selectedTemplateForModal) return;
+    setShowStartModal(false);
+    await createResume({
+      templateId: selectedTemplateForModal,
+      loadExample: true,
+    });
+  }, [selectedTemplateForModal, createResume]);
+
+  const handleContinueAsGuest = useCallback(() => {
+    setShowRecoveryModal(false);
+    if (existingResumeId) {
+      navigate(`/editor/${existingResumeId}`);
+    }
+  }, [existingResumeId, navigate]);
+
+  const handleSignInToContinue = useCallback(() => {
+    if (existingResumeId) {
+      localStorage.setItem('resume-recovery-intent', JSON.stringify({
+        resumeId: existingResumeId,
+        action: 'continue',
+        timestamp: Date.now()
+      }));
+    }
+    setShowRecoveryModal(false);
+    setShowAuthModal(true);
+  }, [existingResumeId]);
+
+  const handleAuthSuccess = useCallback(() => {
+    setShowAuthModal(false);
+  }, []);
+
+  const handleCreateNewFromRecovery = useCallback(() => {
+    setShowRecoveryModal(false);
+    setShowStartModal(true);
+  }, []);
+
+  const handleModalSelectImport = useCallback(async (yamlString: string, confidence: number, warnings: string[]) => {
+    setShowStartModal(false);
+
+    const parsedYaml = yaml.load(yamlString) as {
+      contact_info: any;
+      sections: any[];
+      __icons__?: Record<string, string>;
+    };
+
+    const iconsArray: { filename: string; data: string }[] = [];
+    if (parsedYaml.__icons__) {
+      for (const [filename, data] of Object.entries(parsedYaml.__icons__)) {
+        iconsArray.push({ filename, data });
+      }
+    }
+
+    const generateTitle = (): string => {
+      const experienceSection = parsedYaml.sections.find(
+        s => s.type === 'experience'
+      );
+      if (experienceSection && Array.isArray(experienceSection.content) &&
+          experienceSection.content.length > 0) {
+        const firstJob = experienceSection.content[0];
+        if (typeof firstJob === 'object' && firstJob !== null && 'title' in firstJob && firstJob.title) {
+          return firstJob.title;
+        }
+      }
+
+      if (parsedYaml.contact_info?.name) {
+        const templateName = (selectedTemplateForModal || 'modern')
+          .split('-')
+          .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(' ');
+        return `${parsedYaml.contact_info.name} - ${templateName}`;
+      }
+
+      return 'Imported Resume';
+    };
+
+    await createResume({
+      templateId: selectedTemplateForModal || 'modern',
+      title: generateTitle(),
+      contactInfo: parsedYaml.contact_info,
+      sections: parsedYaml.sections,
+      icons: iconsArray,
+      aiImportConfidence: confidence,
+      aiImportWarnings: warnings,
+    });
+  }, [selectedTemplateForModal, createResume]);
+
+  // Check for recovery intent on mount
+  useEffect(() => {
+    const recoveryIntent = localStorage.getItem('resume-recovery-intent');
+    if (recoveryIntent) {
+      try {
+        const { timestamp } = JSON.parse(recoveryIntent);
+        const isRecent = Date.now() - timestamp < 10 * 60 * 1000;
+
+        if (isRecent && (isAuthenticated || anonMigrationInProgress)) {
+          setProcessingRecoveryRedirect(true);
+        }
+      } catch (error) {
+        console.error('Failed to parse recovery intent:', error);
+      }
+    }
+  }, [isAuthenticated, anonMigrationInProgress]);
+
+  // Handle post-auth navigation
+  useEffect(() => {
+    if (isAuthenticated && !isAnonymous && !anonMigrationInProgress) {
+      const recoveryIntent = localStorage.getItem('resume-recovery-intent');
+      if (recoveryIntent) {
+        try {
+          const { resumeId, action, timestamp } = JSON.parse(recoveryIntent);
+          const isRecent = Date.now() - timestamp < 10 * 60 * 1000;
+
+          if (action === 'continue' && resumeId && isRecent) {
+            localStorage.removeItem('resume-recovery-intent');
+            setProcessingRecoveryRedirect(true);
+            navigate(`/editor/${resumeId}`);
+          } else {
+            setProcessingRecoveryRedirect(false);
+          }
+        } catch (error) {
+          console.error('Failed to parse recovery intent:', error);
+          setProcessingRecoveryRedirect(false);
+        }
+      } else {
+        setProcessingRecoveryRedirect(false);
+      }
+    }
+  }, [isAuthenticated, isAnonymous, anonMigrationInProgress, navigate]);
+
+  const selectedTemplateModalName = selectedTemplateForModal
+    ? templates.find(t => t.id === selectedTemplateForModal)?.name || ''
+    : '';
+
+  return {
+    // State
+    selectedTemplate,
+    selectedTemplateForModal,
+    checkingExistingResume,
+    creating,
+    showStartModal,
+    showRecoveryModal,
+    showAuthModal,
+    showPreviewModal,
+    previewTemplateIndex,
+    existingResumeId,
+    existingResumeTitle,
+    processingRecoveryRedirect,
+    isAnonymous,
+    anonMigrationInProgress,
+    selectedTemplateModalName,
+
+    // Handlers
+    handleSelectTemplate,
+    handlePreview,
+    handleUseTemplate,
+    handleModalSelectEmpty,
+    handleModalSelectExample,
+    handleModalSelectImport,
+    handleContinueAsGuest,
+    handleSignInToContinue,
+    handleAuthSuccess,
+    handleCreateNewFromRecovery,
+
+    // Setters (for modal close)
+    setShowStartModal,
+    setShowRecoveryModal,
+    setShowAuthModal,
+    setShowPreviewModal,
+  };
+}

--- a/templates/registry.py
+++ b/templates/registry.py
@@ -57,7 +57,7 @@ _register(
         engine=TemplateEngine.latex,
         sample="samples/classic/alex_rivera_data.yml",
         name="Professional Resume",
-        description="Clean, structured layout with traditional formatting and excellent space utilization.",
+        description="Single-column LaTeX layout with section dividers. Best for finance, law, and corporate analytics roles.",
         preview="alex_rivera.png",
         tags=["traditional", "structured", "versatile"],
     )
@@ -69,8 +69,8 @@ _register(
         dir="classic",
         engine=TemplateEngine.latex,
         sample="samples/classic/jane_doe.yml",
-        name="Elegant Resume",
-        description="Refined design with sophisticated typography and organized section layout.",
+        name="Creative Resume",
+        description="Refined LaTeX layout with sophisticated typography. Best for marketing, design, and client-facing creative roles.",
         preview="jane_doe.png",
         tags=["refined", "sophisticated", "classic"],
     )
@@ -83,7 +83,7 @@ _register(
         engine=TemplateEngine.html,
         sample="samples/modern/john_doe.yml",
         name="Modern Resume",
-        description="Contemporary design enhanced with visual icons and dynamic styling elements.",
+        description="Contemporary single-column design with visual contact icons and clean skill sections.",
         preview="modern-with-icons.png",
         supports_icons=True,
         tags=["professional", "icons", "visual"],
@@ -97,7 +97,7 @@ _register(
         engine=TemplateEngine.html,
         sample="samples/modern/john_doe_no_icon.yml",
         name="Minimalist Resume",
-        description="Clean and simple design focused on content clarity and easy readability.",
+        description="Same modern layout, icon-free — safest bet for strict ATS parsers and traditional industries.",
         preview="modern-no-icons.png",
         tags=["clean", "simple", "ats-friendly"],
     )
@@ -110,7 +110,7 @@ _register(
         engine=TemplateEngine.html,
         sample="samples/ats-optimized/sample_data.yml",
         name="ATS Resume",
-        description="Ultra-plain, zero-decoration layout designed for maximum ATS parsability.",
+        description="Ultra-plain, zero-decoration single-column layout built to pass ATS keyword extraction.",
         preview="ats-optimized.png",
         tags=["ats-friendly", "single-column", "recruiter-approved"],
         pdf_options=PDFOptions(
@@ -129,7 +129,7 @@ _register(
         engine=TemplateEngine.html,
         sample="samples/student/sample_data.yml",
         name="Student Resume",
-        description="Education-first layout designed for students and first-time job seekers.",
+        description="Education-first section order with room for coursework and projects. Built for students and interns.",
         preview="student.png",
         tags=["entry-level", "education-first", "new-graduate"],
         pdf_options=PDFOptions(
@@ -148,7 +148,7 @@ _register(
         engine=TemplateEngine.latex,
         sample="samples/executive/sample_data.yml",
         name="Executive Resume",
-        description="Premium typography for senior professionals. Handles multi-page resumes elegantly.",
+        description="Premium serif typography with multi-page support and optional page numbers. For senior leaders.",
         preview="executive.png",
         tags=["senior", "multi-page", "premium-typography"],
     )
@@ -179,9 +179,9 @@ _register(
         engine=TemplateEngine.html,
         sample="samples/uk-cv/sample_data.yml",
         name="UK CV",
-        description="British CV format with Personal Profile. A4 paper, two-page layout, optional references.",
+        description="A4 page size with UK Personal Profile structure and an optional references section. Two-page default.",
         preview="uk-cv.png",
-        tags=["british", "a4", "two-page", "international"],
+        tags=["uk-cv", "british", "a4", "two-page", "international"],
         pdf_options=PDFOptions(
             page_size="A4",
             margin_top="0.75in",


### PR DESCRIPTION
## Summary

Replaces the two-zone `/templates` layout (TemplateCarousel at top + JobExamplesSection below an ad) with a single `<UnifiedTemplateSection>` component that lets users switch between **Design Templates** (default), **Resume Examples**, and **All** via a ViewSwitcher with contextual sub-filters.

Also brings example cards to parity with template cards: clicking an example image now opens a preview modal (with arrow nav) that routes to `/examples/{slug}` via a "See Full Example →" CTA — preserving the SEO equity on those pages.

Plus a disciplined data-accuracy pass on `templates/registry.py`.

## Why

1. Users can't preview examples the same way they preview templates — the two zones feel disconnected.
2. Job examples live below the in-content ad and are hard to discover.
3. Template card metadata has real gaps (orphaned `uk-cv`, missing `TEMPLATE_BEST_FOR` entries, confusing "Professional" vs "Elegant" naming).

Full plan lives at `~/.claude/plans/templates-page-ux-steady-puzzle.md`.

## What changed

### Unified gallery UX
- `TemplatesPage.tsx` now renders `<UnifiedTemplateSection />` in place of the old `TemplateCarousel` + `JobExamplesSection` duo. Ad placement unchanged (after the section).
- `ViewSwitcher` reordered: Templates → Examples → All. Default view = Templates (matches `/templates` URL intent). URL stays canonical; `?view=` param only appears when a non-default view is active.
- `JobExampleCard` accepts `onImageClick` — when provided, image area opens the preview modal; card body still routes to `/examples/{slug}` via `<Link>` (middle-click new-tab preserved).
- **New**: `JobExamplePreviewModal` — mirrors `TemplatePreviewModal`'s keyboard (Esc / ← →), focus trap, and swipe behavior. Primary CTA is a `<Link>` to `/examples/{slug}`; no "Use This Example" inside the modal (preserves SEO flow through the example page, where the full bullet bank + FAQs live).

### Registry accuracy (minimal, data-driven)
- **One display rename**: `classic-jane-doe` "Elegant Resume" → **"Creative Resume"**. All other names unchanged.
- **All 8 display template descriptions rewritten** to be concrete and differentiating (no marketing-speak — each mentions a structural or audience differentiator).
- `uk-cv` tags now include `'uk-cv'` and `'international'` so it matches the new filter pill.
- **`TEMPLATE_BEST_FOR` gaps**: added `uk-cv`; tightened `classic-jane-doe` to "marketing, design & client-facing creatives". Applied in both `TemplateCard.tsx` and `TemplatePreviewModal.tsx`.

### Filter bar
- New **International** pill in `FILTER_CATEGORIES` (tags: `uk-cv, british, international, a4`). All 8 display templates now appear in at least one filter.

### Keeping SEO quiet
- `/templates` is Tier 2 (pos 7.9) — change logged in `seo-tracking/changelog.md` with before-stats snapshot.
- No changes to `/templates/ats-friendly` (Tier 1), no changes to any `/templates/*` SEO landing page, no changes to `TemplatesPage.tsx` schema `ItemList` (category-based, not registry-based).
- `prerender.ts` mock data synced to match new registry so prerendered HTML stays consistent with the live `/api/templates` response.

### What was rejected in planning
- Aggressive renames from the audit (Visual Resume, Sidebar Resume, Clean Resume) — cosmetic without supporting data.
- Un-aliasing `two-column` (still excluded from display templates; left alone).
- Removing the now-unused `JobExamplesSection.tsx` — follow-up cleanup PR to keep this diff focused.

## Files

- **New**: `resume-builder-ui/src/components/JobExamplePreviewModal.tsx`, `UnifiedTemplateSection.tsx`, `ViewSwitcher.tsx`, `JobExampleCard.tsx`, `hooks/useTemplateActions.ts`
- **Modified**: `TemplatesPage.tsx`, `TemplateFilterBar.tsx`, `TemplateCard.tsx`, `TemplatePreviewModal.tsx`, `templates/registry.py`, `resume-builder-ui/scripts/prerender.ts`, `.gitignore`
- **TemplateCarousel.tsx**: untouched — still used by `CVTemplatesPage`, `ModernTemplatesPage`, `MinimalistTemplatesPage`, `StudentTemplatesPage`.

## Test plan

- [x] `npx vitest run` — 1630 passed, 28 skipped
- [x] `pytest tests/test_templates.py tests/test_template_html_rendering.py` — 74 passed
- [x] `npx tsc --noEmit` — clean
- [ ] **Deploy preview QA** (requires backend + Supabase):
  - [ ] `/templates` loads with ViewSwitcher showing **Templates** selected, 8 template cards
  - [ ] International filter pill reveals only the UK CV card with its new tagline
  - [ ] Switching to **Examples** shows 27 example cards with category pills; image-click opens modal with arrow nav + "See Full Example →"
  - [ ] Card-body click on an example still routes to `/examples/{slug}` directly
  - [ ] Esc closes both modals; ← → cycle inside both
  - [ ] `/templates?view=examples` deep link works; switching back to Templates strips the param
  - [ ] Mobile: ViewSwitcher + filter bars scroll horizontally; no layout shift
  - [ ] Gallery card for `classic-jane-doe` shows "Creative Resume" (not "Elegant Resume")

## SEO follow-up

- Snapshot `/templates` GSC stats in the next two weekly reviews (2026-04-29, 2026-05-06). Flag if position drops more than 5 spots.
- Revert candidate if needed: the Elegant → Creative rename.