### PR TITLE
🎨 Palette: Improve accessibility of experience list controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2024-05-24 - Inline List Control Accessibility
+**Learning:** Inline removal/addition controls inside dynamically mapped lists (e.g., experience bullets) often lose default browser focus outlines due to custom Tailwind padding/colors, making keyboard navigation difficult.
+**Action:** Explicitly add `focus-visible:outline-none focus-visible:ring-2` (using `ring-red-500` for destructive, `ring-accent` for additive) with `ring-offset-1` to ensure consistent keyboard focus visibility. Add `type="button"` to prevent accidental form submission and `aria-label` for screen readers on icon-only or generic symbol buttons (like `✕`).

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -94,8 +94,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-medium">Experience #{index + 1}</h3>
         <button
+          type="button"
           onClick={() => onDelete(index)}
-          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
           aria-label="Delete experience entry"
           title="Delete this experience"
         >
@@ -178,8 +179,10 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                             />
                           </div>
                           <button
+                            type="button"
                             onClick={() => handleDescRemove(descIndex)}
-                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2"
+                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
+                            aria-label="Remove description point"
                             title="Remove description point"
                           >
                             ✕
@@ -193,8 +196,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
             )}
           </div>
           <button
+            type="button"
             onClick={handleDescAdd}
-            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2"
+            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             + Add Description Point
           </button>


### PR DESCRIPTION
**What**: Added proper ARIA labels, `type="button"`, and explicit keyboard focus rings (`focus-visible`) to the add/remove controls within experience items.
**Why**: To ensure that users navigating via keyboard can clearly see which control has focus, and to prevent accidental form submissions or screen reader ambiguity.
**Before/After**: Visually similar, but adding a visible ring on keyboard focus.
**Accessibility**: Improved screen reader context for the "Remove description point" button and added focus outlines for keyboard navigation.

---
*PR created automatically by Jules for task [3959323074322675156](https://jules.google.com/task/3959323074322675156) started by @aafre*