### PR TITLE
🎨 Palette: Add type=button and aria-label to inline section controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2026-05-06 - Add type="button" and aria-labels to Section Controls
+**Learning:** Many icon-only controls for inline list editing or removing items lack `type="button"` and `aria-label` attributes, which can cause accidental form submissions or unclear interactions for screen readers.
+**Action:** When adding or modifying inline editing controls, always ensure they are properly designated as `type="button"` and have descriptive accessible names.

--- a/resume-builder-ui/src/components/EducationItem.tsx
+++ b/resume-builder-ui/src/components/EducationItem.tsx
@@ -49,6 +49,7 @@ const EducationItem: React.FC<EducationItemProps> = memo(({
         <div className="flex justify-between items-center">
           <h3 className="text-lg font-semibold">Entry {index + 1}</h3>
           <button
+            type="button"
             onClick={() => onRemove(index)}
             className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
             aria-label="Delete education entry"

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -94,6 +94,7 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-medium">Experience #{index + 1}</h3>
         <button
+          type="button"
           onClick={() => onDelete(index)}
           className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
           aria-label="Delete experience entry"
@@ -178,6 +179,8 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                             />
                           </div>
                           <button
+                            type="button"
+                            aria-label="Remove description point"
                             onClick={() => handleDescRemove(descIndex)}
                             className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2"
                             title="Remove description point"

--- a/resume-builder-ui/src/components/SectionEditor.tsx
+++ b/resume-builder-ui/src/components/SectionEditor.tsx
@@ -46,6 +46,8 @@ const SectionEditor: React.FC<{
                 autoFocus
               />
               <button
+                type="button"
+                aria-label="Save Section Name"
                 onClick={handleSaveName}
                 className="ml-2 text-green-500 hover:text-green-600"
                 title="Save Section Name"
@@ -53,6 +55,8 @@ const SectionEditor: React.FC<{
                 💾
               </button>
               <button
+                type="button"
+                aria-label="Cancel Edit"
                 onClick={handleCancelEdit}
                 className="ml-2 text-red-500 hover:text-red-600"
                 title="Cancel Edit"
@@ -149,6 +153,8 @@ const SectionEditor: React.FC<{
                 placeholder="Enter item text"
               />
               <button
+                type="button"
+                aria-label="Remove item"
                 onClick={() => {
                   const updatedSections = [...sections];
                   updatedSections[sectionIndex].content.splice(itemIndex, 1);


### PR DESCRIPTION
**What:** Added `type="button"` and explicit `aria-label` attributes to icon-only and inline control buttons across SectionEditor, ExperienceItem, and EducationItem components.
**Why:** Prevents accidental form submissions and ensures screen reader users can understand the purpose of icon-only controls.
**Before/After:** No visual changes, purely accessibility and semantic HTML improvements.
**Accessibility:** Improves keyboard/screen-reader accessibility by providing clear labels for 'Save', 'Cancel', and 'Remove' actions that previously only relied on emoji or tooltips.

---
*PR created automatically by Jules for task [13255535009312332919](https://jules.google.com/task/13255535009312332919) started by @aafre*