### PR TITLE
⚡ Bolt: Optimize exportIconsForYAML by replacing sequential await loop with concurrent Promise.all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-04 - Concurrent FileReader I/O Optimization
+**Learning:** Sequential `await` in loops over independent asynchronous operations (like `FileReader` conversions) needlessly blocks execution. JavaScript's single-threaded event loop ensures that concurrent modifications to distinct keys of a shared object within `Promise.all` callbacks do not cause race conditions.
+**Action:** Always refactor sequential `for...await` loops over independent asynchronous I/O tasks into `Promise.all(array.map(...))` to parallelize execution, maintaining isolated error handling to prevent batch failure.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,25 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
-      const entry = registry[filename];
-      if (entry) {
-        try {
-          const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
-          };
-        } catch (error) {
-          console.warn(`Failed to export icon ${filename}:`, error);
+    // ⚡ Bolt: Optimize sequential FileReader await to concurrent Promise.all execution
+    await Promise.all(
+      targetFilenames.map(async (filename) => {
+        const entry = registry[filename];
+        if (entry) {
+          try {
+            const base64Data = await fileToBase64(entry.file);
+            exportData[filename] = {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            };
+          } catch (error) {
+            console.warn(`Failed to export icon ${filename}:`, error);
+          }
         }
-      }
-    }
+      })
+    );
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
### What
Refactored the sequential `for` loop in `exportIconsForYAML` to use `Promise.all` for concurrent execution of asynchronous `FileReader` conversions.

### Why
The previous implementation awaited the `fileToBase64` conversion sequentially for each icon file, needlessly blocking execution and slowing down the export process, especially when multiple icons are present.

### Impact
Significantly reduces the total time required to export icons by processing all `FileReader` operations in parallel.

### Measurement
Verify the improvement by profiling the execution time of `exportIconsForYAML` when multiple icon files are registered. The parallel implementation handles the I/O conversions concurrently, reducing overall wait time.

---
*PR created automatically by Jules for task [17027412782608959801](https://jules.google.com/task/17027412782608959801) started by @aafre*