### PR TITLE
🎨 Palette: Improve keyboard focus visibility and accessibility for inline controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2024-05-05 - Consistent Keyboard Focus Visibility for Inline Controls
+**Learning:** Inline icon-only controls (like ✕ or ✏️) often lose default browser outlines due to custom Tailwind padding or colors, rendering them invisible to keyboard-only navigation.
+**Action:** Explicitly add `type="button"`, `aria-label`, and focus-visible outlines (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1`) to all custom icon buttons to ensure proper accessibility.

--- a/resume-builder-ui/src/components/EditableTitle.tsx
+++ b/resume-builder-ui/src/components/EditableTitle.tsx
@@ -81,7 +81,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
           type="button"
           aria-label="Save Section Title"
           onClick={onSave}
-          className="text-green-600 hover:text-green-800 transition-colors"
+          className="text-green-600 hover:text-green-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-1 rounded"
           title="Save Title (Enter)"
         >
           ✅
@@ -90,7 +90,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
           type="button"
           aria-label="Cancel Editing Title"
           onClick={onCancel}
-          className="text-red-600 hover:text-red-800 transition-colors"
+          className="text-red-600 hover:text-red-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 rounded"
           title="Cancel (Esc)"
         >
           ✕
@@ -110,7 +110,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
         type="button"
         aria-label="Edit Section Title"
         onClick={onEdit}
-        className="ml-2 text-gray-500 hover:text-gray-700 transition-colors"
+        className="ml-2 text-gray-500 hover:text-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded"
         title="Edit Title"
       >
         ✏️

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -178,9 +178,11 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                             />
                           </div>
                           <button
+                            type="button"
                             onClick={() => handleDescRemove(descIndex)}
-                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2"
+                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                             title="Remove description point"
+                            aria-label="Remove description point"
                           >
                             ✕
                           </button>

--- a/resume-builder-ui/src/components/editor/EditorHeader.tsx
+++ b/resume-builder-ui/src/components/editor/EditorHeader.tsx
@@ -246,8 +246,9 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
               <span aria-hidden="true">💡</span>
               <span>Don't forget to save your progress permanently</span>
               <button
+                type="button"
                 onClick={onDismissIdleTooltip}
-                className="ml-2 hover:opacity-75 text-white"
+                className="ml-2 hover:opacity-75 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-1 focus-visible:ring-offset-accent rounded"
                 aria-label="Dismiss reminder"
               >
                 ✕


### PR DESCRIPTION
### 💡 What
Added explicit keyboard focus outlines (`focus-visible`) and missing `type="button"` / `aria-label` attributes to various inline icon-only controls (e.g., remove description points, title editing actions, dismiss tooltips).

### 🎯 Why
Custom Tailwind padding and background colors can obscure default browser focus outlines. This made it difficult or impossible for keyboard-only users to see which inline action was currently focused.

### 📸 Before/After
*Before:* Tabbing to the "✕" or "✅" buttons provided no visual feedback.
*After:* Tabbing to these buttons displays a clear, accessible focus ring.

### ♿ Accessibility
- Ensured keyboard focus visibility (`focus-visible:ring-2`) on inline controls.
- Prevented accidental form submissions by ensuring `type="button"` is present on all icon buttons.
- Confirmed all icon-only buttons have descriptive `aria-label`s.

---
*PR created automatically by Jules for task [10293947439441721319](https://jules.google.com/task/10293947439441721319) started by @aafre*