### PR TITLE
🎨 Palette: Add ARIA labels and focus states to modal close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2024-05-03 - Accessible Modal Close Buttons
+**Learning:** Custom modals using React portals often have custom header implementations where icon-only close buttons lack both accessible names (`aria-label`) and visible focus states, which breaks keyboard navigation and screen reader experience.
+**Action:** Always ensure custom modal close buttons include `aria-label="Close modal"` and explicit focus states like `focus-visible:ring-2 focus-visible:ring-accent` using Tailwind.

--- a/resume-builder-ui/src/components/PreviewModal.tsx
+++ b/resume-builder-ui/src/components/PreviewModal.tsx
@@ -119,8 +119,9 @@ const PreviewModal: React.FC<PreviewModalProps> = ({
 
             <button
               onClick={onClose}
-              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               title="Close (ESC)"
+              aria-label="Close preview modal"
             >
               <MdClose className="text-xl" />
             </button>

--- a/resume-builder-ui/src/components/TabbedHelpModal.tsx
+++ b/resume-builder-ui/src/components/TabbedHelpModal.tsx
@@ -39,7 +39,8 @@ export default function TabbedHelpModal({
             </h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 transition-colors rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              aria-label="Close help modal"
             >
               <MdClose className="w-6 h-6" />
             </button>

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
### 💡 What
Added explicit `aria-label` attributes and focus ring styling (`focus-visible:ring-2`) to icon-only close buttons in `UploadResumeModal`, `TabbedHelpModal`, and `PreviewModal`.

### 🎯 Why
Custom modal implementations in React often use icon-only buttons for dismissing the dialog. Without `aria-label`, screen readers only announce these as "button". Without visible focus states, keyboard-only users cannot easily tell when the close button has focus, making navigation frustrating.

### 📸 Before/After
**Before:** Close buttons only had visual icons. Pressing Tab to navigate to them provided no visible indication they were focused.
**After:** Close buttons have semantic labels for screen readers. When navigating via keyboard, a clear ring appears around the button.

### ♿ Accessibility
- Ensures WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value) by giving a clear, programmatic name to icon-only buttons.
- Ensures WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by providing a highly visible focus indicator via `focus-visible:ring-2` on all modal close buttons.

---
*PR created automatically by Jules for task [1917953382697108983](https://jules.google.com/task/1917953382697108983) started by @aafre*