### PR TITLE
🎨 Palette: Add Escape key support to ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2024-05-24 - Escape Key Support in Custom Modals
+**Learning:** Custom interactive dialogs and modals (like `ResponsiveConfirmDialog`) must implement an `Escape` key event listener to conform with standard accessibility guidelines. Without it, keyboard users are forced to manually tab to the close button or cancel button, creating a frustrating and non-standard experience.
+**Action:** Always implement a global or modal-scoped `keydown` listener for the `Escape` key that triggers the modal's `onClose` handler, and ensure it cleans up properly on unmount.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,22 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen && !isLoading) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isLoading, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {


### PR DESCRIPTION
### What
Added an `Escape` key event listener to the `ResponsiveConfirmDialog` component to automatically close the dialog when the user presses the Escape key.

### Why
Previously, the dialog could only be closed by clicking the close button, clicking the backdrop, or selecting one of the action buttons. This change brings the component in line with standard expected modal behavior, improving usability and reducing friction for keyboard users.

### Before/After
**Before:** Pressing the `Escape` key while the dialog was open had no effect.
**After:** Pressing the `Escape` key while the dialog is open now triggers the `onClose` handler and dismisses the dialog immediately.

### Accessibility
Enhances keyboard accessibility by allowing screen reader and keyboard-only users to dismiss potentially destructive confirmation dialogs quickly using a standard, familiar keystroke without needing to navigate focus to a specific "Cancel" or "Close" button.

---
*PR created automatically by Jules for task [1402749168612669187](https://jules.google.com/task/1402749168612669187) started by @aafre*