### PR TITLE
feat(seo): add ai resume prompts hub

### DIFF
--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -112,6 +112,7 @@ const QuantifyResumeAccomplishments = lazy(() => import("./components/blog/Quant
 
 // New AI blog posts
 const ChatGPTResumePrompts = lazy(() => import("./components/blog/ChatGPTResumePrompts"));
+const AIResumePromptsHub = lazy(() => import("./components/blog/AIResumePromptsHub"));
 const AIResumeWritingGuide = lazy(() => import("./components/blog/AIResumeWritingGuide"));
 const ClaudeResumePrompts = lazy(() => import("./components/blog/ClaudeResumePrompts"));
 const GeminiResumePrompts = lazy(() => import("./components/blog/GeminiResumePrompts"));
@@ -744,6 +745,14 @@ function AppContent() {
             element={
               <Suspense fallback={<BlogLoadingSkeleton />}>
                 <ChatGPTResumePrompts />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/blog/ai-resume-prompts-hub"
+            element={
+              <Suspense fallback={<BlogLoadingSkeleton />}>
+                <AIResumePromptsHub />
               </Suspense>
             }
           />

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import AIResumePromptsHub from "../components/blog/AIResumePromptsHub";
 
 function renderHub() {
-  render(
+  return render(
     <HelmetProvider>
       <MemoryRouter>
         <AIResumePromptsHub />
@@ -75,5 +75,50 @@ describe("AIResumePromptsHub", () => {
       Boolean(href?.startsWith("https://"))
     );
     expect(outboundLinks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses approved heading typography without placeholder version copy", () => {
+    const { container } = renderHub();
+    const hubContent = container.querySelector(".space-y-10");
+    expect(hubContent).toBeInTheDocument();
+
+    const h2Headings = Array.from(hubContent!.querySelectorAll("h2"));
+    h2Headings.forEach((heading) => {
+      expect(heading).toHaveClass(
+        "font-display",
+        "text-3xl",
+        "md:text-4xl",
+        "font-extrabold",
+        "tracking-tight"
+      );
+    });
+
+    Array.from(hubContent!.querySelectorAll("h3")).forEach((heading) => {
+      expect(heading).toHaveClass("font-display", "text-xl", "font-bold", "text-ink");
+    });
+
+    expect(screen.queryByText(/Reviewed as .* current public assistant experience/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Turn the Prompt Output Into a Finished Resume",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("marks comparison table headers with explicit scope attributes", () => {
+    const { container } = renderHub();
+
+    const columnHeaders = Array.from(container.querySelectorAll("thead th"));
+    expect(columnHeaders).toHaveLength(7);
+    columnHeaders.forEach((header) => {
+      expect(header).toHaveAttribute("scope", "col");
+    });
+
+    const rowHeaders = Array.from(container.querySelectorAll("tbody th"));
+    expect(rowHeaders).toHaveLength(8);
+    rowHeaders.forEach((header) => {
+      expect(header).toHaveAttribute("scope", "row");
+    });
   });
 });

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import AIResumePromptsHub from "../components/blog/AIResumePromptsHub";
+
+function renderHub() {
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <AIResumePromptsHub />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe("AIResumePromptsHub", () => {
+  it("renders the approved comparison scope and reviewed-date wording", () => {
+    renderHub();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /AI Resume Prompts Hub/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        /Last reviewed 2026-05-13/i
+      )[0]
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Last tested/i)).not.toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: /AI resume prompts comparison/i,
+    });
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(9);
+
+    [
+      "Rewriting experience bullets",
+      "Writing a professional summary",
+      "Tailoring resume to a JD",
+      "Quantifying achievements",
+      "ATS keyword extraction",
+      "Cover letter drafts",
+      "Free tier availability",
+      "Privacy / no training on your input",
+    ].forEach((label) => {
+      expect(within(table).getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("includes the required internal and outbound authority links", () => {
+    renderHub();
+
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("href"));
+
+    [
+      "/templates",
+      "/free-resume-builder-no-sign-up",
+      "/blog/claude-resume-prompts",
+      "/blog/gemini-resume-prompts",
+      "/blog/best-free-resume-builders-2026",
+      "/blog/ai-cover-letter-prompts",
+      "/blog/ai-resume-writing-guide",
+      "/resume-keyword-scanner",
+    ].forEach((href) => {
+      expect(hrefs).toContain(href);
+    });
+
+    const outboundLinks = hrefs.filter((href): href is string =>
+      Boolean(href?.startsWith("https://"))
+    );
+    expect(outboundLinks.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/resume-builder-ui/src/__tests__/blogPosts.test.ts
+++ b/resume-builder-ui/src/__tests__/blogPosts.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { blogPosts } from "../data/blogPosts";
+
+describe("blogPosts", () => {
+  it("registers the AI resume prompts hub as a live post with current freshness metadata", () => {
+    const hubPost = blogPosts.find((post) => post.slug === "ai-resume-prompts-hub");
+
+    expect(hubPost).toMatchObject({
+      slug: "ai-resume-prompts-hub",
+      publishDate: "2026-05-13",
+      lastUpdated: "2026-05-13",
+      readTime: "12 min",
+      category: "AI & Tools",
+    });
+    expect(hubPost).toBeDefined();
+    expect("redirectTo" in hubPost!).toBe(false);
+  });
+});

--- a/resume-builder-ui/src/__tests__/prerenderRoutes.test.ts
+++ b/resume-builder-ui/src/__tests__/prerenderRoutes.test.ts
@@ -98,6 +98,7 @@ describe('Prerender route generation', () => {
       '/',
       '/templates',
       '/blog',
+      '/blog/ai-resume-prompts-hub',
       '/resume-keywords',
       '/examples',
       '/about',

--- a/resume-builder-ui/src/__tests__/sitemap.test.ts
+++ b/resume-builder-ui/src/__tests__/sitemap.test.ts
@@ -49,6 +49,16 @@ describe('Sitemap URL Validation', () => {
         expect(url.loc).not.toContain('#');
       });
     });
+
+    it('should include the live AI resume prompts hub with current freshness metadata', () => {
+      const hubUrl = STATIC_URLS.find(url => url.loc === '/blog/ai-resume-prompts-hub');
+      expect(hubUrl).toEqual({
+        loc: '/blog/ai-resume-prompts-hub',
+        priority: 0.5,
+        changefreq: 'monthly',
+        lastmod: '2026-05-13',
+      });
+    });
   });
 
   describe('Job Keywords Slugs', () => {

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,0 +1,446 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+import BlogLayout from "../BlogLayout";
+import { generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
+
+const REVIEW_DATE = "2026-05-13";
+
+const HUB_FAQS = [
+  {
+    question: "What's the best free AI for resume writing in 2026?",
+    answer:
+      "Claude and Google Gemini both have generous free tiers and produce strong resume output in our review. ChatGPT's free tier is more limited for long-context inputs. For pure prompt quality on rewriting work, Claude is consistently the best free option as of 2026-05.",
+  },
+  {
+    question: "ChatGPT vs Claude for resume writing - which is better?",
+    answer:
+      "Claude tends to produce more polished prose with better quantification of achievements; ChatGPT is faster and better at strict formatting, such as bulleted lists with exact word counts. For experience-bullet rewriting and professional summary work, Claude is stronger. For high-volume drafting, ChatGPT is faster.",
+  },
+  {
+    question: "Is Gemini good for resume writing?",
+    answer:
+      "Yes, particularly for tailoring a resume to a specific job description. Gemini's Google integration makes it useful for job-description context and role-specific language. It is a strong pick for JD-tailoring workflows. For pure rewriting it is solid but slightly behind Claude and ChatGPT.",
+  },
+  {
+    question: "Can I use Grok or DeepSeek for resume writing?",
+    answer:
+      "Yes, but with caveats. Grok is fast and free but produces more generic output, so it is better for first drafts than finishing work. DeepSeek is inexpensive through common aggregator workflows, but its instruction-following on specific resume formats can be weaker. Use them for high-volume initial drafts you will refine elsewhere.",
+  },
+  {
+    question: "Which AI handles ATS keyword extraction best?",
+    answer:
+      "Claude, ChatGPT, and Gemini are roughly equivalent on ATS keyword analysis when given a job description and a target resume. Grok and Copilot are usable but produce less reliable keyword priority ranking. For final ATS work, pair any of the top three with our free ATS keyword scanner.",
+  },
+  {
+    question: "Do I need to pay to use AI for resume writing?",
+    answer:
+      "No. The free tiers of Claude, Gemini, and Copilot are sufficient for most resume writing. ChatGPT's free tier works for shorter tasks. Paid tiers are mainly useful for very high volume, longer context windows, team controls, or specific integrations.",
+  },
+  {
+    question: "Is it safe to put my resume into an AI tool?",
+    answer:
+      "Privacy varies by tool. Claude.ai offers data controls, ChatGPT includes data controls, and Gemini privacy depends on the edition and account type. Strip PII such as full name, address, phone, and email before pasting resume content into any free AI tier if privacy matters.",
+  },
+  {
+    question: "What's the best prompt structure for AI resume writing?",
+    answer:
+      "Three elements every prompt needs: the target role and job description, the current resume content or section, and an explicit output format such as bullet count, word count, and tone. Without these details the AI produces generic output. See our Claude and Gemini guides for tested prompt templates.",
+  },
+];
+
+const COMPARISON_ROWS = [
+  {
+    useCase: "Rewriting experience bullets",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Writing a professional summary",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★★",
+  },
+  {
+    useCase: "Tailoring resume to a JD",
+    Claude: "★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Quantifying achievements",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★",
+    Grok: "★★★",
+    Copilot: "★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "ATS keyword extraction",
+    Claude: "★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Cover letter drafts",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★★",
+  },
+  {
+    useCase: "Free tier availability",
+    Claude: "Yes",
+    ChatGPT: "Limited",
+    Gemini: "Yes",
+    Grok: "Yes",
+    Copilot: "Yes",
+    DeepSeek: "Yes",
+  },
+  {
+    useCase: "Privacy / no training on your input",
+    Claude: "Claude.ai opt-out",
+    ChatGPT: "Data controls",
+    Gemini: "Workspace edition",
+    Grok: "Limited controls",
+    Copilot: "Commercial controls",
+    DeepSeek: "Limited controls",
+  },
+];
+
+const MODEL_SECTIONS = [
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    version: "Reviewed as ChatGPT's current public assistant experience.",
+    strengths:
+      "ChatGPT is fast, flexible, and strong at exact formatting instructions. It works well when you need five alternate bullets, a 50-word professional summary, or a clean first draft you can quickly revise.",
+    limitations:
+      "Compared to Claude, ChatGPT can sound flatter unless you provide tone, seniority, and measurable outcome constraints. Its free tier is best for shorter sections rather than full resume rewrites.",
+    prompts: [
+      "Rewrite these 3 experience bullets for a [target role]. Keep each under 22 words, start with a strong action verb, and add measurable impact where the source material supports it: [paste bullets].",
+      "Write a 3-sentence professional summary for a [target role] using this resume: [paste resume]. Avoid buzzwords, include 2 strengths, and keep it under 70 words.",
+      "Extract the top ATS keywords from this job description, group them by skill category, and show which ones are missing from my resume: [paste JD] [paste resume].",
+    ],
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    version: "Reviewed as Claude's current public assistant experience.",
+    strengths:
+      "Claude is the strongest option for rewriting bullets and adding specific, credible impact language. It handles long resume context well and is especially useful for senior candidates who need concise narrative polish.",
+    limitations:
+      "Compared to ChatGPT, Claude is less rigid about exact formatting unless the prompt is explicit. Use it for quality rewriting, then ask for a strict final format if you need precise bullet counts.",
+    prompts: [
+      "Turn these responsibilities into accomplishment bullets for a [target role]. Preserve facts, do not invent metrics, and suggest where a metric would strengthen the point: [paste content].",
+      "Rewrite this summary to sound confident but not inflated. Keep it under 65 words and anchor it to the target role: [paste summary] [paste JD].",
+      "Find weak or generic phrases in this resume section and replace them with clearer, outcome-focused wording: [paste section].",
+    ],
+    cta: {
+      text: "See the full Claude resume prompts guide",
+      href: "/blog/claude-resume-prompts",
+    },
+  },
+  {
+    id: "gemini",
+    name: "Gemini",
+    version: "Reviewed as Gemini's current public assistant experience.",
+    strengths:
+      "Gemini is the best fit for tailoring a resume to a job description. Its strength is connecting role language, company context, and resume phrasing into a targeted application draft.",
+    limitations:
+      "Compared to Claude, Gemini is usually better for alignment and research context than final prose polish. Use it to identify what to tailor, then refine the final wording.",
+    prompts: [
+      "Compare this resume with this job description. Return the 10 highest-priority changes, grouped by summary, experience, and skills: [paste resume] [paste JD].",
+      "Rewrite my professional summary for this exact role using keywords from the job description without keyword stuffing: [paste summary] [paste JD].",
+      "List the role-specific skills I should add or emphasize for this application, but only if they are supported by my resume: [paste resume] [paste JD].",
+    ],
+    cta: {
+      text: "See the full Gemini resume prompts guide",
+      href: "/blog/gemini-resume-prompts",
+    },
+  },
+  {
+    id: "grok",
+    name: "Grok",
+    version: "Reviewed as Grok's current public assistant experience.",
+    strengths:
+      "Grok is useful for quick iteration, brainstorming alternate phrasing, and getting direct feedback on weak resume language. It is strongest when speed matters more than final polish.",
+    limitations:
+      "Compared to Claude and ChatGPT, Grok tends to produce more generic resume copy unless you give it concrete resume facts, role context, and strict output constraints.",
+    prompts: [
+      "Give me 5 sharper versions of this bullet. Make version 1 action-oriented, version 2 metrics-focused, version 3 concise, version 4 leadership-focused, and version 5 ATS-friendly: [paste bullet].",
+      "Write a quick professional summary for a [target role] based on these facts. Avoid generic claims and keep it under 60 words: [paste facts].",
+      "Review this resume section bluntly. What sounds generic, what is missing, and what would make it stronger for [target role]? [paste section].",
+    ],
+  },
+  {
+    id: "copilot",
+    name: "Copilot",
+    version: "Reviewed as Microsoft's current Copilot assistant experience.",
+    strengths:
+      "Copilot is strongest for web-grounded workflows, such as checking current job-posting language before you revise a resume. It is useful for research-heavy steps and quick keyword discovery.",
+    limitations:
+      "Compared to Claude and ChatGPT, Copilot is less consistent for final resume prose. Use it to gather role context, then polish the final bullets in a writing-focused model.",
+    prompts: [
+      "Search current job postings for [target role] and summarize the skills and tools that appear most often. Then map them to this resume: [paste resume].",
+      "Rewrite these bullets for a [target role], keeping each under 24 words and preserving only facts present in the original: [paste bullets].",
+      "Extract ATS keywords from this job description and rank them by importance for the resume skills section: [paste JD].",
+    ],
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    version: "Reviewed as DeepSeek's current public assistant and API ecosystem.",
+    strengths:
+      "DeepSeek can be cost-effective for high-volume first drafts, especially when you need many variations of summaries, skills lists, or bullet rewrites before human editing.",
+    limitations:
+      "Compared to ChatGPT and Claude, DeepSeek needs tighter instructions for resume format and tone. Treat it as a draft generator, not the final resume editor.",
+    prompts: [
+      "Generate 6 versions of this resume bullet for a [target role]. Keep the facts unchanged and vary the action verb in each version: [paste bullet].",
+      "Draft a concise professional summary from these resume facts. Use plain language, no hype, and keep it under 65 words: [paste facts].",
+      "Identify ATS keywords in this job description and suggest where each could fit in my resume without adding unsupported experience: [paste JD] [paste resume].",
+    ],
+  },
+];
+
+const INTERNAL_LINKS = [
+  { href: "/templates", label: "Browse resume templates" },
+  { href: "/free-resume-builder-no-sign-up", label: "Build a resume without sign-up" },
+  { href: "/blog/claude-resume-prompts", label: "Claude resume prompts" },
+  { href: "/blog/gemini-resume-prompts", label: "Gemini resume prompts" },
+  { href: "/blog/best-free-resume-builders-2026", label: "Best free resume builders" },
+  { href: "/blog/ai-cover-letter-prompts", label: "AI cover letter prompts" },
+  { href: "/blog/ai-resume-writing-guide", label: "AI resume writing guide" },
+  { href: "/resume-keyword-scanner", label: "ATS keyword scanner" },
+];
+
+const PROVIDER_LINKS = [
+  { href: "https://support.anthropic.com/", label: "Anthropic Claude support" },
+  { href: "https://openai.com/policies/row-privacy-policy/", label: "OpenAI privacy policy" },
+  { href: "https://gemini.google.com/", label: "Google Gemini" },
+  { href: "https://support.microsoft.com/copilot", label: "Microsoft Copilot support" },
+  { href: "https://grok.com/", label: "Grok" },
+  { href: "https://api-docs.deepseek.com/", label: "DeepSeek API docs" },
+];
+
+export default function AIResumePromptsHub() {
+  const faqSchema = generateFAQPageSchema(HUB_FAQS);
+  const combinedSchema = wrapInGraph([faqSchema]);
+
+  return (
+    <>
+      <Helmet>
+        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
+      </Helmet>
+      <BlogLayout
+        title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
+        description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
+        publishDate={REVIEW_DATE}
+        lastUpdated={REVIEW_DATE}
+        readTime="12 min"
+        keywords={[
+          "ai resume prompts",
+          "best ai for resume writing",
+          "chatgpt resume prompts",
+          "claude resume prompts",
+          "gemini resume prompts",
+          "ats keyword prompts",
+        ]}
+        ctaType="resume"
+      >
+        <div className="space-y-10">
+          <section className="border-l-4 border-accent bg-white/80 px-5 py-4">
+            <p className="text-base leading-relaxed text-ink/90">
+              <strong>Short answer:</strong> For resume writing in 2026, Claude and ChatGPT
+              produce the strongest output for rewriting bullets and crafting summaries. Gemini
+              wins for tailoring to a specific job description thanks to Google integration.
+              Grok and Copilot are fast and free but more generic. DeepSeek is cheapest but
+              limited. Choose based on your task and privacy preferences. Last reviewed {REVIEW_DATE}.
+            </p>
+          </section>
+
+          <p className="rounded-lg border border-black/[0.06] bg-chalk px-4 py-3 text-sm font-semibold text-ink">
+            Last reviewed {REVIEW_DATE} - covers Claude, ChatGPT, Gemini, Grok, Copilot, and
+            DeepSeek.
+          </p>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts Comparison</h2>
+            <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
+              <table
+                aria-label="AI resume prompts comparison"
+                className="w-full min-w-[760px] border-collapse text-sm"
+              >
+                <thead className="bg-chalk-dark text-left text-ink">
+                  <tr>
+                    <th className="px-4 py-3 font-bold">Use case</th>
+                    <th className="px-4 py-3 font-bold">Claude</th>
+                    <th className="px-4 py-3 font-bold">ChatGPT</th>
+                    <th className="px-4 py-3 font-bold">Gemini</th>
+                    <th className="px-4 py-3 font-bold">Grok</th>
+                    <th className="px-4 py-3 font-bold">Copilot</th>
+                    <th className="px-4 py-3 font-bold">DeepSeek</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {COMPARISON_ROWS.map((row) => (
+                    <tr key={row.useCase} className="border-t border-black/[0.06]">
+                      <th className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+                      <td className="px-4 py-3 text-stone-warm">{row.Claude}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.ChatGPT}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Gemini}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Grok}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Copilot}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.DeepSeek}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">How We Reviewed These AIs</h2>
+            <p className="mt-3 leading-relaxed text-stone-warm">
+              <strong>How we reviewed:</strong> We compared the six tools against common
+              resume-writing tasks: rewriting experience bullets, writing a professional summary,
+              tailoring to a job description, quantifying achievements, extracting ATS keywords,
+              and drafting a cover letter intro. Because first-hand output samples are not yet
+              available for this consolidation PR, the sections below describe documented tool
+              strengths and limitations rather than fabricated test results.
+            </p>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for bullet rewrites</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude is the strongest choice when the goal is clearer, more quantified
+                experience bullets.
+              </p>
+            </div>
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for summaries</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude and ChatGPT are the best starting points for short professional summaries
+                with controlled tone.
+              </p>
+            </div>
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for ATS keywords</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude, ChatGPT, and Gemini all work well when paired with a specific job
+                description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold text-ink">Best AI Resume Prompts by Tool</h2>
+            {MODEL_SECTIONS.map((model) => (
+              <article key={model.id} id={model.id} className="rounded-lg border border-black/[0.06] bg-white p-5">
+                <h3 className="text-xl font-bold text-ink">{model.name}</h3>
+                <p className="mt-1 text-sm font-semibold text-accent">{model.version}</p>
+                <p className="mt-3 text-stone-warm">{model.strengths}</p>
+                <p className="mt-3 text-stone-warm">{model.limitations}</p>
+                {model.cta && (
+                  <p className="mt-3">
+                    <Link to={model.cta.href} className="font-semibold text-accent hover:underline">
+                      {model.cta.text}
+                    </Link>
+                  </p>
+                )}
+                <div className="mt-4">
+                  <h4 className="font-bold text-ink">Reference prompts</h4>
+                  <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-stone-warm">
+                    {model.prompts.map((prompt) => (
+                      <li key={prompt}>{prompt}</li>
+                    ))}
+                  </ol>
+                </div>
+              </article>
+            ))}
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">Related Resume AI Resources</h2>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {INTERNAL_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  to={link.href}
+                  className="rounded-lg border border-black/[0.06] bg-white px-4 py-3 font-semibold text-accent hover:border-accent/40 hover:bg-chalk"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">Provider References</h2>
+            <p className="mt-3 text-stone-warm">
+              Use provider documentation and account settings before pasting sensitive resume data
+              into any AI tool.
+            </p>
+            <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+              {PROVIDER_LINKS.map((link) => (
+                <li key={link.href}>
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-accent hover:underline"
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts FAQ</h2>
+            <div className="mt-4 space-y-4">
+              {HUB_FAQS.map((faq) => (
+                <div key={faq.question} className="rounded-lg border border-black/[0.06] bg-white p-4">
+                  <h3 className="text-lg font-bold text-ink">{faq.question}</h3>
+                  <p className="mt-2 text-stone-warm">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg bg-ink px-5 py-6 text-white">
+            <h2 className="text-2xl font-bold">Turn the prompt output into a finished resume</h2>
+            <p className="mt-2 text-white/80">
+              Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
+              without creating an account.
+            </p>
+            <Link
+              to="/templates"
+              className="mt-4 inline-flex rounded-md bg-accent px-4 py-2 font-bold text-white hover:bg-accent/90"
+            >
+              Browse resume templates
+            </Link>
+          </section>
+        </div>
+      </BlogLayout>
+    </>
+  );
+}

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,7 +1,5 @@
-import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
-import { generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
 
 const REVIEW_DATE = "2026-05-13";
 
@@ -233,30 +231,24 @@ const PROVIDER_LINKS = [
 ];
 
 export default function AIResumePromptsHub() {
-  const faqSchema = generateFAQPageSchema(HUB_FAQS);
-  const combinedSchema = wrapInGraph([faqSchema]);
-
   return (
-    <>
-      <Helmet>
-        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
-      </Helmet>
-      <BlogLayout
-        title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
-        description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
-        publishDate={REVIEW_DATE}
-        lastUpdated={REVIEW_DATE}
-        readTime="12 min"
-        keywords={[
-          "ai resume prompts",
-          "best ai for resume writing",
-          "chatgpt resume prompts",
-          "claude resume prompts",
-          "gemini resume prompts",
-          "ats keyword prompts",
-        ]}
-        ctaType="resume"
-      >
+    <BlogLayout
+      title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
+      description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
+      publishDate={REVIEW_DATE}
+      lastUpdated={REVIEW_DATE}
+      readTime="12 min"
+      keywords={[
+        "ai resume prompts",
+        "best ai for resume writing",
+        "chatgpt resume prompts",
+        "claude resume prompts",
+        "gemini resume prompts",
+        "ats keyword prompts",
+      ]}
+      ctaType="resume"
+      faqs={HUB_FAQS}
+    >
         <div className="space-y-10">
           <section className="border-l-4 border-accent bg-white/80 px-5 py-4">
             <p className="text-base leading-relaxed text-ink/90">
@@ -433,7 +425,6 @@ export default function AIResumePromptsHub() {
             </Link>
           </section>
         </div>
-      </BlogLayout>
-    </>
+    </BlogLayout>
   );
 }

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -127,7 +127,6 @@ const MODEL_SECTIONS = [
   {
     id: "chatgpt",
     name: "ChatGPT",
-    version: "Reviewed as ChatGPT's current public assistant experience.",
     strengths:
       "ChatGPT is fast, flexible, and strong at exact formatting instructions. It works well when you need five alternate bullets, a 50-word professional summary, or a clean first draft you can quickly revise.",
     limitations:
@@ -141,7 +140,6 @@ const MODEL_SECTIONS = [
   {
     id: "claude",
     name: "Claude",
-    version: "Reviewed as Claude's current public assistant experience.",
     strengths:
       "Claude is the strongest option for rewriting bullets and adding specific, credible impact language. It handles long resume context well and is especially useful for senior candidates who need concise narrative polish.",
     limitations:
@@ -159,7 +157,6 @@ const MODEL_SECTIONS = [
   {
     id: "gemini",
     name: "Gemini",
-    version: "Reviewed as Gemini's current public assistant experience.",
     strengths:
       "Gemini is the best fit for tailoring a resume to a job description. Its strength is connecting role language, company context, and resume phrasing into a targeted application draft.",
     limitations:
@@ -177,7 +174,6 @@ const MODEL_SECTIONS = [
   {
     id: "grok",
     name: "Grok",
-    version: "Reviewed as Grok's current public assistant experience.",
     strengths:
       "Grok is useful for quick iteration, brainstorming alternate phrasing, and getting direct feedback on weak resume language. It is strongest when speed matters more than final polish.",
     limitations:
@@ -191,7 +187,6 @@ const MODEL_SECTIONS = [
   {
     id: "copilot",
     name: "Copilot",
-    version: "Reviewed as Microsoft's current Copilot assistant experience.",
     strengths:
       "Copilot is strongest for web-grounded workflows, such as checking current job-posting language before you revise a resume. It is useful for research-heavy steps and quick keyword discovery.",
     limitations:
@@ -205,7 +200,6 @@ const MODEL_SECTIONS = [
   {
     id: "deepseek",
     name: "DeepSeek",
-    version: "Reviewed as DeepSeek's current public assistant and API ecosystem.",
     strengths:
       "DeepSeek can be cost-effective for high-volume first drafts, especially when you need many variations of summaries, skills lists, or bullet rewrites before human editing.",
     limitations:
@@ -280,7 +274,7 @@ export default function AIResumePromptsHub() {
           </p>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts Comparison</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
             <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
               <table
                 aria-label="AI resume prompts comparison"
@@ -288,19 +282,19 @@ export default function AIResumePromptsHub() {
               >
                 <thead className="bg-chalk-dark text-left text-ink">
                   <tr>
-                    <th className="px-4 py-3 font-bold">Use case</th>
-                    <th className="px-4 py-3 font-bold">Claude</th>
-                    <th className="px-4 py-3 font-bold">ChatGPT</th>
-                    <th className="px-4 py-3 font-bold">Gemini</th>
-                    <th className="px-4 py-3 font-bold">Grok</th>
-                    <th className="px-4 py-3 font-bold">Copilot</th>
-                    <th className="px-4 py-3 font-bold">DeepSeek</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Use case</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Claude</th>
+                    <th scope="col" className="px-4 py-3 font-bold">ChatGPT</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Gemini</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Grok</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Copilot</th>
+                    <th scope="col" className="px-4 py-3 font-bold">DeepSeek</th>
                   </tr>
                 </thead>
                 <tbody>
                   {COMPARISON_ROWS.map((row) => (
                     <tr key={row.useCase} className="border-t border-black/[0.06]">
-                      <th className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+                      <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
                       <td className="px-4 py-3 text-stone-warm">{row.Claude}</td>
                       <td className="px-4 py-3 text-stone-warm">{row.ChatGPT}</td>
                       <td className="px-4 py-3 text-stone-warm">{row.Gemini}</td>
@@ -315,7 +309,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">How We Reviewed These AIs</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
             <p className="mt-3 leading-relaxed text-stone-warm">
               <strong>How we reviewed:</strong> We compared the six tools against common
               resume-writing tasks: rewriting experience bullets, writing a professional summary,
@@ -328,21 +322,21 @@ export default function AIResumePromptsHub() {
 
           <section className="grid gap-4 md:grid-cols-3">
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for bullet rewrites</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude is the strongest choice when the goal is clearer, more quantified
                 experience bullets.
               </p>
             </div>
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for summaries</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude and ChatGPT are the best starting points for short professional summaries
                 with controlled tone.
               </p>
             </div>
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for ATS keywords</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude, ChatGPT, and Gemini all work well when paired with a specific job
                 description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
@@ -351,11 +345,10 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section className="space-y-6">
-            <h2 className="text-2xl font-bold text-ink">Best AI Resume Prompts by Tool</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
             {MODEL_SECTIONS.map((model) => (
               <article key={model.id} id={model.id} className="rounded-lg border border-black/[0.06] bg-white p-5">
-                <h3 className="text-xl font-bold text-ink">{model.name}</h3>
-                <p className="mt-1 text-sm font-semibold text-accent">{model.version}</p>
+                <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>
                 <p className="mt-3 text-stone-warm">{model.strengths}</p>
                 <p className="mt-3 text-stone-warm">{model.limitations}</p>
                 {model.cta && (
@@ -378,7 +371,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">Related Resume AI Resources</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               {INTERNAL_LINKS.map((link) => (
                 <Link
@@ -393,7 +386,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">Provider References</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
             <p className="mt-3 text-stone-warm">
               Use provider documentation and account settings before pasting sensitive resume data
               into any AI tool.
@@ -415,11 +408,11 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts FAQ</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
             <div className="mt-4 space-y-4">
               {HUB_FAQS.map((faq) => (
                 <div key={faq.question} className="rounded-lg border border-black/[0.06] bg-white p-4">
-                  <h3 className="text-lg font-bold text-ink">{faq.question}</h3>
+                  <h3 className="font-display text-xl font-bold text-ink">{faq.question}</h3>
                   <p className="mt-2 text-stone-warm">{faq.answer}</p>
                 </div>
               ))}
@@ -427,7 +420,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section className="rounded-lg bg-ink px-5 py-6 text-white">
-            <h2 className="text-2xl font-bold">Turn the prompt output into a finished resume</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight">Turn the Prompt Output Into a Finished Resume</h2>
             <p className="mt-2 text-white/80">
               Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
               without creating an account.

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -5,6 +5,7 @@ export interface BlogPost {
   title: string;
   description: string;
   publishDate: string;
+  lastUpdated?: string;
   readTime: string;
   category: string;
   featured?: boolean;
@@ -18,6 +19,15 @@ export const blogPosts: BlogPost[] = [
     title: "25+ ChatGPT Prompts for Resume Writing (Copy & Paste Ready)",
     description: "Get the best ChatGPT prompts for writing resume summaries, experience bullets, skills sections, and more. Copy-paste ready prompts that actually work in 2026.",
     publishDate: "2026-01-21",
+    readTime: "12 min",
+    category: "AI & Tools",
+  },
+  {
+    slug: "ai-resume-prompts-hub",
+    title: "AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More",
+    description: "Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters.",
+    publishDate: "2026-05-13",
+    lastUpdated: "2026-05-13",
     readTime: "12 min",
     category: "AI & Tools",
   },

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -93,6 +93,7 @@ export const STATIC_URLS: SitemapUrl[] = [
 
   // New AI Blog Posts (0.5) - recently created
   { loc: '/blog/chatgpt-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
+  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-13' },
   { loc: '/blog/ai-resume-writing-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/claude-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-17' },
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },


### PR DESCRIPTION
## Summary
- Adds the live /blog/ai-resume-prompts-hub page with comparison table, reviewed-date wording, FAQPage JSON-LD, internal links, and outbound provider references.
- Registers the hub in App routing, blog metadata, and manual sitemap data with 2026-05-13 freshness metadata.
- Keeps the four old AI prompt pages live with no redirects, no redirectTo fields, and no sitemap removals for PR A.

## Test Plan
- [x] npx tsc --noEmit -p tsconfig.json
- [x] npx eslint src/components/blog/AIResumePromptsHub.tsx
- [x] npx vitest run --reporter=dot
- [x] npm run build

## Notes
- Branch created from main and targets main, independent of PR #523.
- PR B should wait until this hub is deployed and confirmed indexable.