### PR TITLE
🎨 Palette: Add explicit focus states and ARIA labels to section item buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-23 - Focus Outlines on Custom Controls
+**Learning:** Custom inline removal/addition controls inside dynamically mapped lists often lose default browser focus outlines due to custom Tailwind padding and colors. This makes keyboard navigation difficult or impossible for screen readers.
+**Action:** Always explicitly add `focus-visible:outline-none focus-visible:ring-2` (using `ring-red-500` for destructive actions and `ring-accent` for additive ones) with `ring-offset-1` to ensure consistent keyboard focus visibility on custom buttons.

--- a/resume-builder-ui/src/components/EducationItem.tsx
+++ b/resume-builder-ui/src/components/EducationItem.tsx
@@ -49,8 +49,9 @@ const EducationItem: React.FC<EducationItemProps> = memo(({
         <div className="flex justify-between items-center">
           <h3 className="text-lg font-semibold">Entry {index + 1}</h3>
           <button
+            type="button"
             onClick={() => onRemove(index)}
-            className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
             aria-label="Delete education entry"
             title="Delete this entry"
           >

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -94,8 +94,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-medium">Experience #{index + 1}</h3>
         <button
+          type="button"
           onClick={() => onDelete(index)}
-          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
           aria-label="Delete experience entry"
           title="Delete this experience"
         >
@@ -178,9 +179,11 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                             />
                           </div>
                           <button
+                            type="button"
                             onClick={() => handleDescRemove(descIndex)}
-                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2"
+                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                             title="Remove description point"
+                            aria-label="Remove description point"
                           >
                             ✕
                           </button>
@@ -193,8 +196,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
             )}
           </div>
           <button
+            type="button"
             onClick={handleDescAdd}
-            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2"
+            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             + Add Description Point
           </button>

--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -155,7 +155,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                             <button
                               type="button"
                               onClick={() => handleRemoveItem(index)}
-                              className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0"
+                              className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                               title="Remove Item"
                               aria-label="Remove item"
                             >
@@ -217,7 +217,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                               <button
                                 type="button"
                                 onClick={() => handleRemoveItem(index)}
-                                className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0"
+                                className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                                 title="Remove Item"
                                 aria-label="Remove item"
                               >
@@ -279,7 +279,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                               <button
                                 type="button"
                                 onClick={() => handleRemoveItem(index)}
-                                className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0"
+                                className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                                 title="Remove Item"
                                 aria-label="Remove item"
                               >


### PR DESCRIPTION
**What:** Added explicit focus-visible Tailwind classes (`focus-visible:ring-2 focus-visible:ring-offset-1`, etc.) and `type="button"` to item deletion buttons in `ExperienceItem.tsx`, `EducationItem.tsx`, and `GenericSection.tsx`. Also added these to the description point removal and addition buttons in `ExperienceItem.tsx`.
**Why:** Inline removal/addition controls inside dynamically mapped lists were losing default browser focus outlines due to custom Tailwind padding and colors, making keyboard navigation difficult for users relying on screen readers or keyboard navigation.
**Before/After:** The buttons now show clear focus rings when navigating via keyboard (red for destructive actions, accent color for additive actions).
**Accessibility:** Improved keyboard navigability by ensuring focus visibility. Added explicit `type="button"` to prevent accidental form submissions, and `aria-label`s for screen reader accessibility on icon-only buttons (like the `✕` description point removal button).

---
*PR created automatically by Jules for task [541238815875527125](https://jules.google.com/task/541238815875527125) started by @aafre*