### PR TITLE
🎨 Palette: Add deletion confirmation to array items

### DIFF
--- a/resume-builder-ui/src/__tests__/EducationSection.test.tsx
+++ b/resume-builder-ui/src/__tests__/EducationSection.test.tsx
@@ -136,7 +136,7 @@ describe("EducationSection", { timeout: 5000 }, () => {
     expect(updatedEducation[1]).toEqual(mockEducation[1]);
   });
 
-  it("removes an education entry when the Remove button is clicked", () => {
+  it("removes an education entry when the Remove button is clicked and confirmed", () => {
     const onUpdateMock = vi.fn();
     const props = createDefaultProps({ onUpdate: onUpdateMock });
     render(<EducationSection {...props} />, { wrapper: DndWrapper });
@@ -144,6 +144,10 @@ describe("EducationSection", { timeout: 5000 }, () => {
     // Get all delete buttons (the trash icon)
     const deleteButtons = screen.getAllByTitle("Delete this entry");
     fireEvent.click(deleteButtons[0]);
+
+    // Click confirm in the dialog
+    const confirmBtn = screen.getByText("Confirm");
+    fireEvent.click(confirmBtn);
 
     expect(onUpdateMock).toHaveBeenCalledTimes(1);
     const updatedEducation = onUpdateMock.mock.calls[0][0];
@@ -228,6 +232,9 @@ describe("EducationSection", { timeout: 5000 }, () => {
 
     const deleteButtons = screen.getAllByTitle("Delete this entry");
     fireEvent.click(deleteButtons[0]);
+
+    const confirmBtn = screen.getByText("Confirm");
+    fireEvent.click(confirmBtn);
 
     // Should call onDeleteEntry for confirmation, not onUpdate
     expect(onDeleteEntryMock).toHaveBeenCalledWith(0);

--- a/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
+++ b/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
@@ -151,7 +151,7 @@ describe("ExperienceSection", { timeout: 5000 }, () => {
     expect(updatedExperiences[1]).toEqual(baseMockExperiences[1]);
   });
 
-  it("removes an experience entry when the Remove button is clicked", () => {
+  it("removes an experience entry when the Remove button is clicked and confirmed", () => {
     const onUpdateMock = vi.fn();
     const props = createDefaultProps({ onUpdate: onUpdateMock });
     render(<ExperienceSection {...props} />, { wrapper: DndWrapper });
@@ -159,6 +159,9 @@ describe("ExperienceSection", { timeout: 5000 }, () => {
     // Click the delete button (trash icon) for the first experience.
     const deleteButtons = screen.getAllByTitle("Delete this experience");
     fireEvent.click(deleteButtons[0]);
+
+    const confirmBtn = screen.getByText("Confirm");
+    fireEvent.click(confirmBtn);
 
     expect(onUpdateMock).toHaveBeenCalledTimes(1);
     const updatedExperiences = onUpdateMock.mock.calls[0][0];
@@ -258,6 +261,9 @@ describe("ExperienceSection", { timeout: 5000 }, () => {
 
     const deleteButtons = screen.getAllByTitle("Delete this experience");
     fireEvent.click(deleteButtons[0]);
+
+    const confirmBtn = screen.getByText("Confirm");
+    fireEvent.click(confirmBtn);
 
     // Should call onDeleteEntry for confirmation, not onUpdate
     expect(onDeleteEntryMock).toHaveBeenCalledWith(0);

--- a/resume-builder-ui/src/__tests__/GenericSection.test.tsx
+++ b/resume-builder-ui/src/__tests__/GenericSection.test.tsx
@@ -213,7 +213,7 @@ describe("GenericSection (List Type)", () => {
     expect(updatedSection.content[2]).toBe("");
   });
 
-  it("removes an item when its delete button is clicked", () => {
+  it("removes an item when its delete button is clicked and confirmed", () => {
     const onUpdateMock = vi.fn();
     const onEditTitleMock = vi.fn();
     const onSaveTitleMock = vi.fn();
@@ -238,6 +238,10 @@ describe("GenericSection (List Type)", () => {
     // For each list item, there's a delete button with title "Remove Item".
     const deleteButtons = screen.getAllByTitle("Remove Item");
     fireEvent.click(deleteButtons[0]);
+
+    const confirmBtn = screen.getByText("Confirm");
+    fireEvent.click(confirmBtn);
+
     expect(onUpdateMock).toHaveBeenCalledTimes(1);
     const updatedSection = onUpdateMock.mock.calls[0][0];
     // Original length is 2; after removing, it should be 1.

--- a/resume-builder-ui/src/components/EducationItem.tsx
+++ b/resume-builder-ui/src/components/EducationItem.tsx
@@ -1,8 +1,9 @@
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 import IconManager from "./IconManager";
 import { RichTextInput } from "./RichTextInput";
 import { MdDelete } from "react-icons/md";
 import SortableItem from "./SortableItem";
+import ResponsiveConfirmDialog from "./ResponsiveConfirmDialog";
 
 export interface EducationItemData {
   degree: string;
@@ -43,13 +44,15 @@ const EducationItem: React.FC<EducationItemProps> = memo(({
   supportsIcons,
   iconRegistry,
 }) => {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   return (
     <SortableItem id={id}>
       <div className="bg-gray-50/80 backdrop-blur-sm p-6 mb-6 rounded-xl border border-gray-200 shadow-md">
         <div className="flex justify-between items-center">
           <h3 className="text-lg font-semibold">Entry {index + 1}</h3>
           <button
-            onClick={() => onRemove(index)}
+            onClick={() => setShowDeleteConfirm(true)}
             className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
             aria-label="Delete education entry"
             title="Delete this entry"
@@ -119,6 +122,17 @@ const EducationItem: React.FC<EducationItemProps> = memo(({
           </div>
         </div>
       </div>
+      <ResponsiveConfirmDialog
+        isOpen={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        onConfirm={() => {
+          onRemove(index);
+          setShowDeleteConfirm(false);
+        }}
+        title="Delete Education?"
+        message="Are you sure you want to delete this education entry? This action cannot be undone."
+        isDestructive={true}
+      />
     </SortableItem>
   );
 });

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { RichTextInput } from './RichTextInput';
 import { MarkdownHint } from './MarkdownLinkPreview';
@@ -6,6 +6,7 @@ import IconManager from './IconManager';
 import ItemDndContext from './ItemDndContext';
 import SortableItem from './SortableItem';
 import { arrayMove } from '@dnd-kit/sortable';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 export interface ExperienceItemData {
   company: string;
@@ -89,12 +90,15 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
     onUpdate(index, { ...itemRef.current, description: [...itemRef.current.description, ""] });
   }, [index, onUpdate]);
 
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   return (
+    <>
     <div className="bg-gray-50/80 backdrop-blur-sm p-6 mb-6 rounded-xl border border-gray-200 shadow-md">
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-medium">Experience #{index + 1}</h3>
         <button
-          onClick={() => onDelete(index)}
+          onClick={() => setShowDeleteConfirm(true)}
           className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
           aria-label="Delete experience entry"
           title="Delete this experience"
@@ -201,6 +205,18 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
         </div>
       </div>
     </div>
+    <ResponsiveConfirmDialog
+      isOpen={showDeleteConfirm}
+      onClose={() => setShowDeleteConfirm(false)}
+      onConfirm={() => {
+        onDelete(index);
+        setShowDeleteConfirm(false);
+      }}
+      title="Delete Experience?"
+      message="Are you sure you want to delete this experience entry? This action cannot be undone."
+      isDestructive={true}
+    />
+    </>
   );
 });
 

--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -6,6 +6,7 @@ import { RichTextArea } from "./RichTextArea";
 import ItemDndContext from "./ItemDndContext";
 import SortableItem from "./SortableItem";
 import { GhostButton } from "./shared/GhostButton";
+import ResponsiveConfirmDialog from "./ResponsiveConfirmDialog";
 import { MdDelete } from "react-icons/md";
 
 interface Section {
@@ -78,17 +79,26 @@ const GenericSection: React.FC<GenericSectionProps> = ({
     }
   };
 
+  const [deleteTargetIndex, setDeleteTargetIndex] = useState<number | null>(null);
+
   const handleRemoveItem = (index: number) => {
+    setDeleteTargetIndex(index);
+  };
+
+  const confirmRemoveItem = () => {
+    if (deleteTargetIndex === null) return;
+
     if (onDeleteEntry) {
-      // Trigger confirmation dialog
-      onDeleteEntry(index);
+      // Trigger parent confirmation dialog (or direct action) if provided
+      onDeleteEntry(deleteTargetIndex);
     } else {
       // Fallback: direct delete (backward compatibility)
       const updatedContent = section.content.filter(
-        (_: string, i: number) => i !== index
+        (_: string, i: number) => i !== deleteTargetIndex
       );
       onUpdate({ ...section, content: updatedContent });
     }
+    setDeleteTargetIndex(null);
   };
 
   return (
@@ -306,6 +316,14 @@ const GenericSection: React.FC<GenericSectionProps> = ({
         )}
         </div>
       )}
+      <ResponsiveConfirmDialog
+        isOpen={deleteTargetIndex !== null}
+        onClose={() => setDeleteTargetIndex(null)}
+        onConfirm={confirmRemoveItem}
+        title="Delete Item?"
+        message="Are you sure you want to delete this item? This action cannot be undone."
+        isDestructive={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### What
Added `ResponsiveConfirmDialog` to confirm deletion of items in `ExperienceItem`, `EducationItem`, and `GenericSection`.

### Why
Prevents accidental data loss by confirming before deleting experience, education, and generic list items. Previously, clicking the delete button removed the item instantly without warning.

### Accessibility
Utilized the existing `ResponsiveConfirmDialog` which already provides appropriate `role="dialog"`, ARIA attributes, focus management, and mobile-friendly bottom sheet behavior.

### Before/After
Before: Clicking delete on an item would remove it immediately.
After: A confirmation dialog appears to ensure the user intended to delete the item before it is removed.

---
*PR created automatically by Jules for task [4734394976008816392](https://jules.google.com/task/4734394976008816392) started by @aafre*