### PR TITLE
🎨 Palette: Add accessibility attributes to Duplicate and Upload modals

### DIFF
--- a/resume-builder-ui/src/components/DuplicateResumeModal.tsx
+++ b/resume-builder-ui/src/components/DuplicateResumeModal.tsx
@@ -24,6 +24,16 @@ export function DuplicateResumeModal({
     }
   }, [resume]);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onCancel();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onCancel]);
+
   if (!isOpen || !resume) return null;
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -34,8 +44,17 @@ export function DuplicateResumeModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-modal-title"
+      >
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">
             <div className="flex-shrink-0">
@@ -54,7 +73,9 @@ export function DuplicateResumeModal({
               </svg>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Duplicate Resume</h2>
+              <h2 id="duplicate-modal-title" className="text-xl font-bold text-gray-900">
+                Duplicate Resume
+              </h2>
               <p className="text-sm text-gray-500 mt-1">Create a copy with a new name</p>
             </div>
           </div>

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -100,6 +100,7 @@ export function UploadResumeModal({
           <button
             onClick={handleCloseModal}
             className="text-white/80 hover:text-white transition-colors"
+            aria-label="Close dialog"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
- **What**: Added `aria-label` to the close button in `UploadResumeModal.tsx`. Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and `Escape` key support to `DuplicateResumeModal.tsx`.
- **Why**: To improve keyboard navigation and screen reader support for these modals.
- **Before/After**: N/A (no visual changes).
- **Accessibility**: Improved screen reader support by adding necessary ARIA attributes and improved keyboard navigation by adding `Escape` key support to close the modal.

---
*PR created automatically by Jules for task [12082853777398001689](https://jules.google.com/task/12082853777398001689) started by @aafre*