### PR TITLE
⚡ Bolt: Optimize icon export with concurrent processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-05 - Parallelize independent async file operations
+**Learning:** Sequential `await` in loops over independent asynchronous file operations (like `FileReader` conversions in `useIconRegistry`) creates significant unnecessary delays. JavaScript's single-threaded nature allows `Promise.all` to safely map distinct keys on a shared object concurrently without race conditions.
+**Action:** Refactor sequential asynchronous tasks in loops into concurrent operations using `Promise.all`, while ensuring individual error handling remains intact.

--- a/resume-builder-ui/src/hooks/useIconRegistry.ts
+++ b/resume-builder-ui/src/hooks/useIconRegistry.ts
@@ -169,22 +169,25 @@ export const useIconRegistry = (): UseIconRegistryReturn => {
     const targetFilenames = filenames || Object.keys(registry);
     const exportData: IconExportData = {};
 
-    for (const filename of targetFilenames) {
-      const entry = registry[filename];
-      if (entry) {
-        try {
-          const base64Data = await fileToBase64(entry.file);
-          exportData[filename] = {
-            data: base64Data,
-            type: entry.file.type,
-            size: entry.file.size,
-            uploadedAt: entry.uploadedAt.toISOString(),
-          };
-        } catch (error) {
-          console.warn(`Failed to export icon ${filename}:`, error);
+    // Use Promise.all to parallelize asynchronous file-to-base64 conversions
+    await Promise.all(
+      targetFilenames.map(async (filename) => {
+        const entry = registry[filename];
+        if (entry) {
+          try {
+            const base64Data = await fileToBase64(entry.file);
+            exportData[filename] = {
+              data: base64Data,
+              type: entry.file.type,
+              size: entry.file.size,
+              uploadedAt: entry.uploadedAt.toISOString(),
+            };
+          } catch (error) {
+            console.warn(`Failed to export icon ${filename}:`, error);
+          }
         }
-      }
-    }
+      })
+    );
 
     return exportData;
   }, [registry, fileToBase64]);


### PR DESCRIPTION
### 💡 What
Refactored `exportIconsForYAML` in `useIconRegistry` to use `Promise.all` for concurrent file-to-base64 conversions, rather than awaiting each file sequentially.

### 🎯 Why
As the number of icons increases, converting them one-by-one creates a performance bottleneck since these file read operations are independent. Parallelizing them reduces the total wait time to approximately the time of the longest single file conversion.

### 📊 Impact
Reduces the time taken to export a large registry of icons by executing file reads concurrently.

### 🔬 Measurement
Create a large icon registry in the application. Export the registry for YAML portability or saving to storage, and profile the function execution time. It will complete significantly faster.

---
*PR created automatically by Jules for task [15337575665680162534](https://jules.google.com/task/15337575665680162534) started by @aafre*