### PR TITLE
🎨 Palette: Enhance UploadResumeModal accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - File Input Keyboard Accessibility via Peer Classes
+**Learning:** Standard `<input type="file">` elements styled via `display: none` or Tailwind's `hidden` are completely removed from the DOM's accessibility tree, making them un-focusable via keyboard navigation.
+**Action:** When creating custom styled file upload components, always apply `sr-only peer` to the `<input type="file">` and place it immediately before the custom `<label>` visual wrapper. Then, use `peer-focus-visible` classes on the label to render a visible focus ring, ensuring full keyboard and screen-reader accessibility without compromising the design.

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -88,18 +88,24 @@ export function UploadResumeModal({
 
   const modalContent = (
     <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="upload-modal-title"
+        className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden"
+      >
         {/* Header */}
         <div className="bg-ink px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="bg-white/20 p-2 rounded-lg">
               <DocumentArrowUpIcon className="w-6 h-6 text-white" />
             </div>
-            <h2 className="text-xl font-bold text-white">Upload Resume</h2>
+            <h2 id="upload-modal-title" className="text-xl font-bold text-white">Upload Resume</h2>
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            aria-label="Close dialog"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded p-1"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -208,12 +214,12 @@ export function UploadResumeModal({
                 accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
                 onChange={handleFileInput}
                 disabled={parsing}
-                className="hidden"
+                className="sr-only peer"
                 id="resume-file-input"
               />
               <label
                 htmlFor="resume-file-input"
-                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50"
+                className="btn-primary inline-flex items-center gap-2 px-6 py-3 cursor-pointer disabled:opacity-50 peer-focus-visible:ring-2 peer-focus-visible:ring-accent peer-focus-visible:ring-offset-2"
               >
                 <DocumentArrowUpIcon className="w-5 h-5" />
                 {parsing ? 'Parsing...' : 'Choose File'}
@@ -245,11 +251,11 @@ export function UploadResumeModal({
           <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end gap-3">
             <button
               onClick={handleCloseModal}
-              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors"
+              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             >
               Cancel
             </button>
-            <button onClick={handleContinue} className="btn-primary px-6 py-2">
+            <button onClick={handleContinue} className="btn-primary px-6 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2">
               Continue to Editor
             </button>
           </div>


### PR DESCRIPTION
- **What:** Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the upload modal. Fixed the file input's keyboard accessibility by replacing `hidden` with `sr-only peer` and adding `peer-focus-visible` to its label. Added `aria-label` and `focus-visible` styles to all modal buttons.
- **Why:** The modal was not correctly announced to screen readers. Furthermore, the file input used `hidden` which removed it from the tab order, making it impossible to upload files using only a keyboard. The close and action buttons lacked visible focus indicators, hindering keyboard navigation.
- **Before/After:** Before, the file input could not be tabbed to, and the modal was missing standard dialog semantics. Now, the entire upload flow can be navigated and executed via keyboard, with clear visual focus states and screen reader support.
- **Accessibility:** Ensured compliance with WAI-ARIA dialog patterns, maintained keyboard tab order for file inputs, and added clear focus indicators and ARIA labels.

---
*PR created automatically by Jules for task [2339022617521647010](https://jules.google.com/task/2339022617521647010) started by @aafre*