### PR TITLE
🎨 Palette: Fix file input accessibility in UploadResumeModal

### DIFF
--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -208,12 +208,12 @@ export function UploadResumeModal({
                 accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 onChange={handleFileInput}
                 disabled={parsing}
-                className="hidden"
+                className="sr-only peer"
                 id="resume-file-input"
               />
               <label
                 htmlFor="resume-file-input"
-                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:ring-offset-2"
               >
                 <DocumentArrowUpIcon className="w-5 h-5" />
                 {parsing ? 'Parsing...' : 'Choose File'}


### PR DESCRIPTION
💡 What: Replaced `hidden` with `sr-only peer` on the file input and added focus-visible ring classes to its label wrapper in `UploadResumeModal.tsx`.
🎯 Why: Using `hidden` or `display: none` completely removes elements from the keyboard tab order. This change ensures keyboard users can tab to the upload button and see clear visual focus.
📸 Before/After: Visual change only visible on keyboard focus.
♿ Accessibility: Improved keyboard navigation support for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [5988020814701380557](https://jules.google.com/task/5988020814701380557) started by @aafre*