### PR TITLE
🎨 Palette: Improve DuplicateResumeModal accessibility and interaction

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2024-05-15 - DuplicateResumeModal Accessibility Enhancement
+**Learning:** Custom modals like DuplicateResumeModal often lack basic interactive backdrop close handling, keyboard handlers, ARIA roles, and keyboard navigation outline visibility, which impairs accessibility.
+**Action:** When creating or modifying custom modals, ensure `onClick` handlers for the backdrop correctly ignore inner modal clicks (via `stopPropagation`), handle the `Escape` key, assign `role="dialog"`, use `aria-modal="true"`, link titles via `aria-labelledby`, add `aria-hidden` to decorative items, and add explicit `focus-visible` outline styles to buttons.

--- a/resume-builder-ui/src/components/DuplicateResumeModal.tsx
+++ b/resume-builder-ui/src/components/DuplicateResumeModal.tsx
@@ -24,6 +24,17 @@ export function DuplicateResumeModal({
     }
   }, [resume]);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen && !isDuplicating) {
+        onCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isDuplicating, onCancel]);
+
   if (!isOpen || !resume) return null;
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -34,8 +45,17 @@ export function DuplicateResumeModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={() => !isDuplicating && onCancel()}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-modal-title"
+      >
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">
             <div className="flex-shrink-0">
@@ -44,6 +64,7 @@ export function DuplicateResumeModal({
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
@@ -54,7 +75,7 @@ export function DuplicateResumeModal({
               </svg>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Duplicate Resume</h2>
+              <h2 id="duplicate-modal-title" className="text-xl font-bold text-gray-900">Duplicate Resume</h2>
               <p className="text-sm text-gray-500 mt-1">Create a copy with a new name</p>
             </div>
           </div>
@@ -84,7 +105,7 @@ export function DuplicateResumeModal({
               <button
                 type="submit"
                 disabled={isDuplicating || !newTitle.trim()}
-                className="flex-1 bg-accent hover:bg-accent/90 disabled:bg-accent/80 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+                className="flex-1 bg-accent hover:bg-accent/90 disabled:bg-accent/80 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
               >
                 {isDuplicating ? 'Duplicating...' : 'Duplicate'}
               </button>
@@ -92,7 +113,7 @@ export function DuplicateResumeModal({
                 type="button"
                 onClick={onCancel}
                 disabled={isDuplicating}
-                className="flex-1 bg-gray-200 hover:bg-gray-300 disabled:bg-gray-100 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors"
+                className="flex-1 bg-gray-200 hover:bg-gray-300 disabled:bg-gray-100 text-gray-800 font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500"
               >
                 Cancel
               </button>


### PR DESCRIPTION
**💡 What:** 
Added accessibility and interaction improvements to the `DuplicateResumeModal`. This includes backdrop click to close, Escape key support, ARIA roles, and proper focus ring visibility for buttons.

**🎯 Why:**
The modal previously required users to explicitly click the "Cancel" button to close it, which was not intuitive. It also lacked necessary ARIA attributes for screen readers and did not clearly indicate focus state for keyboard navigation.

**📸 Before/After:**
Visually similar, but buttons now show a distinct outline when focused via keyboard, and the modal can be closed by clicking the backdrop or pressing the Escape key.

**♿ Accessibility:**
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the modal container.
- Linked the modal title `h2` with the `aria-labelledby` ID.
- Added `aria-hidden="true"` to the decorative SVG icon.
- Added `focus-visible:ring-2 focus-visible:ring-offset-2` classes to the "Duplicate" and "Cancel" buttons.
- Added `Escape` key event listener for quick closing.

---
*PR created automatically by Jules for task [13457695637123231205](https://jules.google.com/task/13457695637123231205) started by @aafre*