### PR TITLE
🎨 Palette: Add confirmation for deleting sections

### DIFF
--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -17,6 +20,7 @@ const SectionControls: React.FC<{
     const newSections = [...sections];
     newSections.splice(sectionIndex, 1);
     setSections(newSections);
+    setIsConfirmOpen(false);
   };
 
   return (
@@ -53,11 +57,22 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsConfirmOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
+
+      <ResponsiveConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={deleteSection}
+        title="Delete Section"
+        message="Are you sure you want to delete this section? This action cannot be undone."
+        confirmText="Delete Section"
+        cancelText="Cancel"
+        isDestructive={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
💡 What: Added a `ResponsiveConfirmDialog` confirmation prompt before deleting a resume section.
🎯 Why: To prevent accidental data loss when users click the delete section button.
📸 Before/After: Before, clicking delete immediately removed the section. After, a standard, mobile-friendly confirmation dialog requires user confirmation.
♿ Accessibility: Leverages the existing `ResponsiveConfirmDialog` which handles proper `role="dialog"`, ARIA attributes, and focus management.

---
*PR created automatically by Jules for task [18413180632263056216](https://jules.google.com/task/18413180632263056216) started by @aafre*