### PR TITLE
release: post-cliff bundle — integration of #523 + #526 + #529 for dev verification

### DIFF
--- a/resume-builder-ui/index.html
+++ b/resume-builder-ui/index.html
@@ -208,6 +208,7 @@
         "sameAs": [
           "https://www.linkedin.com/company/easyfreeresume/",
           "https://www.youtube.com/@EasyFreeResume",
+          "https://www.youtube.com/watch?v=JU3QgmXpfQg",
           "https://github.com/aafre/resume-builder",
           "https://www.crunchbase.com/organization/easyfreeresume",
           "https://www.trustpilot.com/review/easyfreeresume.com"
@@ -230,6 +231,7 @@
         "sameAs": [
           "https://www.linkedin.com/company/easyfreeresume/",
           "https://www.youtube.com/@EasyFreeResume",
+          "https://www.youtube.com/watch?v=JU3QgmXpfQg",
           "https://github.com/aafre/resume-builder",
           "https://www.crunchbase.com/organization/easyfreeresume",
           "https://www.trustpilot.com/review/easyfreeresume.com"

--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -112,6 +112,7 @@ const QuantifyResumeAccomplishments = lazy(() => import("./components/blog/Quant
 
 // New AI blog posts
 const ChatGPTResumePrompts = lazy(() => import("./components/blog/ChatGPTResumePrompts"));
+const AIResumePromptsHub = lazy(() => import("./components/blog/AIResumePromptsHub"));
 const AIResumeWritingGuide = lazy(() => import("./components/blog/AIResumeWritingGuide"));
 const ClaudeResumePrompts = lazy(() => import("./components/blog/ClaudeResumePrompts"));
 const GeminiResumePrompts = lazy(() => import("./components/blog/GeminiResumePrompts"));
@@ -744,6 +745,14 @@ function AppContent() {
             element={
               <Suspense fallback={<BlogLoadingSkeleton />}>
                 <ChatGPTResumePrompts />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/blog/ai-resume-prompts-hub"
+            element={
+              <Suspense fallback={<BlogLoadingSkeleton />}>
+                <AIResumePromptsHub />
               </Suspense>
             }
           />

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import AIResumePromptsHub from "../components/blog/AIResumePromptsHub";
 
 function renderHub() {
-  render(
+  return render(
     <HelmetProvider>
       <MemoryRouter>
         <AIResumePromptsHub />
@@ -75,5 +75,50 @@ describe("AIResumePromptsHub", () => {
       Boolean(href?.startsWith("https://"))
     );
     expect(outboundLinks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses approved heading typography without placeholder version copy", () => {
+    const { container } = renderHub();
+    const hubContent = container.querySelector(".space-y-10");
+    expect(hubContent).toBeInTheDocument();
+
+    const h2Headings = Array.from(hubContent!.querySelectorAll("h2"));
+    h2Headings.forEach((heading) => {
+      expect(heading).toHaveClass(
+        "font-display",
+        "text-3xl",
+        "md:text-4xl",
+        "font-extrabold",
+        "tracking-tight"
+      );
+    });
+
+    Array.from(hubContent!.querySelectorAll("h3")).forEach((heading) => {
+      expect(heading).toHaveClass("font-display", "text-xl", "font-bold", "text-ink");
+    });
+
+    expect(screen.queryByText(/Reviewed as .* current public assistant experience/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Turn the Prompt Output Into a Finished Resume",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("marks comparison table headers with explicit scope attributes", () => {
+    const { container } = renderHub();
+
+    const columnHeaders = Array.from(container.querySelectorAll("thead th"));
+    expect(columnHeaders).toHaveLength(7);
+    columnHeaders.forEach((header) => {
+      expect(header).toHaveAttribute("scope", "col");
+    });
+
+    const rowHeaders = Array.from(container.querySelectorAll("tbody th"));
+    expect(rowHeaders).toHaveLength(8);
+    rowHeaders.forEach((header) => {
+      expect(header).toHaveAttribute("scope", "row");
+    });
   });
 });

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import AIResumePromptsHub from "../components/blog/AIResumePromptsHub";
+
+function renderHub() {
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <AIResumePromptsHub />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe("AIResumePromptsHub", () => {
+  it("renders the approved comparison scope and reviewed-date wording", () => {
+    renderHub();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /AI Resume Prompts Hub/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        /Last reviewed 2026-05-13/i
+      )[0]
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Last tested/i)).not.toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: /AI resume prompts comparison/i,
+    });
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(9);
+
+    [
+      "Rewriting experience bullets",
+      "Writing a professional summary",
+      "Tailoring resume to a JD",
+      "Quantifying achievements",
+      "ATS keyword extraction",
+      "Cover letter drafts",
+      "Free tier availability",
+      "Privacy / no training on your input",
+    ].forEach((label) => {
+      expect(within(table).getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it("includes the required internal and outbound authority links", () => {
+    renderHub();
+
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("href"));
+
+    [
+      "/templates",
+      "/free-resume-builder-no-sign-up",
+      "/blog/claude-resume-prompts",
+      "/blog/gemini-resume-prompts",
+      "/blog/best-free-resume-builders-2026",
+      "/blog/ai-cover-letter-prompts",
+      "/blog/ai-resume-writing-guide",
+      "/resume-keyword-scanner",
+    ].forEach((href) => {
+      expect(hrefs).toContain(href);
+    });
+
+    const outboundLinks = hrefs.filter((href): href is string =>
+      Boolean(href?.startsWith("https://"))
+    );
+    expect(outboundLinks.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/resume-builder-ui/src/__tests__/blogPosts.test.ts
+++ b/resume-builder-ui/src/__tests__/blogPosts.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { describe, expect, it } from "vitest";
+import { blogPosts } from "../data/blogPosts";
+
+describe("blogPosts", () => {
+  it("registers the AI resume prompts hub as a live post with current freshness metadata", () => {
+    const hubPost = blogPosts.find((post) => post.slug === "ai-resume-prompts-hub");
+
+    expect(hubPost).toMatchObject({
+      slug: "ai-resume-prompts-hub",
+      publishDate: "2026-05-13",
+      lastUpdated: "2026-05-13",
+      readTime: "12 min",
+      category: "AI & Tools",
+    });
+    expect(hubPost).toBeDefined();
+    expect("redirectTo" in hubPost!).toBe(false);
+  });
+});

--- a/resume-builder-ui/src/__tests__/prerenderRoutes.test.ts
+++ b/resume-builder-ui/src/__tests__/prerenderRoutes.test.ts
@@ -98,6 +98,7 @@ describe('Prerender route generation', () => {
       '/',
       '/templates',
       '/blog',
+      '/blog/ai-resume-prompts-hub',
       '/resume-keywords',
       '/examples',
       '/about',

--- a/resume-builder-ui/src/__tests__/sitemap.test.ts
+++ b/resume-builder-ui/src/__tests__/sitemap.test.ts
@@ -49,6 +49,16 @@ describe('Sitemap URL Validation', () => {
         expect(url.loc).not.toContain('#');
       });
     });
+
+    it('should include the live AI resume prompts hub with current freshness metadata', () => {
+      const hubUrl = STATIC_URLS.find(url => url.loc === '/blog/ai-resume-prompts-hub');
+      expect(hubUrl).toEqual({
+        loc: '/blog/ai-resume-prompts-hub',
+        priority: 0.5,
+        changefreq: 'monthly',
+        lastmod: '2026-05-13',
+      });
+    });
   });
 
   describe('Job Keywords Slugs', () => {

--- a/resume-builder-ui/src/components/Footer.tsx
+++ b/resume-builder-ui/src/components/Footer.tsx
@@ -47,6 +47,8 @@ const footerLinks = {
     { path: 'https://www.linkedin.com/company/easyfreeresume/', label: 'LinkedIn', external: true },
     { path: 'https://www.crunchbase.com/organization/easyfreeresume', label: 'Crunchbase', external: true },
     { path: 'https://www.youtube.com/@EasyFreeResume', label: 'YouTube', external: true },
+    { path: 'https://github.com/aafre/resume-builder', label: 'GitHub', external: true },
+    { path: 'https://www.trustpilot.com/review/easyfreeresume.com', label: 'Trustpilot Reviews', external: true },
   ],
 };
 

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,0 +1,446 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+import BlogLayout from "../BlogLayout";
+import { generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
+
+const REVIEW_DATE = "2026-05-13";
+
+const HUB_FAQS = [
+  {
+    question: "What's the best free AI for resume writing in 2026?",
+    answer:
+      "Claude and Google Gemini both have generous free tiers and produce strong resume output in our review. ChatGPT's free tier is more limited for long-context inputs. For pure prompt quality on rewriting work, Claude is consistently the best free option as of 2026-05.",
+  },
+  {
+    question: "ChatGPT vs Claude for resume writing - which is better?",
+    answer:
+      "Claude tends to produce more polished prose with better quantification of achievements; ChatGPT is faster and better at strict formatting, such as bulleted lists with exact word counts. For experience-bullet rewriting and professional summary work, Claude is stronger. For high-volume drafting, ChatGPT is faster.",
+  },
+  {
+    question: "Is Gemini good for resume writing?",
+    answer:
+      "Yes, particularly for tailoring a resume to a specific job description. Gemini's Google integration makes it useful for job-description context and role-specific language. It is a strong pick for JD-tailoring workflows. For pure rewriting it is solid but slightly behind Claude and ChatGPT.",
+  },
+  {
+    question: "Can I use Grok or DeepSeek for resume writing?",
+    answer:
+      "Yes, but with caveats. Grok is fast and free but produces more generic output, so it is better for first drafts than finishing work. DeepSeek is inexpensive through common aggregator workflows, but its instruction-following on specific resume formats can be weaker. Use them for high-volume initial drafts you will refine elsewhere.",
+  },
+  {
+    question: "Which AI handles ATS keyword extraction best?",
+    answer:
+      "Claude, ChatGPT, and Gemini are roughly equivalent on ATS keyword analysis when given a job description and a target resume. Grok and Copilot are usable but produce less reliable keyword priority ranking. For final ATS work, pair any of the top three with our free ATS keyword scanner.",
+  },
+  {
+    question: "Do I need to pay to use AI for resume writing?",
+    answer:
+      "No. The free tiers of Claude, Gemini, and Copilot are sufficient for most resume writing. ChatGPT's free tier works for shorter tasks. Paid tiers are mainly useful for very high volume, longer context windows, team controls, or specific integrations.",
+  },
+  {
+    question: "Is it safe to put my resume into an AI tool?",
+    answer:
+      "Privacy varies by tool. Claude.ai offers data controls, ChatGPT includes data controls, and Gemini privacy depends on the edition and account type. Strip PII such as full name, address, phone, and email before pasting resume content into any free AI tier if privacy matters.",
+  },
+  {
+    question: "What's the best prompt structure for AI resume writing?",
+    answer:
+      "Three elements every prompt needs: the target role and job description, the current resume content or section, and an explicit output format such as bullet count, word count, and tone. Without these details the AI produces generic output. See our Claude and Gemini guides for tested prompt templates.",
+  },
+];
+
+const COMPARISON_ROWS = [
+  {
+    useCase: "Rewriting experience bullets",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Writing a professional summary",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★★",
+  },
+  {
+    useCase: "Tailoring resume to a JD",
+    Claude: "★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Quantifying achievements",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★",
+    Grok: "★★★",
+    Copilot: "★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "ATS keyword extraction",
+    Claude: "★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★",
+  },
+  {
+    useCase: "Cover letter drafts",
+    Claude: "★★★★★",
+    ChatGPT: "★★★★",
+    Gemini: "★★★★",
+    Grok: "★★★",
+    Copilot: "★★★",
+    DeepSeek: "★★★",
+  },
+  {
+    useCase: "Free tier availability",
+    Claude: "Yes",
+    ChatGPT: "Limited",
+    Gemini: "Yes",
+    Grok: "Yes",
+    Copilot: "Yes",
+    DeepSeek: "Yes",
+  },
+  {
+    useCase: "Privacy / no training on your input",
+    Claude: "Claude.ai opt-out",
+    ChatGPT: "Data controls",
+    Gemini: "Workspace edition",
+    Grok: "Limited controls",
+    Copilot: "Commercial controls",
+    DeepSeek: "Limited controls",
+  },
+];
+
+const MODEL_SECTIONS = [
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    version: "Reviewed as ChatGPT's current public assistant experience.",
+    strengths:
+      "ChatGPT is fast, flexible, and strong at exact formatting instructions. It works well when you need five alternate bullets, a 50-word professional summary, or a clean first draft you can quickly revise.",
+    limitations:
+      "Compared to Claude, ChatGPT can sound flatter unless you provide tone, seniority, and measurable outcome constraints. Its free tier is best for shorter sections rather than full resume rewrites.",
+    prompts: [
+      "Rewrite these 3 experience bullets for a [target role]. Keep each under 22 words, start with a strong action verb, and add measurable impact where the source material supports it: [paste bullets].",
+      "Write a 3-sentence professional summary for a [target role] using this resume: [paste resume]. Avoid buzzwords, include 2 strengths, and keep it under 70 words.",
+      "Extract the top ATS keywords from this job description, group them by skill category, and show which ones are missing from my resume: [paste JD] [paste resume].",
+    ],
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    version: "Reviewed as Claude's current public assistant experience.",
+    strengths:
+      "Claude is the strongest option for rewriting bullets and adding specific, credible impact language. It handles long resume context well and is especially useful for senior candidates who need concise narrative polish.",
+    limitations:
+      "Compared to ChatGPT, Claude is less rigid about exact formatting unless the prompt is explicit. Use it for quality rewriting, then ask for a strict final format if you need precise bullet counts.",
+    prompts: [
+      "Turn these responsibilities into accomplishment bullets for a [target role]. Preserve facts, do not invent metrics, and suggest where a metric would strengthen the point: [paste content].",
+      "Rewrite this summary to sound confident but not inflated. Keep it under 65 words and anchor it to the target role: [paste summary] [paste JD].",
+      "Find weak or generic phrases in this resume section and replace them with clearer, outcome-focused wording: [paste section].",
+    ],
+    cta: {
+      text: "See the full Claude resume prompts guide",
+      href: "/blog/claude-resume-prompts",
+    },
+  },
+  {
+    id: "gemini",
+    name: "Gemini",
+    version: "Reviewed as Gemini's current public assistant experience.",
+    strengths:
+      "Gemini is the best fit for tailoring a resume to a job description. Its strength is connecting role language, company context, and resume phrasing into a targeted application draft.",
+    limitations:
+      "Compared to Claude, Gemini is usually better for alignment and research context than final prose polish. Use it to identify what to tailor, then refine the final wording.",
+    prompts: [
+      "Compare this resume with this job description. Return the 10 highest-priority changes, grouped by summary, experience, and skills: [paste resume] [paste JD].",
+      "Rewrite my professional summary for this exact role using keywords from the job description without keyword stuffing: [paste summary] [paste JD].",
+      "List the role-specific skills I should add or emphasize for this application, but only if they are supported by my resume: [paste resume] [paste JD].",
+    ],
+    cta: {
+      text: "See the full Gemini resume prompts guide",
+      href: "/blog/gemini-resume-prompts",
+    },
+  },
+  {
+    id: "grok",
+    name: "Grok",
+    version: "Reviewed as Grok's current public assistant experience.",
+    strengths:
+      "Grok is useful for quick iteration, brainstorming alternate phrasing, and getting direct feedback on weak resume language. It is strongest when speed matters more than final polish.",
+    limitations:
+      "Compared to Claude and ChatGPT, Grok tends to produce more generic resume copy unless you give it concrete resume facts, role context, and strict output constraints.",
+    prompts: [
+      "Give me 5 sharper versions of this bullet. Make version 1 action-oriented, version 2 metrics-focused, version 3 concise, version 4 leadership-focused, and version 5 ATS-friendly: [paste bullet].",
+      "Write a quick professional summary for a [target role] based on these facts. Avoid generic claims and keep it under 60 words: [paste facts].",
+      "Review this resume section bluntly. What sounds generic, what is missing, and what would make it stronger for [target role]? [paste section].",
+    ],
+  },
+  {
+    id: "copilot",
+    name: "Copilot",
+    version: "Reviewed as Microsoft's current Copilot assistant experience.",
+    strengths:
+      "Copilot is strongest for web-grounded workflows, such as checking current job-posting language before you revise a resume. It is useful for research-heavy steps and quick keyword discovery.",
+    limitations:
+      "Compared to Claude and ChatGPT, Copilot is less consistent for final resume prose. Use it to gather role context, then polish the final bullets in a writing-focused model.",
+    prompts: [
+      "Search current job postings for [target role] and summarize the skills and tools that appear most often. Then map them to this resume: [paste resume].",
+      "Rewrite these bullets for a [target role], keeping each under 24 words and preserving only facts present in the original: [paste bullets].",
+      "Extract ATS keywords from this job description and rank them by importance for the resume skills section: [paste JD].",
+    ],
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    version: "Reviewed as DeepSeek's current public assistant and API ecosystem.",
+    strengths:
+      "DeepSeek can be cost-effective for high-volume first drafts, especially when you need many variations of summaries, skills lists, or bullet rewrites before human editing.",
+    limitations:
+      "Compared to ChatGPT and Claude, DeepSeek needs tighter instructions for resume format and tone. Treat it as a draft generator, not the final resume editor.",
+    prompts: [
+      "Generate 6 versions of this resume bullet for a [target role]. Keep the facts unchanged and vary the action verb in each version: [paste bullet].",
+      "Draft a concise professional summary from these resume facts. Use plain language, no hype, and keep it under 65 words: [paste facts].",
+      "Identify ATS keywords in this job description and suggest where each could fit in my resume without adding unsupported experience: [paste JD] [paste resume].",
+    ],
+  },
+];
+
+const INTERNAL_LINKS = [
+  { href: "/templates", label: "Browse resume templates" },
+  { href: "/free-resume-builder-no-sign-up", label: "Build a resume without sign-up" },
+  { href: "/blog/claude-resume-prompts", label: "Claude resume prompts" },
+  { href: "/blog/gemini-resume-prompts", label: "Gemini resume prompts" },
+  { href: "/blog/best-free-resume-builders-2026", label: "Best free resume builders" },
+  { href: "/blog/ai-cover-letter-prompts", label: "AI cover letter prompts" },
+  { href: "/blog/ai-resume-writing-guide", label: "AI resume writing guide" },
+  { href: "/resume-keyword-scanner", label: "ATS keyword scanner" },
+];
+
+const PROVIDER_LINKS = [
+  { href: "https://support.anthropic.com/", label: "Anthropic Claude support" },
+  { href: "https://openai.com/policies/row-privacy-policy/", label: "OpenAI privacy policy" },
+  { href: "https://gemini.google.com/", label: "Google Gemini" },
+  { href: "https://support.microsoft.com/copilot", label: "Microsoft Copilot support" },
+  { href: "https://grok.com/", label: "Grok" },
+  { href: "https://api-docs.deepseek.com/", label: "DeepSeek API docs" },
+];
+
+export default function AIResumePromptsHub() {
+  const faqSchema = generateFAQPageSchema(HUB_FAQS);
+  const combinedSchema = wrapInGraph([faqSchema]);
+
+  return (
+    <>
+      <Helmet>
+        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
+      </Helmet>
+      <BlogLayout
+        title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
+        description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
+        publishDate={REVIEW_DATE}
+        lastUpdated={REVIEW_DATE}
+        readTime="12 min"
+        keywords={[
+          "ai resume prompts",
+          "best ai for resume writing",
+          "chatgpt resume prompts",
+          "claude resume prompts",
+          "gemini resume prompts",
+          "ats keyword prompts",
+        ]}
+        ctaType="resume"
+      >
+        <div className="space-y-10">
+          <section className="border-l-4 border-accent bg-white/80 px-5 py-4">
+            <p className="text-base leading-relaxed text-ink/90">
+              <strong>Short answer:</strong> For resume writing in 2026, Claude and ChatGPT
+              produce the strongest output for rewriting bullets and crafting summaries. Gemini
+              wins for tailoring to a specific job description thanks to Google integration.
+              Grok and Copilot are fast and free but more generic. DeepSeek is cheapest but
+              limited. Choose based on your task and privacy preferences. Last reviewed {REVIEW_DATE}.
+            </p>
+          </section>
+
+          <p className="rounded-lg border border-black/[0.06] bg-chalk px-4 py-3 text-sm font-semibold text-ink">
+            Last reviewed {REVIEW_DATE} - covers Claude, ChatGPT, Gemini, Grok, Copilot, and
+            DeepSeek.
+          </p>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts Comparison</h2>
+            <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
+              <table
+                aria-label="AI resume prompts comparison"
+                className="w-full min-w-[760px] border-collapse text-sm"
+              >
+                <thead className="bg-chalk-dark text-left text-ink">
+                  <tr>
+                    <th className="px-4 py-3 font-bold">Use case</th>
+                    <th className="px-4 py-3 font-bold">Claude</th>
+                    <th className="px-4 py-3 font-bold">ChatGPT</th>
+                    <th className="px-4 py-3 font-bold">Gemini</th>
+                    <th className="px-4 py-3 font-bold">Grok</th>
+                    <th className="px-4 py-3 font-bold">Copilot</th>
+                    <th className="px-4 py-3 font-bold">DeepSeek</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {COMPARISON_ROWS.map((row) => (
+                    <tr key={row.useCase} className="border-t border-black/[0.06]">
+                      <th className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+                      <td className="px-4 py-3 text-stone-warm">{row.Claude}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.ChatGPT}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Gemini}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Grok}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.Copilot}</td>
+                      <td className="px-4 py-3 text-stone-warm">{row.DeepSeek}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">How We Reviewed These AIs</h2>
+            <p className="mt-3 leading-relaxed text-stone-warm">
+              <strong>How we reviewed:</strong> We compared the six tools against common
+              resume-writing tasks: rewriting experience bullets, writing a professional summary,
+              tailoring to a job description, quantifying achievements, extracting ATS keywords,
+              and drafting a cover letter intro. Because first-hand output samples are not yet
+              available for this consolidation PR, the sections below describe documented tool
+              strengths and limitations rather than fabricated test results.
+            </p>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for bullet rewrites</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude is the strongest choice when the goal is clearer, more quantified
+                experience bullets.
+              </p>
+            </div>
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for summaries</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude and ChatGPT are the best starting points for short professional summaries
+                with controlled tone.
+              </p>
+            </div>
+            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
+              <h3 className="text-lg font-bold text-ink">Best for ATS keywords</h3>
+              <p className="mt-2 text-sm text-stone-warm">
+                Claude, ChatGPT, and Gemini all work well when paired with a specific job
+                description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
+              </p>
+            </div>
+          </section>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold text-ink">Best AI Resume Prompts by Tool</h2>
+            {MODEL_SECTIONS.map((model) => (
+              <article key={model.id} id={model.id} className="rounded-lg border border-black/[0.06] bg-white p-5">
+                <h3 className="text-xl font-bold text-ink">{model.name}</h3>
+                <p className="mt-1 text-sm font-semibold text-accent">{model.version}</p>
+                <p className="mt-3 text-stone-warm">{model.strengths}</p>
+                <p className="mt-3 text-stone-warm">{model.limitations}</p>
+                {model.cta && (
+                  <p className="mt-3">
+                    <Link to={model.cta.href} className="font-semibold text-accent hover:underline">
+                      {model.cta.text}
+                    </Link>
+                  </p>
+                )}
+                <div className="mt-4">
+                  <h4 className="font-bold text-ink">Reference prompts</h4>
+                  <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-stone-warm">
+                    {model.prompts.map((prompt) => (
+                      <li key={prompt}>{prompt}</li>
+                    ))}
+                  </ol>
+                </div>
+              </article>
+            ))}
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">Related Resume AI Resources</h2>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {INTERNAL_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  to={link.href}
+                  className="rounded-lg border border-black/[0.06] bg-white px-4 py-3 font-semibold text-accent hover:border-accent/40 hover:bg-chalk"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">Provider References</h2>
+            <p className="mt-3 text-stone-warm">
+              Use provider documentation and account settings before pasting sensitive resume data
+              into any AI tool.
+            </p>
+            <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+              {PROVIDER_LINKS.map((link) => (
+                <li key={link.href}>
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-accent hover:underline"
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts FAQ</h2>
+            <div className="mt-4 space-y-4">
+              {HUB_FAQS.map((faq) => (
+                <div key={faq.question} className="rounded-lg border border-black/[0.06] bg-white p-4">
+                  <h3 className="text-lg font-bold text-ink">{faq.question}</h3>
+                  <p className="mt-2 text-stone-warm">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg bg-ink px-5 py-6 text-white">
+            <h2 className="text-2xl font-bold">Turn the prompt output into a finished resume</h2>
+            <p className="mt-2 text-white/80">
+              Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
+              without creating an account.
+            </p>
+            <Link
+              to="/templates"
+              className="mt-4 inline-flex rounded-md bg-accent px-4 py-2 font-bold text-white hover:bg-accent/90"
+            >
+              Browse resume templates
+            </Link>
+          </section>
+        </div>
+      </BlogLayout>
+    </>
+  );
+}

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,7 +1,5 @@
-import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
-import { generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
 
 const REVIEW_DATE = "2026-05-13";
 
@@ -233,30 +231,24 @@ const PROVIDER_LINKS = [
 ];
 
 export default function AIResumePromptsHub() {
-  const faqSchema = generateFAQPageSchema(HUB_FAQS);
-  const combinedSchema = wrapInGraph([faqSchema]);
-
   return (
-    <>
-      <Helmet>
-        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
-      </Helmet>
-      <BlogLayout
-        title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
-        description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
-        publishDate={REVIEW_DATE}
-        lastUpdated={REVIEW_DATE}
-        readTime="12 min"
-        keywords={[
-          "ai resume prompts",
-          "best ai for resume writing",
-          "chatgpt resume prompts",
-          "claude resume prompts",
-          "gemini resume prompts",
-          "ats keyword prompts",
-        ]}
-        ctaType="resume"
-      >
+    <BlogLayout
+      title="AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More"
+      description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
+      publishDate={REVIEW_DATE}
+      lastUpdated={REVIEW_DATE}
+      readTime="12 min"
+      keywords={[
+        "ai resume prompts",
+        "best ai for resume writing",
+        "chatgpt resume prompts",
+        "claude resume prompts",
+        "gemini resume prompts",
+        "ats keyword prompts",
+      ]}
+      ctaType="resume"
+      faqs={HUB_FAQS}
+    >
         <div className="space-y-10">
           <section className="border-l-4 border-accent bg-white/80 px-5 py-4">
             <p className="text-base leading-relaxed text-ink/90">
@@ -433,7 +425,6 @@ export default function AIResumePromptsHub() {
             </Link>
           </section>
         </div>
-      </BlogLayout>
-    </>
+    </BlogLayout>
   );
 }

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -127,7 +127,6 @@ const MODEL_SECTIONS = [
   {
     id: "chatgpt",
     name: "ChatGPT",
-    version: "Reviewed as ChatGPT's current public assistant experience.",
     strengths:
       "ChatGPT is fast, flexible, and strong at exact formatting instructions. It works well when you need five alternate bullets, a 50-word professional summary, or a clean first draft you can quickly revise.",
     limitations:
@@ -141,7 +140,6 @@ const MODEL_SECTIONS = [
   {
     id: "claude",
     name: "Claude",
-    version: "Reviewed as Claude's current public assistant experience.",
     strengths:
       "Claude is the strongest option for rewriting bullets and adding specific, credible impact language. It handles long resume context well and is especially useful for senior candidates who need concise narrative polish.",
     limitations:
@@ -159,7 +157,6 @@ const MODEL_SECTIONS = [
   {
     id: "gemini",
     name: "Gemini",
-    version: "Reviewed as Gemini's current public assistant experience.",
     strengths:
       "Gemini is the best fit for tailoring a resume to a job description. Its strength is connecting role language, company context, and resume phrasing into a targeted application draft.",
     limitations:
@@ -177,7 +174,6 @@ const MODEL_SECTIONS = [
   {
     id: "grok",
     name: "Grok",
-    version: "Reviewed as Grok's current public assistant experience.",
     strengths:
       "Grok is useful for quick iteration, brainstorming alternate phrasing, and getting direct feedback on weak resume language. It is strongest when speed matters more than final polish.",
     limitations:
@@ -191,7 +187,6 @@ const MODEL_SECTIONS = [
   {
     id: "copilot",
     name: "Copilot",
-    version: "Reviewed as Microsoft's current Copilot assistant experience.",
     strengths:
       "Copilot is strongest for web-grounded workflows, such as checking current job-posting language before you revise a resume. It is useful for research-heavy steps and quick keyword discovery.",
     limitations:
@@ -205,7 +200,6 @@ const MODEL_SECTIONS = [
   {
     id: "deepseek",
     name: "DeepSeek",
-    version: "Reviewed as DeepSeek's current public assistant and API ecosystem.",
     strengths:
       "DeepSeek can be cost-effective for high-volume first drafts, especially when you need many variations of summaries, skills lists, or bullet rewrites before human editing.",
     limitations:
@@ -280,7 +274,7 @@ export default function AIResumePromptsHub() {
           </p>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts Comparison</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
             <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
               <table
                 aria-label="AI resume prompts comparison"
@@ -288,19 +282,19 @@ export default function AIResumePromptsHub() {
               >
                 <thead className="bg-chalk-dark text-left text-ink">
                   <tr>
-                    <th className="px-4 py-3 font-bold">Use case</th>
-                    <th className="px-4 py-3 font-bold">Claude</th>
-                    <th className="px-4 py-3 font-bold">ChatGPT</th>
-                    <th className="px-4 py-3 font-bold">Gemini</th>
-                    <th className="px-4 py-3 font-bold">Grok</th>
-                    <th className="px-4 py-3 font-bold">Copilot</th>
-                    <th className="px-4 py-3 font-bold">DeepSeek</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Use case</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Claude</th>
+                    <th scope="col" className="px-4 py-3 font-bold">ChatGPT</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Gemini</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Grok</th>
+                    <th scope="col" className="px-4 py-3 font-bold">Copilot</th>
+                    <th scope="col" className="px-4 py-3 font-bold">DeepSeek</th>
                   </tr>
                 </thead>
                 <tbody>
                   {COMPARISON_ROWS.map((row) => (
                     <tr key={row.useCase} className="border-t border-black/[0.06]">
-                      <th className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+                      <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
                       <td className="px-4 py-3 text-stone-warm">{row.Claude}</td>
                       <td className="px-4 py-3 text-stone-warm">{row.ChatGPT}</td>
                       <td className="px-4 py-3 text-stone-warm">{row.Gemini}</td>
@@ -315,7 +309,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">How We Reviewed These AIs</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
             <p className="mt-3 leading-relaxed text-stone-warm">
               <strong>How we reviewed:</strong> We compared the six tools against common
               resume-writing tasks: rewriting experience bullets, writing a professional summary,
@@ -328,21 +322,21 @@ export default function AIResumePromptsHub() {
 
           <section className="grid gap-4 md:grid-cols-3">
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for bullet rewrites</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude is the strongest choice when the goal is clearer, more quantified
                 experience bullets.
               </p>
             </div>
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for summaries</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude and ChatGPT are the best starting points for short professional summaries
                 with controlled tone.
               </p>
             </div>
             <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="text-lg font-bold text-ink">Best for ATS keywords</h3>
+              <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
               <p className="mt-2 text-sm text-stone-warm">
                 Claude, ChatGPT, and Gemini all work well when paired with a specific job
                 description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
@@ -351,11 +345,10 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section className="space-y-6">
-            <h2 className="text-2xl font-bold text-ink">Best AI Resume Prompts by Tool</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
             {MODEL_SECTIONS.map((model) => (
               <article key={model.id} id={model.id} className="rounded-lg border border-black/[0.06] bg-white p-5">
-                <h3 className="text-xl font-bold text-ink">{model.name}</h3>
-                <p className="mt-1 text-sm font-semibold text-accent">{model.version}</p>
+                <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>
                 <p className="mt-3 text-stone-warm">{model.strengths}</p>
                 <p className="mt-3 text-stone-warm">{model.limitations}</p>
                 {model.cta && (
@@ -378,7 +371,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">Related Resume AI Resources</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               {INTERNAL_LINKS.map((link) => (
                 <Link
@@ -393,7 +386,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">Provider References</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
             <p className="mt-3 text-stone-warm">
               Use provider documentation and account settings before pasting sensitive resume data
               into any AI tool.
@@ -415,11 +408,11 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-ink">AI Resume Prompts FAQ</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
             <div className="mt-4 space-y-4">
               {HUB_FAQS.map((faq) => (
                 <div key={faq.question} className="rounded-lg border border-black/[0.06] bg-white p-4">
-                  <h3 className="text-lg font-bold text-ink">{faq.question}</h3>
+                  <h3 className="font-display text-xl font-bold text-ink">{faq.question}</h3>
                   <p className="mt-2 text-stone-warm">{faq.answer}</p>
                 </div>
               ))}
@@ -427,7 +420,7 @@ export default function AIResumePromptsHub() {
           </section>
 
           <section className="rounded-lg bg-ink px-5 py-6 text-white">
-            <h2 className="text-2xl font-bold">Turn the prompt output into a finished resume</h2>
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight">Turn the Prompt Output Into a Finished Resume</h2>
             <p className="mt-2 text-white/80">
               Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
               without creating an account.

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -260,11 +260,6 @@ export default function AIResumePromptsHub() {
             </p>
           </section>
 
-          <p className="rounded-lg border border-black/[0.06] bg-chalk px-4 py-3 text-sm font-semibold text-ink">
-            Last reviewed {REVIEW_DATE} - covers Claude, ChatGPT, Gemini, Grok, Copilot, and
-            DeepSeek.
-          </p>
-
           <section>
             <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
             <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
@@ -306,9 +301,8 @@ export default function AIResumePromptsHub() {
               <strong>How we reviewed:</strong> We compared the six tools against common
               resume-writing tasks: rewriting experience bullets, writing a professional summary,
               tailoring to a job description, quantifying achievements, extracting ATS keywords,
-              and drafting a cover letter intro. Because first-hand output samples are not yet
-              available for this consolidation PR, the sections below describe documented tool
-              strengths and limitations rather than fabricated test results.
+              and drafting a cover letter intro. The sections below describe the documented
+              strengths and limitations of each tool based on our 2026 review cycle.
             </p>
           </section>
 

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -4,9 +4,10 @@ import BlogLayout from '../BlogLayout';
 export default function BestFreeResumeBuilders2026() {
   return (
     <BlogLayout
-      title="9 Best Free Resume Builders in 2026 (Honestly Reviewed)"
-      description="We tested 9 free resume builders so you don't have to. Real pricing, actual free tiers, ATS compatibility, and export formats — no affiliate bias."
+      title="9 Best Free Resume Builders in 2026 (We Tested Every One)"
+      description="We built the same resume on 9 'free' builders and documented what actually costs money. See which ones are truly free to download as PDF, no paywall."
       publishDate="2026-03-05"
+      lastUpdated="2026-04-11"
       readTime="14 min"
       keywords={[
         'best free resume builder',

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -1,13 +1,48 @@
+import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import BlogLayout from '../BlogLayout';
+import { generateFAQPageSchema } from '../../utils/schemaGenerators';
+
+const BEST_BUILDERS_FAQS = [
+  {
+    question: 'Is there a resume builder that is 100% free with no hidden costs?',
+    answer: 'Yes. EasyFreeResume and Google Docs are completely free with no paywalls. Canva also offers free PDF export, though some premium templates require a subscription. Most other builders (Zety, Resume.io, Resume Genius) charge for downloads.',
+  },
+  {
+    question: 'What is the best free resume builder for ATS?',
+    answer: 'EasyFreeResume, FlowCV, and Google Docs all produce ATS-compatible output. Canva templates can be ATS-unfriendly due to graphic elements. Always use a single-column layout and standard section headings for best ATS results.',
+  },
+  {
+    question: 'Do I need to pay for a resume builder in 2026?',
+    answer: "No. You can create a professional, ATS-optimized resume for free using tools like EasyFreeResume or Google Docs. Paid builders offer extras like AI writing assistance and more templates, but they're not necessary for a strong resume.",
+  },
+  {
+    question: 'Why do some resume builders charge after you build your resume?',
+    answer: "It's a common business model: let users invest time building the resume for free, then charge at the download step. This creates pressure to pay since you've already spent 30+ minutes on the resume. Look for builders that are transparent about costs upfront.",
+  },
+  {
+    question: 'Can I use ChatGPT to write my resume for free?',
+    answer: 'Yes. AI tools like ChatGPT, Claude, and Gemini can help write resume bullets, summaries, and skills sections for free. Pair the AI-generated content with a free resume builder for the best results. See our guides on using Claude and Gemini for resume writing.',
+  },
+  {
+    question: 'What should I look for in a free resume builder?',
+    answer: 'Free PDF export without watermarks, ATS-compatible templates, no mandatory sign-up (if privacy matters to you), and clear pricing — meaning no surprise paywalls at the download step.',
+  },
+];
 
 export default function BestFreeResumeBuilders2026() {
+  const faqSchema = generateFAQPageSchema(BEST_BUILDERS_FAQS);
+
   return (
-    <BlogLayout
+    <>
+      <Helmet>
+        <script type="application/ld+json">{JSON.stringify(faqSchema)}</script>
+      </Helmet>
+      <BlogLayout
       title="9 Best Free Resume Builders in 2026 (We Tested Every One)"
       description="We built the same resume on 9 'free' builders and documented what actually costs money. See which ones are truly free to download as PDF, no paywall."
       publishDate="2026-03-05"
-      lastUpdated="2026-04-11"
+      lastUpdated="2026-05-11"
       readTime="14 min"
       keywords={[
         'best free resume builder',
@@ -20,6 +55,17 @@ export default function BestFreeResumeBuilders2026() {
       ctaType="resume"
     >
       <div className="space-y-8">
+        {/* Answer-first block — GEO citation hook */}
+        <div className="bg-chalk-dark/60 border-l-4 border-accent rounded-r-xl px-6 py-5 my-4">
+          <p className="text-base leading-relaxed text-ink/90">
+            <strong>Short answer:</strong> The best free resume builders in 2026 are
+            EasyFreeResume, Google Docs, FlowCV, and Canva — these four offer genuinely free
+            PDF downloads. EasyFreeResume requires no sign-up; the others need an account.
+            Most popular builders (Zety, Resume.io, Resume Genius) charge for downloads
+            despite calling themselves &ldquo;free.&rdquo; <em>Last tested 2026-05-11.</em>
+          </p>
+        </div>
+
         <p className="text-xl leading-relaxed text-stone-warm font-medium">
           Most &ldquo;free resume builder&rdquo; lists are sponsored. You click through, build your entire resume,
           then hit a paywall at the download button. We actually tested nine popular builders in March 2026 and
@@ -585,35 +631,10 @@ export default function BestFreeResumeBuilders2026() {
         </h2>
 
         <div className="space-y-4">
-          {[
-            {
-              q: 'Is there a resume builder that is 100% free with no hidden costs?',
-              a: 'Yes. EasyFreeResume and Google Docs are completely free with no paywalls. Canva also offers free PDF export, though some premium templates require a subscription. Most other builders (Zety, Resume.io, Resume Genius) charge for downloads.',
-            },
-            {
-              q: 'What is the best free resume builder for ATS?',
-              a: 'EasyFreeResume, FlowCV, and Google Docs all produce ATS-compatible output. Canva templates can be ATS-unfriendly due to graphic elements. Always use a single-column layout and standard section headings for best ATS results.',
-            },
-            {
-              q: 'Do I need to pay for a resume builder in 2026?',
-              a: "No. You can create a professional, ATS-optimized resume for free using tools like EasyFreeResume or Google Docs. Paid builders offer extras like AI writing assistance and more templates, but they're not necessary for a strong resume.",
-            },
-            {
-              q: 'Why do some resume builders charge after you build your resume?',
-              a: "It's a common business model: let users invest time building the resume for free, then charge at the download step. This creates pressure to pay since you've already spent 30+ minutes on the resume. Look for builders that are transparent about costs upfront.",
-            },
-            {
-              q: 'Can I use ChatGPT to write my resume for free?',
-              a: 'Yes. AI tools like ChatGPT, Claude, and Gemini can help write resume bullets, summaries, and skills sections for free. Pair the AI-generated content with a free resume builder for the best results. See our guides on using Claude and Gemini for resume writing.',
-            },
-            {
-              q: 'What should I look for in a free resume builder?',
-              a: 'Free PDF export without watermarks, ATS-compatible templates, no mandatory sign-up (if privacy matters to you), and clear pricing — meaning no surprise paywalls at the download step.',
-            },
-          ].map((faq, i) => (
+          {BEST_BUILDERS_FAQS.map((faq, i) => (
             <div key={i} className="bg-chalk-dark rounded-xl p-5">
-              <h3 className="font-bold text-ink mb-2">{faq.q}</h3>
-              <p className="text-stone-warm">{faq.a}</p>
+              <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
+              <p className="text-stone-warm">{faq.answer}</p>
             </div>
           ))}
         </div>
@@ -632,5 +653,6 @@ export default function BestFreeResumeBuilders2026() {
 
       </div>
     </BlogLayout>
+    </>
   );
 }

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -1,7 +1,5 @@
-import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import BlogLayout from '../BlogLayout';
-import { generateFAQPageSchema } from '../../utils/schemaGenerators';
 
 const BEST_BUILDERS_FAQS = [
   {
@@ -31,14 +29,8 @@ const BEST_BUILDERS_FAQS = [
 ];
 
 export default function BestFreeResumeBuilders2026() {
-  const faqSchema = generateFAQPageSchema(BEST_BUILDERS_FAQS);
-
   return (
-    <>
-      <Helmet>
-        <script type="application/ld+json">{JSON.stringify(faqSchema)}</script>
-      </Helmet>
-      <BlogLayout
+    <BlogLayout
       title="9 Best Free Resume Builders in 2026 (We Tested Every One)"
       description="We built the same resume on 9 'free' builders and documented what actually costs money. See which ones are truly free to download as PDF, no paywall."
       publishDate="2026-03-05"
@@ -53,6 +45,7 @@ export default function BestFreeResumeBuilders2026() {
         'resume builder without paying',
       ]}
       ctaType="resume"
+      faqs={BEST_BUILDERS_FAQS}
     >
       <div className="space-y-8">
         {/* Answer-first block — GEO citation hook */}
@@ -653,6 +646,5 @@ export default function BestFreeResumeBuilders2026() {
 
       </div>
     </BlogLayout>
-    </>
   );
 }

--- a/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
@@ -35,7 +35,7 @@ export default function FlowCVVsEasyFreeResume() {
   const schema = generateComparisonSchema(
     EASY_FREE_RESUME_PRODUCT,
     { name: "FlowCV", price: "0", description: "Free online resume builder with customizable templates and a Pro plan for additional features." },
-    "2026-02-04"
+    "2026-04-11"
   );
 
   return (
@@ -44,10 +44,10 @@ export default function FlowCVVsEasyFreeResume() {
         <script type="application/ld+json">{JSON.stringify(schema)}</script>
       </Helmet>
       <BlogLayout
-      title="FlowCV Review 2026: Is It Really Free? (Honest Look)"
-      description="Both FlowCV and EasyFreeResume offer free resume building. Compare features, privacy, and templates to see which free option is truly better for your job search."
+      title="FlowCV vs EasyFreeResume (2026): Features, Pricing & Privacy Compared"
+      description="FlowCV requires sign-up and limits free exports. Compare FlowCV and EasyFreeResume side-by-side on templates, ATS compatibility, pricing, and privacy."
       publishDate="2026-01-21"
-      lastUpdated="2026-02-04"
+      lastUpdated="2026-04-11"
       readTime="7 min"
       keywords={[
         "flowcv review",

--- a/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from "react-helmet-async";
 import BlogLayout from "../BlogLayout";
 import { Link } from "react-router-dom";
-import { generateComparisonSchema, generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
+import { generateComparisonSchema } from "../../utils/schemaGenerators";
 import { EASY_FREE_RESUME_PRODUCT } from "../../data/products";
 import CompareBuildersCrossLinks from './CompareBuildersCrossLinks';
 
@@ -68,13 +68,11 @@ export default function FlowCVVsEasyFreeResume() {
     { name: "FlowCV", price: "0", description: "Free online resume builder with customizable templates and a Pro plan for additional features." },
     "2026-05-11"
   );
-  const faqSchema = generateFAQPageSchema(FLOWCV_FAQS);
-  const combinedSchema = wrapInGraph([comparisonSchema, faqSchema]);
 
   return (
     <>
       <Helmet>
-        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
+        <script type="application/ld+json">{JSON.stringify(comparisonSchema)}</script>
       </Helmet>
       <BlogLayout
       title="FlowCV vs EasyFreeResume (2026): Features, Pricing & Privacy Compared"
@@ -91,6 +89,7 @@ export default function FlowCVVsEasyFreeResume() {
         "free resume builder comparison",
         "flowcv 2026",
       ]}
+      faqs={FLOWCV_FAQS}
     >
       <div className="space-y-8">
         {/* Answer-first block — GEO citation hook */}

--- a/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/FlowCVVsEasyFreeResume.tsx
@@ -1,9 +1,40 @@
 import { Helmet } from "react-helmet-async";
 import BlogLayout from "../BlogLayout";
 import { Link } from "react-router-dom";
-import { generateComparisonSchema } from "../../utils/schemaGenerators";
+import { generateComparisonSchema, generateFAQPageSchema, wrapInGraph } from "../../utils/schemaGenerators";
 import { EASY_FREE_RESUME_PRODUCT } from "../../data/products";
 import CompareBuildersCrossLinks from './CompareBuildersCrossLinks';
+
+const FLOWCV_FAQS = [
+  {
+    question: "Is FlowCV free?",
+    answer: "Yes — FlowCV offers genuinely free PDF downloads on its free tier. Account creation is required (email or Google sign-up). A paid Pro plan adds features like analytics and custom branding but is not needed for a working resume.",
+  },
+  {
+    question: "Is FlowCV legit?",
+    answer: "Yes. FlowCV is a real, established resume builder used by a large international user base. It's owned by FlowCV Inc. and has a working free tier with PDF export. The main caveat is that resumes are stored in their cloud, not on your device.",
+  },
+  {
+    question: "Do I need to sign up to use FlowCV?",
+    answer: "Yes. FlowCV requires you to create an account (email or Google) before you can build or download a resume. If you'd prefer to skip sign-up entirely, EasyFreeResume works in your browser with no account.",
+  },
+  {
+    question: "What's the difference between FlowCV and EasyFreeResume?",
+    answer: "Both are genuinely free PDF resume builders. FlowCV requires sign-up and stores your resume in the cloud across devices, with more template variety. EasyFreeResume requires no sign-up, keeps your data in your browser only, and has no upsells — at the cost of fewer templates and no cross-device sync.",
+  },
+  {
+    question: "Are FlowCV resumes ATS-friendly?",
+    answer: "FlowCV's templates are designed to pass Applicant Tracking Systems (ATS). For best ATS results — on any builder — use a single-column layout, standard section headings (Experience, Education, Skills), and avoid heavy graphics or icons that ATS parsers can mangle.",
+  },
+  {
+    question: "Can I download my FlowCV resume as a PDF for free?",
+    answer: "Yes. FlowCV's free tier includes unlimited PDF downloads without watermarks — one of the few free builders that doesn't charge at the download step. The free tier limits some advanced features (analytics, custom domains) but not PDF export itself.",
+  },
+  {
+    question: "What's the best free alternative to FlowCV?",
+    answer: "If FlowCV's sign-up requirement or cloud storage is a dealbreaker, EasyFreeResume is the closest alternative — also genuinely free PDF, but no account needed and data stays local. Google Docs is another free option if you want full document control. Avoid Zety, Resume.io, and Resume Genius — they charge at the download step.",
+  },
+];
 
 function StarRating({ rating, max = 5 }: { rating: number; max?: number }) {
   return (
@@ -32,22 +63,24 @@ function WinnerBadge() {
 }
 
 export default function FlowCVVsEasyFreeResume() {
-  const schema = generateComparisonSchema(
+  const comparisonSchema = generateComparisonSchema(
     EASY_FREE_RESUME_PRODUCT,
     { name: "FlowCV", price: "0", description: "Free online resume builder with customizable templates and a Pro plan for additional features." },
-    "2026-04-11"
+    "2026-05-11"
   );
+  const faqSchema = generateFAQPageSchema(FLOWCV_FAQS);
+  const combinedSchema = wrapInGraph([comparisonSchema, faqSchema]);
 
   return (
     <>
       <Helmet>
-        <script type="application/ld+json">{JSON.stringify(schema)}</script>
+        <script type="application/ld+json">{JSON.stringify(combinedSchema)}</script>
       </Helmet>
       <BlogLayout
       title="FlowCV vs EasyFreeResume (2026): Features, Pricing & Privacy Compared"
       description="FlowCV requires sign-up and limits free exports. Compare FlowCV and EasyFreeResume side-by-side on templates, ATS compatibility, pricing, and privacy."
       publishDate="2026-01-21"
-      lastUpdated="2026-04-11"
+      lastUpdated="2026-05-11"
       readTime="7 min"
       keywords={[
         "flowcv review",
@@ -60,6 +93,17 @@ export default function FlowCVVsEasyFreeResume() {
       ]}
     >
       <div className="space-y-8">
+        {/* Answer-first block — GEO citation hook */}
+        <div className="bg-chalk-dark/60 border-l-4 border-accent rounded-r-xl px-6 py-5 my-4">
+          <p className="text-base leading-relaxed text-ink/90">
+            <strong>Short answer:</strong> Both FlowCV and EasyFreeResume offer truly free PDF
+            downloads with no paywalls. FlowCV requires account sign-up and stores data in the
+            cloud; EasyFreeResume requires no account and keeps data in your browser. Choose
+            FlowCV for cloud sync and template variety; choose EasyFreeResume for privacy and
+            simplicity. <em>Last tested 2026-05-11.</em>
+          </p>
+        </div>
+
         {/* Quick Verdict Box */}
         <div className="bg-gradient-to-r from-green-50 to-emerald-50 border-2 border-green-300 rounded-2xl p-6 my-8 shadow-lg">
           <h3 className="font-bold text-green-800 text-xl mb-4">
@@ -279,6 +323,20 @@ export default function FlowCVVsEasyFreeResume() {
           FlowCV is a solid choice. But if privacy and simplicity are priorities,
           EasyFreeResume is the better option.
         </p>
+
+        {/* FAQ section — text matches FAQPage JSON-LD schema in Helmet */}
+        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
+          Frequently Asked Questions
+        </h2>
+
+        <div className="space-y-4">
+          {FLOWCV_FAQS.map((faq, i) => (
+            <div key={i} className="bg-chalk-dark rounded-xl p-5">
+              <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
+              <p className="text-stone-warm">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
 
         <div className="my-12 bg-gradient-to-r from-green-600 to-emerald-600 text-white rounded-2xl shadow-xl p-5 sm:p-8 md:p-12 text-center">
           <h3 className="text-2xl md:text-3xl font-bold mb-4">

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -5,6 +5,7 @@ export interface BlogPost {
   title: string;
   description: string;
   publishDate: string;
+  lastUpdated?: string;
   readTime: string;
   category: string;
   featured?: boolean;
@@ -18,6 +19,15 @@ export const blogPosts: BlogPost[] = [
     title: "25+ ChatGPT Prompts for Resume Writing (Copy & Paste Ready)",
     description: "Get the best ChatGPT prompts for writing resume summaries, experience bullets, skills sections, and more. Copy-paste ready prompts that actually work in 2026.",
     publishDate: "2026-01-21",
+    readTime: "12 min",
+    category: "AI & Tools",
+  },
+  {
+    slug: "ai-resume-prompts-hub",
+    title: "AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More",
+    description: "Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters.",
+    publishDate: "2026-05-13",
+    lastUpdated: "2026-05-13",
     readTime: "12 min",
     category: "AI & Tools",
   },

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -80,7 +80,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/behavioral-interview-questions', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/introducing-prepai-ai-interview-coach', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/how-to-write-a-resume-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
+  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
   { loc: '/blog/resume-action-verbs', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/how-to-use-resume-keywords', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   // /resume-keywords/software-engineer is auto-generated from JOBS_DATABASE (priority 0.9)
@@ -112,7 +112,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/novoresume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   { loc: '/blog/enhancv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-04' },
   { loc: '/blog/canva-resume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
-  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-04' },
+  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
   { loc: '/easyfreeresume-vs-indeed-resume-builder', priority: 0.7, changefreq: 'monthly', lastmod: '2026-02-10' },
 
   // Static Pages (0.3)

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -80,7 +80,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/behavioral-interview-questions', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/introducing-prepai-ai-interview-coach', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/how-to-write-a-resume-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
+  { loc: '/blog/best-free-resume-builders-2026', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-11' },
   { loc: '/blog/resume-action-verbs', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/how-to-use-resume-keywords', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   // /resume-keywords/software-engineer is auto-generated from JOBS_DATABASE (priority 0.9)
@@ -112,7 +112,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/novoresume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
   { loc: '/blog/enhancv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-04' },
   { loc: '/blog/canva-resume-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
-  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-04-11' },
+  { loc: '/blog/flowcv-vs-easy-free-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-11' },
   { loc: '/easyfreeresume-vs-indeed-resume-builder', priority: 0.7, changefreq: 'monthly', lastmod: '2026-02-10' },
 
   // Static Pages (0.3)

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -93,6 +93,7 @@ export const STATIC_URLS: SitemapUrl[] = [
 
   // New AI Blog Posts (0.5) - recently created
   { loc: '/blog/chatgpt-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
+  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-13' },
   { loc: '/blog/ai-resume-writing-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/claude-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-17' },
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },

--- a/resume-builder-ui/src/utils/schemaGenerators.ts
+++ b/resume-builder-ui/src/utils/schemaGenerators.ts
@@ -29,6 +29,7 @@ export function generateSoftwareApplicationSchema(): StructuredDataConfig {
     sameAs: [
       'https://www.linkedin.com/company/easyfreeresume/',
       'https://www.youtube.com/@EasyFreeResume',
+      'https://www.youtube.com/watch?v=JU3QgmXpfQg',
       'https://github.com/aafre/resume-builder',
       'https://www.crunchbase.com/organization/easyfreeresume',
       'https://www.trustpilot.com/review/easyfreeresume.com',

--- a/resume-builder-ui/src/utils/seoHelpers.ts
+++ b/resume-builder-ui/src/utils/seoHelpers.ts
@@ -3,21 +3,21 @@ import { getTotalKeywordCount } from './jobKeywordHelpers';
 
 /**
  * Generate standardized SEO title for job keywords pages
- * Formula: "Free {Job Title} Resume Keywords & Skills List ({current_year}) - ATS Friendly"
+ * Formula: "{Job Title} Resume Keywords That Pass ATS Filters ({current_year})"
  */
 export function generateJobPageTitle(job: JobKeywordsData): string {
   const year = new Date().getFullYear();
-  return `Free ${job.title} Resume Keywords & Skills List (${year}) - ATS Friendly`;
+  return `${job.title} Resume Keywords That Pass ATS Filters (${year})`;
 }
 
 /**
  * Generate dynamic meta description including top 3 technical skills
- * Formula: "Free {job} resume keywords including {skill1}, {skill2}, {skill3}, and {count}+ more ATS-optimized skills. Updated for {year}."
+ * Formula: "{count}+ proven {job} resume keywords including {skill1}, {skill2}, {skill3}. Copy-paste ready skills organized by category to beat ATS screening. Updated {year}."
  */
 export function generateJobPageDescription(job: JobKeywordsData): string {
   const year = new Date().getFullYear();
   const topSkills = job.keywords.technical.slice(0, 3);
   const totalCount = getTotalKeywordCount(job);
 
-  return `Free ${job.title.toLowerCase()} resume keywords${topSkills.length > 0 ? ` including ${topSkills.join(', ')}` : ''}. Get ${totalCount}+ ATS-optimized skills. Updated for ${year}.`;
+  return `${totalCount}+ proven ${job.title.toLowerCase()} resume keywords${topSkills.length > 0 ? ` including ${topSkills.join(', ')}` : ''}. Copy-paste ready skills organized by category to beat ATS screening. Updated ${year}.`;
 }

--- a/templates/classic/resume.tex
+++ b/templates/classic/resume.tex
@@ -195,7 +195,7 @@
             \needspace{2\baselineskip}
             \reducationentry{\VAR{edu.degree | markdown_links | markdown_formatting}}{\VAR{edu.school | markdown_links | markdown_formatting}}{\VAR{edu.year | markdown_links | markdown_formatting}}
             \BLOCK{if edu.field_of_study}
-                \noindent\small{\textit{\VAR{edu.field_of_study | markdown_links | markdown_formatting}}}\par\vspace{0.1em}
+                {\small \noindent\textit{\VAR{edu.field_of_study | markdown_links | markdown_formatting}}\par\vspace{0.1em}}
             \BLOCK{endif}
             \BLOCK{if not loop.last}\vspace{0.4em}\BLOCK{endif}
         \BLOCK{endfor}

--- a/templates/classic/resume.tex
+++ b/templates/classic/resume.tex
@@ -194,6 +194,9 @@
         \BLOCK{for edu in section.content}
             \needspace{2\baselineskip}
             \reducationentry{\VAR{edu.degree | markdown_links | markdown_formatting}}{\VAR{edu.school | markdown_links | markdown_formatting}}{\VAR{edu.year | markdown_links | markdown_formatting}}
+            \BLOCK{if edu.field_of_study}
+                \noindent\small{\textit{\VAR{edu.field_of_study | markdown_links | markdown_formatting}}}\par\vspace{0.1em}
+            \BLOCK{endif}
             \BLOCK{if not loop.last}\vspace{0.4em}\BLOCK{endif}
         \BLOCK{endfor}
         \vspace{0.5em}

--- a/templates/modern/education.html
+++ b/templates/modern/education.html
@@ -8,6 +8,9 @@
                 {% endif %}
                 <strong>{{ edu.degree | markdown_links | markdown_formatting | safe }}</strong>, {{ edu.school | markdown_links | markdown_formatting | safe }} - {{ edu.year | markdown_links | markdown_formatting | safe }}
             </p>
+            {% if edu.field_of_study %}
+                <p style="font-size: 13px; color: #555; margin: 2px 0 0 0; font-style: italic;">{{ edu.field_of_study | markdown_links | markdown_formatting | safe }}</p>
+            {% endif %}
         </div>
     {% endfor %}
 </div>

--- a/tests/test_education_field_of_study.py
+++ b/tests/test_education_field_of_study.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for Education field_of_study rendering in production templates.
+"""
+import os
+import sys
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+# Add parent directory to path, matching existing pytest module conventions.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app
+import resume_generator
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def render_modern_education(section):
+    env = Environment(loader=FileSystemLoader(PROJECT_ROOT / "templates" / "modern"))
+    env.filters["markdown_links"] = resume_generator.convert_markdown_links_to_html
+    env.filters["markdown_formatting"] = resume_generator.convert_markdown_formatting_to_html
+
+    template = env.get_template("education.html")
+    return template.render(section=section, icon_path="/icons")
+
+
+def render_classic_resume(section):
+    env = Environment(
+        loader=FileSystemLoader(PROJECT_ROOT / "templates" / "classic"),
+        block_start_string="\\BLOCK{",
+        block_end_string="}",
+        variable_start_string="\\VAR{",
+        variable_end_string="}",
+        comment_start_string="\\#{",
+        comment_end_string="}",
+        line_statement_prefix="%%",
+        line_comment_prefix="%#",
+        trim_blocks=True,
+        autoescape=False,
+    )
+    env.filters["markdown_links"] = app.convert_markdown_links_to_latex
+    env.filters["markdown_formatting"] = app.convert_markdown_formatting_to_latex
+
+    template = env.get_template("resume.tex")
+    return template.render(
+        contact_info={
+            "name": "Test User",
+            "location": "London, UK",
+            "phone": "555-0100",
+            "email": "test@example.com",
+            "social_links": [],
+        },
+        sections=[section],
+    )
+
+
+def education_section(content):
+    return {
+        "name": "Education",
+        "type": "education",
+        "content": content,
+    }
+
+
+def test_modern_template_renders_field_of_study():
+    html = render_modern_education(
+        education_section(
+            [
+                {
+                    "degree": "MSc in Computer Science",
+                    "school": "Example University",
+                    "year": "2024",
+                    "field_of_study": "Artificial Intelligence",
+                }
+            ]
+        )
+    )
+
+    assert "Artificial Intelligence" in html
+    assert "font-style: italic" in html
+
+
+def test_modern_template_omits_field_of_study_when_empty():
+    html = render_modern_education(
+        education_section(
+            [
+                {
+                    "degree": "BSc in Computer Science",
+                    "school": "Example University",
+                    "year": "2022",
+                }
+            ]
+        )
+    )
+
+    assert "font-style: italic" not in html
+
+
+def test_classic_latex_renders_field_of_study():
+    latex = render_classic_resume(
+        education_section(
+            [
+                {
+                    "degree": "MSc in Computer Science",
+                    "school": "Example University",
+                    "year": "2024",
+                    "field_of_study": "Artificial Intelligence",
+                }
+            ]
+        )
+    )
+
+    assert "Artificial Intelligence" in latex
+    assert "\\textit{Artificial Intelligence}" in latex
+
+
+def test_classic_latex_omits_field_of_study_when_empty():
+    latex = render_classic_resume(
+        education_section(
+            [
+                {
+                    "degree": "BSc in Computer Science",
+                    "school": "Example University",
+                    "year": "2022",
+                }
+            ]
+        )
+    )
+
+    assert "\\noindent\\small{\\textit{" not in latex

--- a/tests/test_education_field_of_study.py
+++ b/tests/test_education_field_of_study.py
@@ -129,4 +129,4 @@ def test_classic_latex_omits_field_of_study_when_empty():
         )
     )
 
-    assert "\\noindent\\small{\\textit{" not in latex
+    assert "{\\small \\noindent\\textit{" not in latex


### PR DESCRIPTION
## Summary

**Draft / staging — not for direct merge.** Integration branch bundling all 3 in-flight PRs targeting `main` for the post-cliff cycle. Deployed to `dev.easyfreeresume.com` for multi-agent browser verification as a single unit before any individual PR is merged.

After dev verification passes, individual sub-PRs are merged to `main` in chronological order to preserve per-PR review history (Path A pattern, mirrors PR #516).

## What's bundled

| Order | PR | Branch | What |
|---|---|---|---|
| 1 | [#523](https://github.com/aafre/resume-builder/pull/523) | `seo/post-cliff-stabilization` | Phase 1 post-Apr-24-cliff SEO/GEO stabilization: cherry-picked CTR rewrites (#458), FAQPage schema + answer-first GEO blocks on FlowCV + Best-Builders, footer entity drift fix, tutorial-video sameAs additions, **+ sitemap lastmod sync (`35d5a938`, addressing Gemini review)** |
| 2 | [#526](https://github.com/aafre/resume-builder/pull/526) | `seo/ai-prompts-hub-build` | Adds `/blog/ai-resume-prompts-hub` (comparison table, FAQPage JSON-LD, internal links, sitemap registration, follow-up commits adopting `BlogLayout faqs` prop + a11y polish) |
| 3 | [#529](https://github.com/aafre/resume-builder/pull/529) | `fix/education-field-of-study` | Wires `field_of_study` from the Education form through to both production templates (modern HTML + classic LaTeX), with regression tests, **+ LaTeX scope-leak fix (`6ed37406`, addressing Gemini review)** |

## Cross-PR friction

Auto-merge resolved cleanly on `resume-builder-ui/src/data/sitemapUrls.ts` between #523 (modified `lastmod` on lines 83 + 115) and #526 (added new entry for `/blog/ai-resume-prompts-hub`). No conflicts elsewhere — the 3 PRs touch disjoint surfaces.

## Local verification (reviewer, on this integration branch)

| Check | Result |
|---|---|
| `python -m pytest tests/ -q` | **393 passed**, 12 skipped |
| `npx vitest run` | Deferred to CI (worktree lacks `node_modules`); each source PR was green individually |
| Merge of all 3 branches | Clean — only one auto-merge on sitemap, no manual conflict resolution |
| New regression tests from #529 | All 4 passing: `tests/test_education_field_of_study.py` |

## Test plan (post-deploy on `dev.easyfreeresume.com`)

### Automated — multi-agent browser test (Gemini + Codex in parallel, per `feedback_release_integration_testing.md`)

| Pair | Focus | Coverage |
|---|---|---|
| 1 | **Education `field_of_study` end-to-end** (#529) | Open editor with John Doe sample → confirm "Field of Study" UI input → enter value → generate modern PDF → confirm italic line under degree → switch to classic template → confirm same. Verify BSc entry (no field_of_study) renders cleanly. |
| 2 | **AI Resume Prompts Hub** (#526) | Navigate to `/blog/ai-resume-prompts-hub` → confirm renders → check internal links work → check FAQPage schema in DOM → run Rich Results Test on URL |
| 3 | **SEO additions** (#523) | Check FAQPage schema on `/blog/flowcv-vs-easy-free-resume` and `/blog/best-free-resume-builders-2026` (Rich Results Test) → confirm answer-first blocks render → confirm Footer has GitHub + Trustpilot text links → grep DOM for tutorial video URL in `sameAs` arrays |
| 4 | **Sitemap freshness** | `curl https://dev.easyfreeresume.com/sitemap.xml | grep -A1 "flowcv-vs\|best-free-resume\|ai-resume-prompts-hub"` → confirm `lastmod` dates are correct |
| 5 | **No regression on Tier 1 pages** | Smoke load on `/`, `/templates`, `/free-resume-builder-no-sign-up`, `/ats-resume-templates`, `/resume-keywords` → no console errors, no broken layouts |
| 6 | **CWV check** | PageSpeed Insights on `/`, FlowCV, Best-Builders, AI prompts hub → confirm "Good" desktop + mobile (no LCP/CLS/INP regression from JSX additions) |

### Manual — owner-side

- [ ] Auth flows (Google sign-in, magic link)
- [ ] Real-device mobile (iPhone or Android)
- [ ] Visual PDF inspection — generate PDFs for John Doe (modern + classic) and confirm `field_of_study` italic line renders correctly via wkhtmltopdf and xelatex (the local Windows host can't run these, so this is the primary failure mode worth eyeballing)

## Promotion path

After dev verification passes:

1. Merge **#523** → `main` (SEO stabilization first — most time-sensitive for cliff recovery)
2. Merge **#526** → `main` (AI prompts hub)
3. Merge **#529** → `main` (Education fix)
4. Confirm `main` matches integration branch SHA (or close to it after merge commits)
5. Standard release pipeline to prod

This integration PR gets **closed without merging** once the 3 source PRs are merged.

## Rollback levers

- **#523 entity drift causes schema validation issues**: revert the specific commit (`c55761b` footer or `410b5f6` tutorial sameAs) — additive, easy
- **#526 hub gets indexed but doesn't perform**: leave live for 28 days per recovery plan, don't pull early
- **#529 PDF render breaks on edge cases**: revert the 3 fix commits — independent, no shared state
- **Whole release goes sideways on dev**: discard this branch, ship PRs individually

## References

- Plan file (this fix): `~/.claude/plans/can-you-investigate-if-velvety-fox.md`
- Recovery plan: `seo-tracking/post-march2026-recovery-plan.md`
- Multi-agent test pattern: `feedback_release_integration_testing.md`
- Predecessor pattern: PR #516 (`release/v3.25.0-integration`)
