### PR TITLE
⚡ Bolt: Use Promise.all for concurrent file reading in icon export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Concurrent File Reads in useIconRegistry
+**Learning:** Sequential `await` calls inside loops for independent asynchronous tasks (like `FileReader` operations in `useIconRegistry.ts`) introduce unnecessary blocking and degrade export performance.
+**Action:** Refactor sequential asynchronous operations for independent tasks into concurrent execution using `Promise.all` while maintaining individual try/catch blocks to ensure robust error handling.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,28 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
-      const entry = registry[filename];
-      if (entry) {
-        try {
-          const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
-          };
-        } catch (error) {
-          console.warn(`Failed to export icon ${filename}:`, error);
+    // ⚡ Bolt Performance Optimization: Process FileReader conversions concurrently
+    // Replaced sequential await in loop with Promise.all to significantly reduce
+    // total export time when processing multiple icon files, while preserving
+    // individual error handling.
+    await Promise.all(
+      targetFilenames.map(async (filename) => {
+        const entry = registry[filename];
+        if (entry) {
+          try {
+            const base64Data = await fileToBase64(entry.file);
+            exportData[filename] = {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            };
+          } catch (error) {
+            console.warn(`Failed to export icon ${filename}:`, error);
+          }
         }
-      }
-    }
+      })
+    );
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
💡 What: Replaced a sequential `await` loop with `Promise.all` in `exportIconsForYAML` inside `useIconRegistry.ts`.
🎯 Why: Reading multiple files sequentially blocks execution unnecessarily. Concurrent reads are much faster.
📊 Impact: Significantly reduces total export time when processing multiple icon files by utilizing parallel `FileReader` conversions.
🔬 Measurement: Observe faster YAML exports when multiple icons are in the registry.

---
*PR created automatically by Jules for task [15608440110130733370](https://jules.google.com/task/15608440110130733370) started by @aafre*