### PR TITLE
chore(build): dev build tooling — gitignore artifacts + PostHog bundle verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,5 +229,6 @@ seo-tracking/
 linkedin-content/
 docs/templates/examples/
 pnpm-lock.yaml
-test-screenshots/
 .playwright-mcp/
+test-screenshots/
+.gemini/

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,5 @@ seo-tracking/
 linkedin-content/
 docs/templates/examples/
 pnpm-lock.yaml
+test-screenshots/
+.playwright-mcp/

--- a/scripts/build-dev.ps1
+++ b/scripts/build-dev.ps1
@@ -53,14 +53,26 @@ $REGISTRY = "europe-west2-docker.pkg.dev/uk-vm-00001/resume-builder"
 $IMAGE_NAME = "easyfreeresume-app"
 $TAG = "dev"
 
-Write-Host "Building DEV Docker image..."
-Write-Host "  VITE_APP_URL: $VITE_APP_URL"
-Write-Host "  VITE_SUPABASE_URL: $VITE_SUPABASE_URL"
-Write-Host "  VITE_ENABLE_EXPLICIT_ADS: $VITE_ENABLE_EXPLICIT_ADS"
-Write-Host "  VITE_AFFILIATE_JOB_SEARCH_ENABLED: $VITE_AFFILIATE_JOB_SEARCH_ENABLED"
-Write-Host "  VITE_AFFILIATE_RESUME_REVIEW_ENABLED: $VITE_AFFILIATE_RESUME_REVIEW_ENABLED"
-Write-Host "  VITE_APP_VERSION: $VITE_APP_VERSION"
-Write-Host "  VITE_POSTHOG_KEY: $(if ($VITE_POSTHOG_KEY) { $VITE_POSTHOG_KEY.Substring(0,8) + '...' } else { '(not set)' })"
+Write-Host ""
+Write-Host "=========================================" -ForegroundColor Cyan
+Write-Host "  DEV Build - Environment Variables" -ForegroundColor Cyan
+Write-Host "=========================================" -ForegroundColor Cyan
+Write-Host "  VITE_APP_URL              : $VITE_APP_URL"
+Write-Host "  VITE_APP_VERSION          : $VITE_APP_VERSION"
+Write-Host "  VITE_SUPABASE_URL         : $VITE_SUPABASE_URL"
+Write-Host "  VITE_SUPABASE_PUBLISHABLE : $($VITE_SUPABASE_PUBLISHABLE_KEY.Substring(0,16))..."
+Write-Host "  VITE_ENABLE_EXPLICIT_ADS  : $VITE_ENABLE_EXPLICIT_ADS"
+Write-Host "  VITE_AFFILIATE_JOB_SEARCH : $VITE_AFFILIATE_JOB_SEARCH_ENABLED"
+Write-Host "  VITE_AFFILIATE_REVIEW     : $VITE_AFFILIATE_RESUME_REVIEW_ENABLED"
+if ($VITE_POSTHOG_KEY) {
+    Write-Host "  VITE_POSTHOG_KEY          : $($VITE_POSTHOG_KEY.Substring(0,12))..." -ForegroundColor Green
+} else {
+    Write-Host "  VITE_POSTHOG_KEY          : *** NOT SET - analytics will be disabled ***" -ForegroundColor Red
+}
+Write-Host "  SUPABASE_URL (backend)    : $SUPABASE_URL"
+Write-Host "  SUPABASE_SECRET_KEY       : $($SUPABASE_SECRET_KEY.Substring(0,12))..."
+Write-Host "=========================================" -ForegroundColor Cyan
+Write-Host ""
 
 docker build `
     --build-arg VITE_SUPABASE_URL="$VITE_SUPABASE_URL" `
@@ -93,6 +105,18 @@ Write-Host "  Baked version : $baked"
 Write-Host "  Expected      : $VITE_APP_VERSION"
 if (-not $baked -or $baked.Trim() -ne $VITE_APP_VERSION) {
     Write-Warning "Version mismatch -- build may have used stale cache. Re-run with: docker build --no-cache ..."
+}
+
+# Verify PostHog was baked into the JS bundle
+Write-Host "Verifying PostHog in bundle..."
+$phCheck = docker run --rm "${IMAGE_NAME}:${TAG}" grep -rl "posthog" /app/static/assets/ 2>$null
+if ($phCheck) {
+    Write-Host "  PostHog: FOUND in JS bundle" -ForegroundColor Green
+} else {
+    Write-Host "  PostHog: NOT FOUND in JS bundle - analytics will not work!" -ForegroundColor Red
+    if (-not $VITE_POSTHOG_KEY) {
+        Write-Host "  Cause: VITE_POSTHOG_KEY was empty at build time (check .env)" -ForegroundColor Yellow
+    }
 }
 Write-Host ""
 Write-Host "To push: docker push ${REGISTRY}/${IMAGE_NAME}:${TAG}"

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -27,14 +27,26 @@ REGISTRY="europe-west2-docker.pkg.dev/uk-vm-00001/resume-builder"
 IMAGE_NAME="easyfreeresume-app"
 TAG="dev"
 
-echo "Building DEV Docker image..."
-echo "  VITE_APP_URL: $VITE_APP_URL"
-echo "  VITE_SUPABASE_URL: $VITE_SUPABASE_URL"
-echo "  VITE_ENABLE_EXPLICIT_ADS: $VITE_ENABLE_EXPLICIT_ADS"
-echo "  VITE_AFFILIATE_JOB_SEARCH_ENABLED: $VITE_AFFILIATE_JOB_SEARCH_ENABLED"
-echo "  VITE_AFFILIATE_RESUME_REVIEW_ENABLED: $VITE_AFFILIATE_RESUME_REVIEW_ENABLED"
-echo "  VITE_APP_VERSION: $VITE_APP_VERSION"
-if [ -n "$VITE_POSTHOG_KEY" ]; then echo "  VITE_POSTHOG_KEY: ${VITE_POSTHOG_KEY:0:8}..."; else echo "  VITE_POSTHOG_KEY: (not set)"; fi
+echo ""
+echo "========================================="
+echo "  DEV Build — Environment Variables"
+echo "========================================="
+echo "  VITE_APP_URL              : $VITE_APP_URL"
+echo "  VITE_APP_VERSION          : $VITE_APP_VERSION"
+echo "  VITE_SUPABASE_URL         : $VITE_SUPABASE_URL"
+echo "  VITE_SUPABASE_PUBLISHABLE : ${VITE_SUPABASE_PUBLISHABLE_KEY:0:16}..."
+echo "  VITE_ENABLE_EXPLICIT_ADS  : $VITE_ENABLE_EXPLICIT_ADS"
+echo "  VITE_AFFILIATE_JOB_SEARCH : $VITE_AFFILIATE_JOB_SEARCH_ENABLED"
+echo "  VITE_AFFILIATE_REVIEW     : $VITE_AFFILIATE_RESUME_REVIEW_ENABLED"
+if [ -n "$VITE_POSTHOG_KEY" ]; then
+  echo "  VITE_POSTHOG_KEY          : ${VITE_POSTHOG_KEY:0:12}..."
+else
+  echo "  VITE_POSTHOG_KEY          : *** NOT SET — analytics will be disabled ***"
+fi
+echo "  SUPABASE_URL (backend)    : $SUPABASE_URL"
+echo "  SUPABASE_SECRET_KEY       : ${SUPABASE_SECRET_KEY:0:12}..."
+echo "========================================="
+echo ""
 
 docker build \
   --build-arg VITE_SUPABASE_URL="$VITE_SUPABASE_URL" \
@@ -63,6 +75,17 @@ echo "  Baked version : $BAKED"
 echo "  Expected      : $VITE_APP_VERSION"
 if [ "$BAKED" != "$VITE_APP_VERSION" ]; then
   echo "WARNING: Version mismatch — build may have used stale cache. Re-run with: docker build --no-cache ..."
+fi
+
+# Verify PostHog was baked into the JS bundle
+echo "Verifying PostHog in bundle..."
+if docker run --rm "$IMAGE_NAME:$TAG" grep -rl "posthog" /app/static/assets/*.js > /dev/null 2>&1; then
+  echo "  PostHog: FOUND in JS bundle"
+else
+  echo "  PostHog: NOT FOUND in JS bundle — analytics will not work!"
+  if [ -z "$VITE_POSTHOG_KEY" ]; then
+    echo "  Cause: VITE_POSTHOG_KEY was empty at build time (check .env)"
+  fi
 fi
 echo ""
 echo "To push: docker push $REGISTRY/$IMAGE_NAME:$TAG"


### PR DESCRIPTION
## Summary

Two small, independent improvements to dev build/test tooling, broken out of the v3.25.0 release prep so they can ship on their own schedule.

### Commit 1 — `.gitignore`
- Ignore `test-screenshots/` and `.playwright-mcp/` — these directories accumulate during MCP-driven browser testing and should not be tracked.

### Commit 2 — `scripts/build-dev.{ps1,sh}`
- **Better env output**: section header + aligned columns + color coding (PowerShell). Easier to spot missing values at a glance.
- **Show truncated values** for `VITE_SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_URL`, `SUPABASE_SECRET_KEY` — confirms they're set without leaking the full secret.
- **Flag `VITE_POSTHOG_KEY` missing** as a build-time warning (red text in PowerShell, asterisks in bash).
- **Verify PostHog in JS bundle after build**: greps the built `static/assets/*.js` for `"posthog"` and warns if not found. Catches the silent-regression class where `VITE_POSTHOG_KEY` is empty at build time and analytics fail to ship — exactly the kind of thing that's invisible until prod.

### Why now

While prepping the v3.25.0 release (PR #463), it became obvious the dev build script wasn't surfacing enough information to catch env-var problems early. These changes don't gate on the release — shipping them now means the next dev rebuild already benefits.

### Why not bundled into #485 / #486 / #488 / #489 / #471

None of those PRs are about build tooling. Per CLAUDE.md commit style ("If changes touch multiple concerns, split into multiple commits") — and applying the same logic at PR scope.

## Test plan

- [x] `.gitignore` works: `git check-ignore test-screenshots/foo.png` returns the path
- [ ] PowerShell: run `scripts/build-dev.ps1` locally → verify formatted env output, color-coded PostHog status
- [ ] Bash: run `scripts/build-dev.sh` in WSL/Linux → same checks
- [ ] Build with `VITE_POSTHOG_KEY` empty → confirm red/asterisk warning + post-build "PostHog NOT FOUND" message
- [ ] Build with `VITE_POSTHOG_KEY` set → confirm green/check + "PostHog FOUND in JS bundle"
