### PR TITLE
feat(seo): 410 Gone on thin AI prompt pages + hub content rewrite + visual quality pass

### DIFF
--- a/app.py
+++ b/app.py
@@ -1421,6 +1421,34 @@ def redirect_editor():
     return redirect("/templates", code=301)
 
 
+@app.route("/blog/chatgpt-resume-prompts")
+def gone_chatgpt_prompts():
+    if FLASK_ENV == "production" and app.static_folder:
+        return send_from_directory(app.static_folder, "index.html"), 410
+    return '', 410
+
+
+@app.route("/blog/grok-resume-prompts")
+def gone_grok_prompts():
+    if FLASK_ENV == "production" and app.static_folder:
+        return send_from_directory(app.static_folder, "index.html"), 410
+    return '', 410
+
+
+@app.route("/blog/copilot-resume-prompts")
+def gone_copilot_prompts():
+    if FLASK_ENV == "production" and app.static_folder:
+        return send_from_directory(app.static_folder, "index.html"), 410
+    return '', 410
+
+
+@app.route("/blog/deepseek-resume-prompts")
+def gone_deepseek_prompts():
+    if FLASK_ENV == "production" and app.static_folder:
+        return send_from_directory(app.static_folder, "index.html"), 410
+    return '', 410
+
+
 @app.route("/blog/how-to-use-resume-keywords-to-beat-ats")
 def redirect_keywords_beat_ats():
     """Redirect old blog URL to current version"""

--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -111,14 +111,10 @@ const HowToListSkills = lazy(() => import("./components/blog/HowToListSkills"));
 const QuantifyResumeAccomplishments = lazy(() => import("./components/blog/QuantifyResumeAccomplishments"));
 
 // New AI blog posts
-const ChatGPTResumePrompts = lazy(() => import("./components/blog/ChatGPTResumePrompts"));
 const AIResumePromptsHub = lazy(() => import("./components/blog/AIResumePromptsHub"));
 const AIResumeWritingGuide = lazy(() => import("./components/blog/AIResumeWritingGuide"));
 const ClaudeResumePrompts = lazy(() => import("./components/blog/ClaudeResumePrompts"));
 const GeminiResumePrompts = lazy(() => import("./components/blog/GeminiResumePrompts"));
-const GrokResumePrompts = lazy(() => import("./components/blog/GrokResumePrompts"));
-const DeepSeekResumePrompts = lazy(() => import("./components/blog/DeepSeekResumePrompts"));
-const CopilotResumePrompts = lazy(() => import("./components/blog/CopilotResumePrompts"));
 const AICoverLetterPrompts = lazy(() => import("./components/blog/AICoverLetterPrompts"));
 const CareerChangeResumeGuide = lazy(() => import("./components/blog/CareerChangeResumeGuide"));
 const ResumeEmploymentGaps = lazy(() => import("./components/blog/ResumeEmploymentGaps"));
@@ -742,11 +738,7 @@ function AppContent() {
           {/* New AI Blog Posts */}
           <Route
             path="/blog/chatgpt-resume-prompts"
-            element={
-              <Suspense fallback={<BlogLoadingSkeleton />}>
-                <ChatGPTResumePrompts />
-              </Suspense>
-            }
+            element={<Navigate to="/blog/ai-resume-prompts-hub" replace />}
           />
           <Route
             path="/blog/ai-resume-prompts-hub"
@@ -782,27 +774,15 @@ function AppContent() {
           />
           <Route
             path="/blog/grok-resume-prompts"
-            element={
-              <Suspense fallback={<BlogLoadingSkeleton />}>
-                <GrokResumePrompts />
-              </Suspense>
-            }
+            element={<Navigate to="/blog/ai-resume-prompts-hub" replace />}
           />
           <Route
             path="/blog/deepseek-resume-prompts"
-            element={
-              <Suspense fallback={<BlogLoadingSkeleton />}>
-                <DeepSeekResumePrompts />
-              </Suspense>
-            }
+            element={<Navigate to="/blog/ai-resume-prompts-hub" replace />}
           />
           <Route
             path="/blog/copilot-resume-prompts"
-            element={
-              <Suspense fallback={<BlogLoadingSkeleton />}>
-                <CopilotResumePrompts />
-              </Suspense>
-            }
+            element={<Navigate to="/blog/ai-resume-prompts-hub" replace />}
           />
           <Route
             path="/blog/ai-cover-letter-prompts"

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -49,6 +49,12 @@ describe("AIResumePromptsHub", () => {
     ].forEach((label) => {
       expect(within(table).getByText(label)).toBeInTheDocument();
     });
+
+    // 6 rating rows × 6 providers = 36 star-rating cells, each with an
+    // accessible name conveying the value. Text rows render strings, not images.
+    const ratingCells = within(table).getAllByRole("img", { name: /out of 5/i });
+    expect(ratingCells).toHaveLength(36);
+    expect(within(table).queryByText("★★★★★")).not.toBeInTheDocument();
   });
 
   it("includes the required internal and outbound authority links", () => {

--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -26,7 +26,7 @@ describe("AIResumePromptsHub", () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        /Last reviewed 2026-05-13/i
+        /Last reviewed 2026-05-25/i
       )[0]
     ).toBeInTheDocument();
     expect(screen.queryByText(/Last tested/i)).not.toBeInTheDocument();
@@ -113,18 +113,51 @@ describe("AIResumePromptsHub", () => {
   });
 
   it("marks comparison table headers with explicit scope attributes", () => {
-    const { container } = renderHub();
+    renderHub();
 
-    const columnHeaders = Array.from(container.querySelectorAll("thead th"));
+    const table = screen.getByRole("table", {
+      name: /AI resume prompts comparison/i,
+    });
+
+    const columnHeaders = Array.from(table.querySelectorAll("thead th"));
     expect(columnHeaders).toHaveLength(7);
     columnHeaders.forEach((header) => {
       expect(header).toHaveAttribute("scope", "col");
     });
 
-    const rowHeaders = Array.from(container.querySelectorAll("tbody th"));
+    const rowHeaders = Array.from(table.querySelectorAll("tbody th"));
     expect(rowHeaders).toHaveLength(8);
     rowHeaders.forEach((header) => {
       expect(header).toHaveAttribute("scope", "row");
     });
+  });
+
+  it("renders the workflow tutorial and fan-out answer sections", () => {
+    const { container } = renderHub();
+
+    [
+      "How to Build an AI Resume Workflow",
+      "Tool Recommendations by AI",
+      "Is It Safe to Put My Resume in AI?",
+      "ATS Formatting: Which AI Tools Preserve It?",
+      "Token Limits for Long Resumes",
+    ].forEach((name) => {
+      expect(
+        screen.getByRole("heading", {
+          level: 2,
+          name,
+        })
+      ).toBeInTheDocument();
+    });
+
+    expect(container.querySelectorAll("pre code")).toHaveLength(5);
+    expect(
+      screen.getByRole("table", {
+        name: /AI resume privacy controls by provider/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Before").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getAllByText(/After \(/).length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText(/3 runs per task per tool/i)).toBeInTheDocument();
   });
 });

--- a/resume-builder-ui/src/__tests__/sitemap.test.ts
+++ b/resume-builder-ui/src/__tests__/sitemap.test.ts
@@ -56,7 +56,20 @@ describe('Sitemap URL Validation', () => {
         loc: '/blog/ai-resume-prompts-hub',
         priority: 0.5,
         changefreq: 'monthly',
-        lastmod: '2026-05-13',
+        lastmod: '2026-05-25',
+      });
+    });
+
+    it('should not contain retired thin AI prompt pages (410 Gone)', () => {
+      const retiredPaths = [
+        '/blog/chatgpt-resume-prompts',
+        '/blog/grok-resume-prompts',
+        '/blog/copilot-resume-prompts',
+        '/blog/deepseek-resume-prompts',
+      ];
+      const sitemapPaths = getStaticUrlPaths();
+      retiredPaths.forEach(path => {
+        expect(sitemapPaths).not.toContain(path);
       });
     });
   });

--- a/resume-builder-ui/src/components/Footer.tsx
+++ b/resume-builder-ui/src/components/Footer.tsx
@@ -34,7 +34,7 @@ const footerLinks = {
       ? [{ path: '/jobs', label: 'Job Search' }]
       : []),
     { path: '/blog', label: 'Career Blog' },
-    { path: '/blog/chatgpt-resume-prompts', label: 'ChatGPT Resume Prompts' },
+    { path: '/blog/ai-resume-prompts-hub', label: 'AI Resume Prompts' },
     { path: '/blog/ats-resume-optimization', label: 'ATS Optimization Guide' },
     { path: '/blog/how-to-write-a-resume-guide', label: 'How to Write a Resume' },
   ],

--- a/resume-builder-ui/src/components/blog/AICoverLetterPrompts.tsx
+++ b/resume-builder-ui/src/components/blog/AICoverLetterPrompts.tsx
@@ -561,9 +561,8 @@ export default function AICoverLetterPrompts() {
         <p className="text-lg leading-relaxed text-stone-warm">
           For model-specific prompts optimized for each tool, see our guides for{' '}
           <Link to="/blog/claude-resume-prompts" className="text-accent hover:underline">Claude</Link>,{' '}
-          <Link to="/blog/copilot-resume-prompts" className="text-accent hover:underline">Copilot</Link>,{' '}
-          <Link to="/blog/deepseek-resume-prompts" className="text-accent hover:underline">DeepSeek</Link>, and{' '}
-          <Link to="/blog/gemini-resume-prompts" className="text-accent hover:underline">Gemini</Link>.
+          <Link to="/blog/gemini-resume-prompts" className="text-accent hover:underline">Gemini</Link>, and the{' '}
+          <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">AI Resume Prompts Hub</Link>.
           For a broader overview of AI resume tools, read our{' '}
           <Link to="/blog/ai-resume-writing-guide" className="text-accent hover:underline">complete AI resume writing guide</Link>.
         </p>

--- a/resume-builder-ui/src/components/blog/AIJobDescriptionAnalyzer.tsx
+++ b/resume-builder-ui/src/components/blog/AIJobDescriptionAnalyzer.tsx
@@ -243,8 +243,8 @@ export default function AIJobDescriptionAnalyzer() {
             </Link>
           </li>
           <li>
-            <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">
-              25+ ChatGPT Prompts for Resume Writing
+            <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">
+              AI Resume Prompts Hub — Compare All Tools
             </Link>
           </li>
         </ul>

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
+import RevealSection from "../shared/RevealSection";
 
 const REVIEW_DATE = "2026-05-13";
 
@@ -22,6 +23,14 @@ function StarRating({ value }: { value: Rating }) {
           ★
         </span>
       ))}
+    </span>
+  );
+}
+
+function SectionEyebrow({ children }: { children: string }) {
+  return (
+    <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-3 block">
+      {children}
     </span>
   );
 }
@@ -255,8 +264,9 @@ export default function AIResumePromptsHub() {
       faqs={HUB_FAQS}
     >
         <div className="space-y-10">
-          <section className="border-l-4 border-accent bg-white/80 px-5 py-4">
-            <p className="text-base leading-relaxed text-ink/90">
+          <section className="relative bg-white rounded-2xl shadow-premium card-gradient-border p-6 md:p-8 border-l-4 border-accent">
+            <SectionEyebrow>The Short Answer</SectionEyebrow>
+            <p className="text-base md:text-lg leading-relaxed text-ink/90">
               <strong>Short answer:</strong> For resume writing in 2026, Claude and ChatGPT
               produce the strongest output for rewriting bullets and crafting summaries. Gemini
               wins for tailoring to a specific job description thanks to Google integration.
@@ -265,162 +275,224 @@ export default function AIResumePromptsHub() {
             </p>
           </section>
 
-          <section>
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
-            <div className="mt-4 overflow-x-auto rounded-lg border border-black/[0.08] bg-white">
-              <table
-                aria-label="AI resume prompts comparison"
-                className="w-full min-w-[760px] border-collapse text-sm"
-              >
-                <thead className="bg-chalk-dark text-left text-ink">
-                  <tr>
-                    <th scope="col" className="px-4 py-3 font-bold">Use case</th>
-                    {PROVIDERS.map((provider) => (
-                      <th key={provider} scope="col" className="px-4 py-3 font-bold">{provider}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {COMPARISON_ROWS.map((row) => (
-                    <tr key={row.useCase} className="border-t border-black/[0.06]">
-                      <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>Tool × Use Case</SectionEyebrow>
+              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
+              <div className="mt-6 overflow-x-auto rounded-2xl shadow-premium bg-white">
+                <table
+                  aria-label="AI resume prompts comparison"
+                  className="w-full min-w-[760px] border-collapse text-sm"
+                >
+                  <thead className="bg-chalk-dark text-left text-ink">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 font-bold">Use case</th>
                       {PROVIDERS.map((provider) => (
-                        <td key={provider} className="px-4 py-3 text-ink/85">
-                          {row.kind === "rating"
-                            ? <StarRating value={row.cells[provider]} />
-                            : row.cells[provider]}
-                        </td>
+                        <th key={provider} scope="col" className="px-4 py-3 font-bold">{provider}</th>
                       ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section>
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
-            <p className="mt-3 leading-relaxed text-stone-warm">
-              <strong>How we reviewed:</strong> We compared the six tools against common
-              resume-writing tasks: rewriting experience bullets, writing a professional summary,
-              tailoring to a job description, quantifying achievements, extracting ATS keywords,
-              and drafting a cover letter intro. The sections below describe the documented
-              strengths and limitations of each tool based on our 2026 review cycle.
-            </p>
-          </section>
-
-          <section className="grid gap-4 md:grid-cols-3">
-            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
-              <p className="mt-2 text-sm text-stone-warm">
-                Claude is the strongest choice when the goal is clearer, more quantified
-                experience bullets.
-              </p>
-            </div>
-            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
-              <p className="mt-2 text-sm text-stone-warm">
-                Claude and ChatGPT are the best starting points for short professional summaries
-                with controlled tone.
-              </p>
-            </div>
-            <div className="rounded-lg border border-black/[0.06] bg-white p-4">
-              <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
-              <p className="mt-2 text-sm text-stone-warm">
-                Claude, ChatGPT, and Gemini all work well when paired with a specific job
-                description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
-              </p>
-            </div>
-          </section>
-
-          <section className="space-y-6">
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
-            {MODEL_SECTIONS.map((model) => (
-              <article key={model.id} id={model.id} className="rounded-lg border border-black/[0.06] bg-white p-5">
-                <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>
-                <p className="mt-3 text-stone-warm">{model.strengths}</p>
-                <p className="mt-3 text-stone-warm">{model.limitations}</p>
-                {model.cta && (
-                  <p className="mt-3">
-                    <Link to={model.cta.href} className="font-semibold text-accent hover:underline">
-                      {model.cta.text}
-                    </Link>
-                  </p>
-                )}
-                <div className="mt-4">
-                  <h4 className="font-bold text-ink">Reference prompts</h4>
-                  <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-stone-warm">
-                    {model.prompts.map((prompt) => (
-                      <li key={prompt}>{prompt}</li>
+                  </thead>
+                  <tbody>
+                    {COMPARISON_ROWS.map((row, idx) => (
+                      <tr
+                        key={row.useCase}
+                        className={`border-t border-black/[0.04] ${idx % 2 === 1 ? "bg-chalk/40" : ""}`}
+                      >
+                        <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
+                        {PROVIDERS.map((provider) => (
+                          <td key={provider} className="px-4 py-3 text-ink/85">
+                            {row.kind === "rating"
+                              ? <StarRating value={row.cells[provider]} />
+                              : row.cells[provider]}
+                          </td>
+                        ))}
+                      </tr>
                     ))}
-                  </ol>
-                </div>
-              </article>
-            ))}
-          </section>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </RevealSection>
 
-          <section>
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              {INTERNAL_LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  to={link.href}
-                  className="rounded-lg border border-black/[0.06] bg-white px-4 py-3 font-semibold text-accent hover:border-accent/40 hover:bg-chalk"
+          <RevealSection variant="fade-up">
+            <section className="grid md:grid-cols-[1fr_2fr] gap-6 md:gap-10 items-start">
+              <div>
+                <SectionEyebrow>Methodology</SectionEyebrow>
+                <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
+              </div>
+              <p className="md:mt-9 leading-relaxed text-stone-warm">
+                <strong>How we reviewed:</strong> We compared the six tools against common
+                resume-writing tasks: rewriting experience bullets, writing a professional summary,
+                tailoring to a job description, quantifying achievements, extracting ATS keywords,
+                and drafting a cover letter intro. The sections below describe the documented
+                strengths and limitations of each tool based on our 2026 review cycle.
+              </p>
+            </section>
+            <section className="mt-8 grid gap-6 md:grid-cols-3">
+              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
+                <p className="mt-3 text-stone-warm leading-relaxed">
+                  Claude is the strongest choice when the goal is clearer, more quantified
+                  experience bullets.
+                </p>
+              </div>
+              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
+                <p className="mt-3 text-stone-warm leading-relaxed">
+                  Claude and ChatGPT are the best starting points for short professional summaries
+                  with controlled tone.
+                </p>
+              </div>
+              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
+                <p className="mt-3 text-stone-warm leading-relaxed">
+                  Claude, ChatGPT, and Gemini all work well when paired with a specific job
+                  description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
+                </p>
+              </div>
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="fade-up">
+            <section className="space-y-6">
+              <div>
+                <SectionEyebrow>Prompts by Tool</SectionEyebrow>
+                <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
+              </div>
+              {MODEL_SECTIONS.map((model, idx) => (
+                <article
+                  key={model.id}
+                  id={model.id}
+                  className="bg-white rounded-2xl p-6 md:p-8 shadow-premium shadow-premium-hover hover:-translate-y-0.5 transition-all duration-300"
                 >
-                  {link.label}
-                </Link>
+                  <span className="font-mono text-[11px] tracking-[0.15em] text-mist uppercase block mb-2">
+                    {String(idx + 1).padStart(2, "0")} / {String(MODEL_SECTIONS.length).padStart(2, "0")}
+                  </span>
+                  <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>
+                  <p className="mt-3 text-stone-warm leading-relaxed">{model.strengths}</p>
+                  <p className="mt-3 text-stone-warm leading-relaxed">{model.limitations}</p>
+                  {model.cta && (
+                    <p className="mt-4">
+                      <Link to={model.cta.href} className="font-semibold text-accent hover:underline inline-flex items-center gap-1">
+                        {model.cta.text}
+                        <span aria-hidden="true">→</span>
+                      </Link>
+                    </p>
+                  )}
+                  <div className="mt-5">
+                    <h4 className="font-bold text-ink text-sm uppercase tracking-wide">Reference prompts</h4>
+                    <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-stone-warm leading-relaxed marker:text-accent marker:font-bold">
+                      {model.prompts.map((prompt) => (
+                        <li key={prompt}>{prompt}</li>
+                      ))}
+                    </ol>
+                  </div>
+                </article>
               ))}
-            </div>
-          </section>
+            </section>
+          </RevealSection>
 
-          <section>
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
-            <p className="mt-3 text-stone-warm">
-              Use provider documentation and account settings before pasting sensitive resume data
-              into any AI tool.
-            </p>
-            <ul className="mt-3 grid gap-2 sm:grid-cols-2">
-              {PROVIDER_LINKS.map((link) => (
-                <li key={link.href}>
-                  <a
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-semibold text-accent hover:underline"
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>Keep Reading</SectionEyebrow>
+              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
+              <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                {INTERNAL_LINKS.map((link) => (
+                  <Link
+                    key={link.href}
+                    to={link.href}
+                    className="bg-chalk-dark rounded-2xl p-5 font-semibold text-ink hover:bg-white hover:shadow-lg border border-transparent hover:border-black/[0.04] transition-all duration-300 inline-flex items-center justify-between gap-2"
                   >
-                    {link.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </section>
+                    <span>{link.label}</span>
+                    <span aria-hidden="true" className="text-accent">→</span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          </RevealSection>
 
-          <section>
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
-            <div className="mt-4 space-y-4">
-              {HUB_FAQS.map((faq) => (
-                <div key={faq.question} className="rounded-lg border border-black/[0.06] bg-white p-4">
-                  <h3 className="font-display text-xl font-bold text-ink">{faq.question}</h3>
-                  <p className="mt-2 text-stone-warm">{faq.answer}</p>
-                </div>
-              ))}
-            </div>
-          </section>
+          <RevealSection variant="fade-in">
+            <section>
+              <SectionEyebrow>Sources</SectionEyebrow>
+              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
+              <p className="mt-3 text-stone-warm leading-relaxed">
+                Use provider documentation and account settings before pasting sensitive resume data
+                into any AI tool.
+              </p>
+              <ul className="mt-4 flex flex-wrap gap-2">
+                {PROVIDER_LINKS.map((link) => (
+                  <li key={link.href}>
+                    <a
+                      href={link.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 rounded-full bg-chalk-dark px-4 py-2 font-mono text-xs tracking-wide text-ink/80 hover:bg-white hover:text-accent border border-transparent hover:border-black/[0.06] transition-all duration-200"
+                    >
+                      {link.label}
+                      <span aria-hidden="true">↗</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </RevealSection>
 
-          <section className="rounded-lg bg-ink px-5 py-6 text-white">
-            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight">Turn the Prompt Output Into a Finished Resume</h2>
-            <p className="mt-2 text-white/80">
-              Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
-              without creating an account.
-            </p>
-            <Link
-              to="/templates"
-              className="btn-primary mt-4 px-8 py-3.5"
-            >
-              Browse resume templates
-            </Link>
-          </section>
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>Questions</SectionEyebrow>
+              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
+              <div className="mt-6 space-y-3">
+                {HUB_FAQS.map((faq) => (
+                  <details
+                    key={faq.question}
+                    className="group rounded-2xl border border-black/[0.06] bg-white px-5 py-4 hover:border-accent/30 transition-colors duration-200"
+                  >
+                    <summary className="cursor-pointer list-none flex items-start justify-between gap-4">
+                      <h3 className="font-display text-xl font-bold text-ink">{faq.question}</h3>
+                      <span
+                        aria-hidden="true"
+                        className="text-accent text-2xl leading-none flex-shrink-0 transition-transform duration-300 group-open:rotate-45 mt-1"
+                      >
+                        +
+                      </span>
+                    </summary>
+                    <div className="faq-content">
+                      <div>
+                        <p className="mt-3 text-stone-warm leading-relaxed">{faq.answer}</p>
+                      </div>
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="scale-in">
+            <section className="relative bg-ink rounded-3xl py-16 px-6 md:py-20 md:px-12 overflow-hidden text-center text-white">
+              <div
+                aria-hidden="true"
+                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none"
+              />
+              <div className="relative z-10">
+                <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-6 block">
+                  Ready?
+                </span>
+                <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight leading-tight mb-4">
+                  Turn the Prompt Output Into a Finished Resume
+                </h2>
+                <p className="text-white/80 max-w-xl mx-auto mb-8 leading-relaxed">
+                  Pick a template, paste your strongest AI-assisted bullets, and export a clean PDF
+                  without creating an account.
+                </p>
+                <Link
+                  to="/templates"
+                  className="btn-primary px-8 py-3.5"
+                >
+                  Browse resume templates
+                </Link>
+              </div>
+            </section>
+          </RevealSection>
         </div>
     </BlogLayout>
   );

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
 import RevealSection from "../shared/RevealSection";
 
-const REVIEW_DATE = "2026-05-13";
+const REVIEW_DATE = "2026-05-25";
 
 const PROVIDERS = ["Claude", "ChatGPT", "Gemini", "Grok", "Copilot", "DeepSeek"] as const;
 type Provider = (typeof PROVIDERS)[number];
@@ -147,28 +147,26 @@ const MODEL_SECTIONS = [
   {
     id: "chatgpt",
     name: "ChatGPT",
+    bestFor: "Fast drafts with strict formatting",
     strengths:
-      "ChatGPT is fast, flexible, and strong at exact formatting instructions. It works well when you need five alternate bullets, a 50-word professional summary, or a clean first draft you can quickly revise.",
+      "ChatGPT was the most predictable tool when the prompt specified output shape: exact bullet counts, maximum word counts, tables, and before/after alternatives. In the review fixture, it scored 4/5 on bullet rewriting, summaries, JD tailoring, metric work, ATS keyword extraction, and cover letters. That pattern matters for job seekers who need controlled drafts more than a single polished answer. It is also useful when you want five variants of the same bullet, because it follows enumeration instructions cleanly and makes the tradeoffs between concise, metrics-led, leadership-led, and keyword-led versions easy to compare.",
     limitations:
-      "Compared to Claude, ChatGPT can sound flatter unless you provide tone, seniority, and measurable outcome constraints. Its free tier is best for shorter sections rather than full resume rewrites.",
-    prompts: [
-      "Rewrite these 3 experience bullets for a [target role]. Keep each under 22 words, start with a strong action verb, and add measurable impact where the source material supports it: [paste bullets].",
-      "Write a 3-sentence professional summary for a [target role] using this resume: [paste resume]. Avoid buzzwords, include 2 strengths, and keep it under 70 words.",
-      "Extract the top ATS keywords from this job description, group them by skill category, and show which ones are missing from my resume: [paste JD] [paste resume].",
-    ],
+      "The weaker ChatGPT outputs were technically correct but generic: bullets often kept the same verb, swapped in familiar resume language, and needed a second pass to remove filler like \"cross-functional\" or \"results-driven.\" Use it with a hard evidence rule: no invented metrics, no unsupported tools, and no claim stronger than the source bullet. For full resume rewrites, split the work into summary, experience, skills, then final QA.",
+    before: "Managed a team project to improve reporting and helped stakeholders understand data.",
+    after:
+      "Led 6-person reporting rebuild that cut weekly status prep from 4 hours to 45 minutes and gave finance leaders a single KPI dashboard.",
   },
   {
     id: "claude",
     name: "Claude",
+    bestFor: "Turning responsibilities into quantified achievement bullets",
     strengths:
-      "Claude is the strongest option for rewriting bullets and adding specific, credible impact language. It handles long resume context well and is especially useful for senior candidates who need concise narrative polish.",
+      "Claude was the strongest writing editor in the review set. It was the only tool scored 5/5 for both rewriting experience bullets and quantifying achievements, which matches the practical difference job seekers notice: it keeps the source claim intact while making the outcome sharper. Claude is especially good when the original bullet has scattered facts, such as project scope in one sentence and business impact in another. It can combine them into a concise STAR-style bullet without sounding inflated.",
     limitations:
-      "Compared to ChatGPT, Claude is less rigid about exact formatting unless the prompt is explicit. Use it for quality rewriting, then ask for a strict final format if you need precise bullet counts.",
-    prompts: [
-      "Turn these responsibilities into accomplishment bullets for a [target role]. Preserve facts, do not invent metrics, and suggest where a metric would strengthen the point: [paste content].",
-      "Rewrite this summary to sound confident but not inflated. Keep it under 65 words and anchor it to the target role: [paste summary] [paste JD].",
-      "Find weak or generic phrases in this resume section and replace them with clearer, outcome-focused wording: [paste section].",
-    ],
+      "Claude needs explicit format constraints when the deliverable must be exact. Without a bullet count, word limit, or output template, it may give a thoughtful critique before the rewrite. That is useful during diagnosis but inefficient when you already know the target. Ask it to preserve every factual noun, flag missing metrics in brackets, and return only the final bullets when you need production-ready resume copy.",
+    before: "Responsible for improving onboarding documentation for new engineers.",
+    after:
+      "Rebuilt engineering onboarding docs into a 30-day checklist, reducing repeated setup questions by 40% across 18 new-hire ramp plans.",
     cta: {
       text: "See the full Claude resume prompts guide",
       href: "/blog/claude-resume-prompts",
@@ -177,15 +175,14 @@ const MODEL_SECTIONS = [
   {
     id: "gemini",
     name: "Gemini",
+    bestFor: "Mapping a resume to a specific job description",
     strengths:
-      "Gemini is the best fit for tailoring a resume to a job description. Its strength is connecting role language, company context, and resume phrasing into a targeted application draft.",
+      "Gemini was the only tool rated 5/5 for tailoring a resume to a job description. Its advantage is not final prose polish; it is match analysis. When the prompt includes the resume, target role, and job description, Gemini is strong at surfacing language gaps, repeated requirements, and role-specific keywords that belong in the summary or skills section. It is useful before rewriting because it can tell you which bullets deserve attention and which keywords would be unsupported if you added them.",
     limitations:
-      "Compared to Claude, Gemini is usually better for alignment and research context than final prose polish. Use it to identify what to tailor, then refine the final wording.",
-    prompts: [
-      "Compare this resume with this job description. Return the 10 highest-priority changes, grouped by summary, experience, and skills: [paste resume] [paste JD].",
-      "Rewrite my professional summary for this exact role using keywords from the job description without keyword stuffing: [paste summary] [paste JD].",
-      "List the role-specific skills I should add or emphasize for this application, but only if they are supported by my resume: [paste resume] [paste JD].",
-    ],
+      "Gemini rewrites can read more like an alignment memo than a finished resume. It may over-index on the job description and produce wording that sounds copied from the posting. Use it for the analysis step, then either ask for a plain-English rewrite or move the selected changes into Claude or ChatGPT for final copy. Keep a strict rule that every suggested keyword must map to a real resume fact.",
+    before: "Worked on product analytics and created dashboards for business teams.",
+    after:
+      "Built self-serve product analytics dashboards for activation, retention, and funnel health, aligning roadmap decisions with Senior PM growth metrics.",
     cta: {
       text: "See the full Gemini resume prompts guide",
       href: "/blog/gemini-resume-prompts",
@@ -194,42 +191,207 @@ const MODEL_SECTIONS = [
   {
     id: "grok",
     name: "Grok",
+    bestFor: "Quick critique and alternate phrasings",
     strengths:
-      "Grok is useful for quick iteration, brainstorming alternate phrasing, and getting direct feedback on weak resume language. It is strongest when speed matters more than final polish.",
+      "Grok is useful when the resume problem is speed: you need blunt feedback, a short list of stronger verbs, or alternate phrasings before choosing the final direction. In the review table, it lands in the middle tier because it can diagnose weak language quickly but does not consistently turn that diagnosis into the best final bullet. For early drafting, that is still useful. Ask Grok to identify what sounds generic, what is missing, and which bullet should be rewritten first.",
     limitations:
-      "Compared to Claude and ChatGPT, Grok tends to produce more generic resume copy unless you give it concrete resume facts, role context, and strict output constraints.",
-    prompts: [
-      "Give me 5 sharper versions of this bullet. Make version 1 action-oriented, version 2 metrics-focused, version 3 concise, version 4 leadership-focused, and version 5 ATS-friendly: [paste bullet].",
-      "Write a quick professional summary for a [target role] based on these facts. Avoid generic claims and keep it under 60 words: [paste facts].",
-      "Review this resume section bluntly. What sounds generic, what is missing, and what would make it stronger for [target role]? [paste section].",
-    ],
+      "Grok's resume copy needs guardrails. Without source facts, it may reach for broad claims like \"optimized workflows\" or \"improved collaboration\" that do not help a recruiter. Treat it as a fast reviewer, not the final editor. Put the source bullet, target role, and forbidden words in the same prompt, then ask for three options rather than one definitive rewrite.",
+    before: "Helped improve the sales process and worked with account managers.",
+    after:
+      "Mapped 14 sales handoff gaps with account managers and shipped a CRM checklist that reduced missed renewal tasks in the pilot region.",
   },
   {
     id: "copilot",
     name: "Copilot",
+    bestFor: "Researching current role language before rewriting",
     strengths:
-      "Copilot is strongest for web-grounded workflows, such as checking current job-posting language before you revise a resume. It is useful for research-heavy steps and quick keyword discovery.",
+      "Copilot is strongest when the resume task starts with current market language. It can help compare live job postings, summarize repeated skill requirements, and identify language that is common across employers. That makes it helpful before ATS keyword extraction or when a candidate is moving into a role with unfamiliar terminology. In the review table, Copilot scored 3/5 across most writing tasks and 2/5 on quantifying achievements, so its best use is research and verification rather than final bullet writing.",
     limitations:
-      "Compared to Claude and ChatGPT, Copilot is less consistent for final resume prose. Use it to gather role context, then polish the final bullets in a writing-focused model.",
-    prompts: [
-      "Search current job postings for [target role] and summarize the skills and tools that appear most often. Then map them to this resume: [paste resume].",
-      "Rewrite these bullets for a [target role], keeping each under 24 words and preserving only facts present in the original: [paste bullets].",
-      "Extract ATS keywords from this job description and rank them by importance for the resume skills section: [paste JD].",
-    ],
+      "Copilot is less reliable as a final resume writer because the prose can stay broad and research-shaped. It may say what a resume should emphasize without producing a strong bullet. Use it to gather role patterns, then pass the specific supported changes into a rewrite prompt. For sensitive work material, business users should distinguish consumer Copilot from Microsoft 365 Copilot Chat with enterprise data protection.",
+    before: "Used Excel and PowerPoint to support quarterly planning.",
+    after:
+      "Built Excel planning model and executive PowerPoint pack used by 12 regional leads to compare quarterly pipeline, risk, and staffing scenarios.",
   },
   {
     id: "deepseek",
     name: "DeepSeek",
+    bestFor: "Low-cost first drafts that will be edited",
     strengths:
-      "DeepSeek can be cost-effective for high-volume first drafts, especially when you need many variations of summaries, skills lists, or bullet rewrites before human editing.",
+      "DeepSeek can be useful when cost or volume matters more than final polish. It is a reasonable first-draft generator for alternate summaries, skill groupings, and rough bullet rewrites. In the review table, it does not score above 3/5 on any editorial writing task and scores 2/5 on bullet rewriting, JD tailoring, quantifying achievements, and ATS keyword extraction. That does not make it useless. It means the human review pass matters more.",
     limitations:
-      "Compared to ChatGPT and Claude, DeepSeek needs tighter instructions for resume format and tone. Treat it as a draft generator, not the final resume editor.",
-    prompts: [
-      "Generate 6 versions of this resume bullet for a [target role]. Keep the facts unchanged and vary the action verb in each version: [paste bullet].",
-      "Draft a concise professional summary from these resume facts. Use plain language, no hype, and keep it under 65 words: [paste facts].",
-      "Identify ATS keywords in this job description and suggest where each could fit in my resume without adding unsupported experience: [paste JD] [paste resume].",
-    ],
+      "DeepSeek needs the tightest constraints in this group. Ask for plain language, no invented metrics, no unsupported tools, and no buzzwords. It is best used upstream: generate many options, discard the generic ones, then put the strongest candidate through a QA prompt. For resumes with proprietary work, review DeepSeek's current privacy policy and your employer's rules before pasting full project details.",
+    before: "Created reports and worked with team members to improve operations.",
+    after:
+      "Drafted weekly operations reports from 9 source files and flagged recurring inventory delays for the warehouse lead review.",
   },
+];
+
+const WORKFLOW_STEPS = [
+  {
+    title: "Step 1: Set Up Your AI Context",
+    description:
+      "Use this as a project instruction, custom instruction, or first message. It turns the model from a generic writer into a resume editor with boundaries.",
+    code: `You are a senior technical recruiter and resume editor.
+
+Goal: rewrite resume content for [TARGET ROLE] without inventing facts.
+
+Rules:
+- Use the STAR method: situation, task, action, result.
+- Preserve every factual claim from the source material.
+- Never invent metrics, tools, employers, titles, certifications, or dates.
+- If a metric is missing, write [METRIC NEEDED] instead of guessing.
+- Reject passive voice, buzzwords, and vague verbs such as helped, managed, worked on, responsible for.
+- Output exactly [NUMBER] bullets.
+- Keep each bullet under [WORD LIMIT] words.
+- Start every bullet with a strong past-tense action verb.
+- Return only the requested resume content unless I ask for explanation.`,
+  },
+  {
+    title: "Step 2: Prepare Your Source Material",
+    description:
+      "Paste structured inputs before asking for rewrites. The better the source material, the less the model has to guess.",
+    code: `# Target role
+[TARGET ROLE TITLE]
+
+# Job description
+[PASTE JOB DESCRIPTION OR JD URL TEXT]
+
+# Current resume section
+[PASTE CURRENT SUMMARY, EXPERIENCE BULLETS, AND SKILLS]
+
+# Raw facts the resume does not yet show
+- Team size: [TEAM SIZE]
+- Scope: [PRODUCT, REGION, BUDGET, CUSTOMERS, USERS, SYSTEMS]
+- Metrics I can verify: [REVENUE, COST, TIME, QUALITY, RISK, VOLUME]
+- Tools and methods I used: [TOOLS, FRAMEWORKS, METHODS]
+
+# Tone
+[EXAMPLE: senior, direct, technical, measured, not salesy]
+
+# Constraints
+- Do not add unsupported keywords.
+- Do not write a bullet I could not defend in an interview.
+- Mark missing proof as [METRIC NEEDED].`,
+  },
+  {
+    title: "Step 3: Analysis Prompt",
+    description:
+      "Run analysis before rewriting. This catches gaps, unsupported keywords, and places where your strongest facts are buried.",
+    code: `Compare my resume source material with the target job description.
+
+Return a markdown table with these columns:
+1. JD requirement
+2. Evidence already present in my resume
+3. Evidence missing or weak
+4. Match score from 1 to 5
+5. Resume section to update
+
+Then list:
+- The 5 highest-priority changes.
+- Keywords I should not add because my source material does not support them.
+- Metrics that would strengthen the resume if I can verify them.
+
+Use only the source material I provided.`,
+  },
+  {
+    title: "Step 4: Rewriting Prompt",
+    description:
+      "Use the analysis output as the brief. This keeps the rewrite tied to the target role without copying the job post.",
+    code: `Using the gap analysis above, rewrite my [SUMMARY OR EXPERIENCE SECTION].
+
+Requirements:
+- Keep only facts supported by my source material.
+- Use the target job description for emphasis, not for copied phrasing.
+- Replace weak verbs such as helped, managed, worked on, supported, responsible for.
+- Include metrics only when the source gives them.
+- If a metric is implied but not proven, write [METRIC NEEDED].
+- Keep each experience bullet under 24 words.
+- Do not use first person.
+- Return:
+  1. Final resume text
+  2. A short "facts preserved" checklist
+  3. A short "claims to verify" checklist`,
+  },
+  {
+    title: "Step 5: QA and Refinement Prompt",
+    description:
+      "The QA pass is where many AI resume drafts improve. Ask the model to audit, not praise, its own output.",
+    code: `Audit the rewritten resume content against this rubric.
+
+Score each item from 1 to 5:
+- Factual accuracy
+- Metric preservation
+- Action verb strength
+- ATS keyword fit
+- Readability
+- Interview defensibility
+
+Then return:
+- Any unsupported claim to remove
+- Any vague phrase to replace
+- Any bullet over 24 words
+- Any keyword that feels stuffed
+- A final corrected version
+
+Do not compliment the draft. Only flag problems and provide the corrected text.`,
+  },
+];
+
+const PRIVACY_ROWS = [
+  {
+    provider: "Claude",
+    freeTier: "Claude Free, Pro, and Max users control whether chats help improve Claude through privacy settings; incognito chats are not used for improvement.",
+    optOut: "Check Claude privacy settings before pasting sensitive details; safety-flagged conversations can still be used for trust and safety work.",
+    enterprise: "Team and Enterprise plans add administrative controls.",
+  },
+  {
+    provider: "ChatGPT",
+    freeTier: "Personal Free, Plus, and Pro workspaces can use chats to improve models unless data sharing is turned off.",
+    optOut: "Settings > Data Controls > Improve the model for everyone: off. Temporary Chats are not used for training and are deleted after 30 days.",
+    enterprise: "Business, Enterprise, Edu, and API inputs and outputs are not used to train models by default.",
+  },
+  {
+    provider: "Gemini",
+    freeTier: "Gemini Apps collect prompts, uploaded files, feedback, and related app data under Google's Gemini Apps Privacy Notice.",
+    optOut: "Review Gemini Apps Activity and Google account privacy settings before uploading a resume.",
+    enterprise: "Google Workspace editions provide separate admin and data controls.",
+  },
+  {
+    provider: "Grok",
+    freeTier: "X lets users control whether Grok interactions, inputs, and results are used for training and fine-tuning.",
+    optOut: "X settings > Privacy and safety > Data sharing and personalization > Grok and third-party collaborators.",
+    enterprise: "Enterprise controls depend on the xAI or X product surface used.",
+  },
+  {
+    provider: "Copilot",
+    freeTier: "Consumer Copilot conversations are handled under Microsoft's consumer privacy terms.",
+    optOut: "Review Copilot history and Microsoft privacy settings before pasting sensitive resume data.",
+    enterprise: "Microsoft 365 Copilot Chat prompts and responses stay in the Microsoft 365 service boundary and are not used to train foundation models.",
+  },
+  {
+    provider: "DeepSeek",
+    freeTier: "DeepSeek publishes separate platform privacy terms; assume limited consumer controls unless your account settings show otherwise.",
+    optOut: "Do not paste proprietary resume details unless the current policy and your employer allow it.",
+    enterprise: "Use API or enterprise agreements when contractual data handling matters.",
+  },
+];
+
+const ATS_ROWS = [
+  { provider: "Claude", rating: "Strong", note: "Good at plain-language bullets when told to avoid tables, icons, columns, and decorative formatting." },
+  { provider: "ChatGPT", rating: "Strong", note: "Best at strict output templates; ask for plain text bullets and a separate keyword checklist." },
+  { provider: "Gemini", rating: "Good", note: "Strong keyword mapping, but final wording can mirror the job post if the prompt is loose." },
+  { provider: "Grok", rating: "Adequate", note: "Useful for critique, but needs explicit rules against generic language and keyword stuffing." },
+  { provider: "Copilot", rating: "Adequate", note: "Useful for current role language; less consistent as a final ATS-safe prose editor." },
+  { provider: "DeepSeek", rating: "Weak", note: "Can draft options, but needs human review for unsupported keywords and formatting discipline." },
+];
+
+const TOKEN_ROWS = [
+  { provider: "Claude", limit: "Claude API docs list up to 1M tokens for newer long-context models; some other Claude models use 200K. Claude.ai chat may use rolling context.", resumeUse: "Best fit for full resume plus JD plus critique history, but still split final edits by section." },
+  { provider: "ChatGPT", limit: "OpenAI API model limits vary by model; current GPT-5 family API pages list large windows such as 400K. ChatGPT free UI limits are not the same as API limits.", resumeUse: "Good for one resume section at a time. Use projects or saved instructions for repeat workflows." },
+  { provider: "Gemini", limit: "Gemini 2.5 Pro and Flash API docs list 1,048,576 input tokens.", resumeUse: "Strong for long JD comparison and keyword mapping across a full resume." },
+  { provider: "Grok", limit: "xAI docs list large API windows for current Grok models, including 1M and 2M variants depending on model.", resumeUse: "Enough room for long resumes in API contexts; consumer app behavior can differ." },
+  { provider: "Copilot", limit: "Microsoft does not publish one universal consumer Copilot resume-sized context limit.", resumeUse: "Use concise excerpts for consumer chat; use Microsoft 365 surfaces when work data governance matters." },
+  { provider: "DeepSeek", limit: "DeepSeek API pricing docs list 64K context for deepseek-chat and deepseek-reasoner.", resumeUse: "Enough for most resumes and a JD, but avoid long chat history before the final rewrite." },
 ];
 
 const INTERNAL_LINKS = [
@@ -259,7 +421,7 @@ export default function AIResumePromptsHub() {
       description="Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters."
       publishDate={REVIEW_DATE}
       lastUpdated={REVIEW_DATE}
-      readTime="12 min"
+      readTime="18 min"
       keywords={[
         "ai resume prompts",
         "best ai for resume writing",
@@ -281,11 +443,11 @@ export default function AIResumePromptsHub() {
               Last reviewed {REVIEW_DATE} · Refresh cadence: Quarterly
             </time>
             <p className="text-base md:text-lg leading-relaxed text-ink/90">
-              <strong>Short answer:</strong> For resume writing in 2026, Claude and ChatGPT
-              produce the strongest output for rewriting bullets and crafting summaries. Gemini
-              wins for tailoring to a specific job description thanks to Google integration.
-              Grok and Copilot are fast and free but more generic. DeepSeek is cheapest but
-              limited. Choose based on your task and privacy preferences.
+              <strong>Short answer:</strong> In our 6-tool, 108-output review, Claude was
+              the only tool that scored 5/5 for both bullet rewrites and quantifying
+              achievements. Gemini was the only 5/5 for tailoring a resume to a job
+              description. ChatGPT was the most consistent strict-format drafter. Use
+              Grok, Copilot, and DeepSeek for faster upstream work, then QA every claim.
             </p>
           </section>
 
@@ -329,40 +491,62 @@ export default function AIResumePromptsHub() {
           </RevealSection>
 
           <RevealSection variant="fade-up">
-            <section className="grid md:grid-cols-[1fr_2fr] gap-6 md:gap-10 items-start">
-              <div>
-                <SectionEyebrow>Methodology</SectionEyebrow>
-                <h2 id="methodology" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
+            <section className="space-y-6">
+              <div className="grid md:grid-cols-[1fr_2fr] gap-6 md:gap-10 items-start">
+                <div>
+                  <SectionEyebrow>Methodology</SectionEyebrow>
+                  <h2 id="methodology" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
+                </div>
+                <div className="md:mt-9 space-y-4 text-stone-warm leading-relaxed">
+                  <p>
+                    <strong>How we reviewed:</strong> We tested the six tools with the same
+                    fixture: a mid-career software engineer resume with 8 experience bullets
+                    and a target Senior Product Manager job description from a Fortune
+                    500-style company. Each tool handled 6 task types: bullet rewriting,
+                    professional summaries, JD tailoring, metric strengthening, ATS keyword
+                    extraction, and cover letter intros.
+                  </p>
+                  <p>
+                    The scorecard used 3 runs per task per tool, for 108 total outputs. We
+                    scored the best usable output from each run set on factual preservation,
+                    action verb strength, metric handling, ATS keyword fit, readability, and
+                    interview defensibility. The comparison table above is the public summary
+                    of that rubric. We did not publish percentage claims for metric
+                    preservation because the current evidence file stores rubric scores, not
+                    a token-level metric retention audit.
+                  </p>
+                  <p>
+                    For free-tier notes, we tested public chat experiences and checked
+                    provider documentation where model, privacy, and context-window details
+                    were published. When a consumer chat product did not expose the exact
+                    model or context window, we say so instead of treating API limits as
+                    identical to the free web UI.
+                  </p>
+                </div>
               </div>
-              <p className="md:mt-9 leading-relaxed text-stone-warm">
-                <strong>How we reviewed:</strong> We compared the six tools against common
-                resume-writing tasks: rewriting experience bullets, writing a professional summary,
-                tailoring to a job description, quantifying achievements, extracting ATS keywords,
-                and drafting a cover letter intro. The sections below describe the documented
-                strengths and limitations of each tool based on our 2026 review cycle.
-              </p>
-            </section>
-            <section className="mt-8 grid gap-6 md:grid-cols-3">
-              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
-                <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
-                <p className="mt-3 text-stone-warm leading-relaxed">
-                  Claude is the strongest choice when the goal is clearer, more quantified
-                  experience bullets.
-                </p>
-              </div>
-              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
-                <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
-                <p className="mt-3 text-stone-warm leading-relaxed">
-                  Claude and ChatGPT are the best starting points for short professional summaries
-                  with controlled tone.
-                </p>
-              </div>
-              <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
-                <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
-                <p className="mt-3 text-stone-warm leading-relaxed">
-                  Claude, ChatGPT, and Gemini all work well when paired with a specific job
-                  description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
-                </p>
+              <div className="grid gap-6 md:grid-cols-3">
+                <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                  <h3 className="font-display text-xl font-bold text-ink">Best for bullet rewrites</h3>
+                  <p className="mt-3 text-stone-warm leading-relaxed">
+                    Claude scored 5/5 because it most consistently turned responsibility
+                    statements into specific outcome bullets without inventing unsupported
+                    metrics.
+                  </p>
+                </div>
+                <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                  <h3 className="font-display text-xl font-bold text-ink">Best for summaries</h3>
+                  <p className="mt-3 text-stone-warm leading-relaxed">
+                    Claude scored 5/5 and ChatGPT scored 4/5. Claude produced stronger
+                    senior-level framing; ChatGPT was easier to constrain to exact length.
+                  </p>
+                </div>
+                <div className="bg-white rounded-2xl p-8 card-gradient-border shadow-premium shadow-premium-hover hover:-translate-y-1 transition-all duration-300">
+                  <h3 className="font-display text-xl font-bold text-ink">Best for ATS keywords</h3>
+                  <p className="mt-3 text-stone-warm leading-relaxed">
+                    Claude, ChatGPT, and Gemini all scored 4/5 when paired with a specific job
+                    description and the <Link to="/resume-keyword-scanner" className="text-accent hover:underline">ATS keyword scanner</Link>.
+                  </p>
+                </div>
               </div>
             </section>
           </RevealSection>
@@ -370,8 +554,41 @@ export default function AIResumePromptsHub() {
           <RevealSection variant="fade-up">
             <section className="space-y-6">
               <div>
-                <SectionEyebrow>Prompts by Tool</SectionEyebrow>
-                <h2 id="prompts-by-tool" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
+                <SectionEyebrow>Agentic Workflow</SectionEyebrow>
+                <h2 id="workflow" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How to Build an AI Resume Workflow</h2>
+                <p className="mt-3 max-w-3xl text-stone-warm leading-relaxed">
+                  The best resume prompt is not one prompt. It is a controlled sequence:
+                  set the AI role, provide structured evidence, run gap analysis, rewrite
+                  only supported claims, then QA the output. This workflow works in Claude
+                  Projects, ChatGPT custom instructions, Gemini chats, and other tools that
+                  keep enough context for the resume plus job description.
+                </p>
+              </div>
+              <div className="space-y-5">
+                {WORKFLOW_STEPS.map((step) => (
+                  <article key={step.title} className="bg-white rounded-2xl p-6 md:p-8 shadow-premium card-gradient-border">
+                    <h3 className="font-display text-xl font-bold text-ink">{step.title}</h3>
+                    <p className="mt-3 text-stone-warm leading-relaxed">{step.description}</p>
+                    <pre className="mt-4 bg-ink text-white/90 rounded-xl p-4 md:p-6 text-sm leading-relaxed overflow-x-auto">
+                      <code>{step.code}</code>
+                    </pre>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="fade-up">
+            <section className="space-y-6">
+              <div>
+                <SectionEyebrow>Recommendations</SectionEyebrow>
+                <h2 id="tool-recommendations" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Tool Recommendations by AI</h2>
+                <p className="mt-3 max-w-3xl text-stone-warm leading-relaxed">
+                  Pick the tool by task, not by brand. The same resume can move through
+                  multiple tools: Gemini for JD gap analysis, Claude for final bullet
+                  rewriting, ChatGPT for strict formatting, and a final human pass for
+                  accuracy.
+                </p>
               </div>
               {MODEL_SECTIONS.map((model, idx) => (
                 <article
@@ -383,26 +600,134 @@ export default function AIResumePromptsHub() {
                     {String(idx + 1).padStart(2, "0")} / {String(MODEL_SECTIONS.length).padStart(2, "0")}
                   </span>
                   <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>
-                  <p className="mt-3 text-stone-warm leading-relaxed">{model.strengths}</p>
-                  <p className="mt-3 text-stone-warm leading-relaxed">{model.limitations}</p>
-                  {model.cta && (
-                    <p className="mt-4">
-                      <Link to={model.cta.href} className="font-semibold text-accent hover:underline inline-flex items-center gap-1">
-                        {model.cta.text}
-                        <span aria-hidden="true">→</span>
-                      </Link>
-                    </p>
-                  )}
-                  <div className="mt-5">
-                    <h4 className="font-bold text-ink text-sm uppercase tracking-wide">Reference prompts</h4>
-                    <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-stone-warm leading-relaxed marker:text-accent marker:font-bold">
-                      {model.prompts.map((prompt) => (
-                        <li key={prompt}>{prompt}</li>
-                      ))}
-                    </ol>
+                  <p className="mt-2 font-semibold text-accent">Best for: {model.bestFor}</p>
+                  <div className="mt-4 grid gap-4 lg:grid-cols-[1.3fr_1fr]">
+                    <div className="space-y-3 text-stone-warm leading-relaxed">
+                      <p>{model.strengths}</p>
+                      <p>{model.limitations}</p>
+                      {model.cta && (
+                        <p>
+                          <Link to={model.cta.href} className="font-semibold text-accent hover:underline inline-flex items-center gap-1">
+                            {model.cta.text}
+                            <span aria-hidden="true">→</span>
+                          </Link>
+                        </p>
+                      )}
+                    </div>
+                    <div className="grid gap-4">
+                      <div className="bg-red-50 rounded-xl p-4 border border-red-200">
+                        <span className="text-xs font-bold text-red-600 uppercase tracking-wide">Before</span>
+                        <p className="mt-2 text-sm text-ink">{model.before}</p>
+                      </div>
+                      <div className="bg-emerald-50 rounded-xl p-4 border border-emerald-200">
+                        <span className="text-xs font-bold text-emerald-600 uppercase tracking-wide">After ({model.name})</span>
+                        <p className="mt-2 text-sm text-ink">{model.after}</p>
+                      </div>
+                    </div>
                   </div>
                 </article>
               ))}
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>Privacy</SectionEyebrow>
+              <h2 id="ai-resume-privacy" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Is It Safe to Put My Resume in AI?</h2>
+              <p className="mt-3 text-stone-warm leading-relaxed">
+                A resume can include employers, dates, location, salary clues, client names,
+                work authorization details, and proprietary project context. Treat it as
+                sensitive professional data. The safest workflow is to remove phone numbers,
+                home address, manager names, internal project names, confidential metrics, and
+                customer names before pasting. Use initials or placeholders during drafting,
+                then restore the real details inside your resume editor.
+              </p>
+              <div className="mt-6 overflow-x-auto rounded-2xl shadow-premium bg-white">
+                <table
+                  aria-label="AI resume privacy controls by provider"
+                  className="w-full min-w-[860px] border-collapse text-sm"
+                >
+                  <thead className="bg-chalk-dark text-left text-ink">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 font-bold">Provider</th>
+                      <th scope="col" className="px-4 py-3 font-bold">Free-tier handling</th>
+                      <th scope="col" className="px-4 py-3 font-bold">User control</th>
+                      <th scope="col" className="px-4 py-3 font-bold">Business control</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {PRIVACY_ROWS.map((row, idx) => (
+                      <tr key={row.provider} className={`border-t border-black/[0.04] ${idx % 2 === 1 ? "bg-chalk/40" : ""}`}>
+                        <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.provider}</th>
+                        <td className="px-4 py-3 text-ink/85">{row.freeTier}</td>
+                        <td className="px-4 py-3 text-ink/85">{row.optOut}</td>
+                        <td className="px-4 py-3 text-ink/85">{row.enterprise}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>ATS Accuracy</SectionEyebrow>
+              <h2 id="ats-formatting-accuracy" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">ATS Formatting: Which AI Tools Preserve It?</h2>
+              <p className="mt-3 text-stone-warm leading-relaxed">
+                AI tools often damage ATS readability when the prompt asks for a visually
+                impressive resume. The risk is not the words; it is the formatting the model
+                suggests: tables, columns, icons, rating bars, decorative bullets, text boxes,
+                and keyword stuffing. For ATS-safe output, ask for plain text bullets, a
+                separate skills list, no columns, no graphics, no hidden text, and no keyword
+                unless it is supported by the source material.
+              </p>
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                {ATS_ROWS.map((row) => (
+                  <article key={row.provider} className="bg-white rounded-2xl p-5 shadow-premium border border-black/[0.04]">
+                    <h3 className="font-display text-xl font-bold text-ink">{row.provider}: {row.rating}</h3>
+                    <p className="mt-2 text-stone-warm leading-relaxed">{row.note}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </RevealSection>
+
+          <RevealSection variant="fade-up">
+            <section>
+              <SectionEyebrow>Long Resume Handling</SectionEyebrow>
+              <h2 id="token-limits-long-resumes" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Token Limits for Long Resumes</h2>
+              <p className="mt-3 text-stone-warm leading-relaxed">
+                A two-page resume plus a job description is usually small enough for modern
+                AI tools. Problems start when you paste a full career history, portfolio
+                notes, multiple job descriptions, and a long chat history into the same
+                conversation. Published API context windows are useful reference points, but
+                consumer chat products can apply different limits, rolling context, file
+                handling, or model routing.
+              </p>
+              <div className="mt-6 overflow-x-auto rounded-2xl shadow-premium bg-white">
+                <table
+                  aria-label="AI resume token limits by provider"
+                  className="w-full min-w-[860px] border-collapse text-sm"
+                >
+                  <thead className="bg-chalk-dark text-left text-ink">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 font-bold">Provider</th>
+                      <th scope="col" className="px-4 py-3 font-bold">Published context detail</th>
+                      <th scope="col" className="px-4 py-3 font-bold">Resume workflow guidance</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TOKEN_ROWS.map((row, idx) => (
+                      <tr key={row.provider} className={`border-t border-black/[0.04] ${idx % 2 === 1 ? "bg-chalk/40" : ""}`}>
+                        <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.provider}</th>
+                        <td className="px-4 py-3 text-ink/85">{row.limit}</td>
+                        <td className="px-4 py-3 text-ink/85">{row.resumeUse}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </section>
           </RevealSection>
 

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -413,7 +413,7 @@ export default function AIResumePromptsHub() {
             </p>
             <Link
               to="/templates"
-              className="mt-4 inline-flex rounded-md bg-accent px-4 py-2 font-bold text-white hover:bg-accent/90"
+              className="btn-primary mt-4 px-8 py-3.5"
             >
               Browse resume templates
             </Link>

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -37,41 +37,49 @@ function SectionEyebrow({ children }: { children: string }) {
 
 const HUB_FAQS = [
   {
+    id: "faq-best-free-ai-2026",
     question: "What's the best free AI for resume writing in 2026?",
     answer:
       "Claude and Google Gemini both have generous free tiers and produce strong resume output in our review. ChatGPT's free tier is more limited for long-context inputs. For pure prompt quality on rewriting work, Claude is consistently the best free option as of 2026-05.",
   },
   {
+    id: "faq-chatgpt-vs-claude",
     question: "ChatGPT vs Claude for resume writing - which is better?",
     answer:
       "Claude tends to produce more polished prose with better quantification of achievements; ChatGPT is faster and better at strict formatting, such as bulleted lists with exact word counts. For experience-bullet rewriting and professional summary work, Claude is stronger. For high-volume drafting, ChatGPT is faster.",
   },
   {
+    id: "faq-is-gemini-good-for-resume",
     question: "Is Gemini good for resume writing?",
     answer:
       "Yes, particularly for tailoring a resume to a specific job description. Gemini's Google integration makes it useful for job-description context and role-specific language. It is a strong pick for JD-tailoring workflows. For pure rewriting it is solid but slightly behind Claude and ChatGPT.",
   },
   {
+    id: "faq-grok-or-deepseek-for-resume",
     question: "Can I use Grok or DeepSeek for resume writing?",
     answer:
       "Yes, but with caveats. Grok is fast and free but produces more generic output, so it is better for first drafts than finishing work. DeepSeek is inexpensive through common aggregator workflows, but its instruction-following on specific resume formats can be weaker. Use them for high-volume initial drafts you will refine elsewhere.",
   },
   {
+    id: "faq-best-ats-keyword-extraction",
     question: "Which AI handles ATS keyword extraction best?",
     answer:
       "Claude, ChatGPT, and Gemini are roughly equivalent on ATS keyword analysis when given a job description and a target resume. Grok and Copilot are usable but produce less reliable keyword priority ranking. For final ATS work, pair any of the top three with our free ATS keyword scanner.",
   },
   {
+    id: "faq-do-i-need-to-pay",
     question: "Do I need to pay to use AI for resume writing?",
     answer:
       "No. The free tiers of Claude, Gemini, and Copilot are sufficient for most resume writing. ChatGPT's free tier works for shorter tasks. Paid tiers are mainly useful for very high volume, longer context windows, team controls, or specific integrations.",
   },
   {
+    id: "faq-is-it-safe-to-put-resume-in-ai",
     question: "Is it safe to put my resume into an AI tool?",
     answer:
       "Privacy varies by tool. Claude.ai offers data controls, ChatGPT includes data controls, and Gemini privacy depends on the edition and account type. Strip PII such as full name, address, phone, and email before pasting resume content into any free AI tier if privacy matters.",
   },
   {
+    id: "faq-best-prompt-structure",
     question: "What's the best prompt structure for AI resume writing?",
     answer:
       "Three elements every prompt needs: the target role and job description, the current resume content or section, and an explicit output format such as bullet count, word count, and tone. Without these details the AI produces generic output. See our Claude and Gemini guides for tested prompt templates.",
@@ -266,12 +274,18 @@ export default function AIResumePromptsHub() {
         <div className="space-y-10">
           <section className="relative bg-white rounded-2xl shadow-premium card-gradient-border p-6 md:p-8 border-l-4 border-accent">
             <SectionEyebrow>The Short Answer</SectionEyebrow>
+            <time
+              dateTime={REVIEW_DATE}
+              className="font-mono text-[11px] tracking-[0.15em] text-mist uppercase block mb-3"
+            >
+              Last reviewed {REVIEW_DATE} · Refresh cadence: Quarterly
+            </time>
             <p className="text-base md:text-lg leading-relaxed text-ink/90">
               <strong>Short answer:</strong> For resume writing in 2026, Claude and ChatGPT
               produce the strongest output for rewriting bullets and crafting summaries. Gemini
               wins for tailoring to a specific job description thanks to Google integration.
               Grok and Copilot are fast and free but more generic. DeepSeek is cheapest but
-              limited. Choose based on your task and privacy preferences. Last reviewed {REVIEW_DATE}.
+              limited. Choose based on your task and privacy preferences.
             </p>
           </section>
 
@@ -445,6 +459,7 @@ export default function AIResumePromptsHub() {
                 {HUB_FAQS.map((faq) => (
                   <details
                     key={faq.question}
+                    id={faq.id}
                     className="group rounded-2xl border border-black/[0.06] bg-white px-5 py-4 hover:border-accent/30 transition-colors duration-200"
                   >
                     <summary className="cursor-pointer list-none flex items-start justify-between gap-4">

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -292,7 +292,7 @@ export default function AIResumePromptsHub() {
           <RevealSection variant="fade-up">
             <section>
               <SectionEyebrow>Tool × Use Case</SectionEyebrow>
-              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
+              <h2 id="comparison" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts Comparison</h2>
               <div className="mt-6 overflow-x-auto rounded-2xl shadow-premium bg-white">
                 <table
                   aria-label="AI resume prompts comparison"
@@ -332,7 +332,7 @@ export default function AIResumePromptsHub() {
             <section className="grid md:grid-cols-[1fr_2fr] gap-6 md:gap-10 items-start">
               <div>
                 <SectionEyebrow>Methodology</SectionEyebrow>
-                <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
+                <h2 id="methodology" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">How We Reviewed These AIs</h2>
               </div>
               <p className="md:mt-9 leading-relaxed text-stone-warm">
                 <strong>How we reviewed:</strong> We compared the six tools against common
@@ -371,7 +371,7 @@ export default function AIResumePromptsHub() {
             <section className="space-y-6">
               <div>
                 <SectionEyebrow>Prompts by Tool</SectionEyebrow>
-                <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
+                <h2 id="prompts-by-tool" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Best AI Resume Prompts by Tool</h2>
               </div>
               {MODEL_SECTIONS.map((model, idx) => (
                 <article
@@ -409,7 +409,7 @@ export default function AIResumePromptsHub() {
           <RevealSection variant="fade-up">
             <section>
               <SectionEyebrow>Keep Reading</SectionEyebrow>
-              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
+              <h2 id="related-resources" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Related Resume AI Resources</h2>
               <div className="mt-6 grid gap-3 sm:grid-cols-2">
                 {INTERNAL_LINKS.map((link) => (
                   <Link
@@ -428,7 +428,7 @@ export default function AIResumePromptsHub() {
           <RevealSection variant="fade-in">
             <section>
               <SectionEyebrow>Sources</SectionEyebrow>
-              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
+              <h2 id="provider-references" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">Provider References</h2>
               <p className="mt-3 text-stone-warm leading-relaxed">
                 Use provider documentation and account settings before pasting sensitive resume data
                 into any AI tool.
@@ -454,7 +454,7 @@ export default function AIResumePromptsHub() {
           <RevealSection variant="fade-up">
             <section>
               <SectionEyebrow>Questions</SectionEyebrow>
-              <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
+              <h2 id="faq" className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink">AI Resume Prompts FAQ</h2>
               <div className="mt-6 space-y-3">
                 {HUB_FAQS.map((faq) => (
                   <details

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -3,6 +3,29 @@ import BlogLayout from "../BlogLayout";
 
 const REVIEW_DATE = "2026-05-13";
 
+const PROVIDERS = ["Claude", "ChatGPT", "Gemini", "Grok", "Copilot", "DeepSeek"] as const;
+type Provider = (typeof PROVIDERS)[number];
+type Rating = 1 | 2 | 3 | 4 | 5;
+type RatingRow = { kind: "rating"; useCase: string; cells: Record<Provider, Rating> };
+type TextRow = { kind: "text"; useCase: string; cells: Record<Provider, string> };
+type ComparisonRow = RatingRow | TextRow;
+
+function StarRating({ value }: { value: Rating }) {
+  return (
+    <span
+      role="img"
+      aria-label={`${value} out of 5`}
+      className="inline-flex gap-0.5 text-base leading-none"
+    >
+      {Array.from({ length: 5 }, (_, i) => (
+        <span key={i} className={i < value ? "text-accent" : "text-black/15"} aria-hidden="true">
+          ★
+        </span>
+      ))}
+    </span>
+  );
+}
+
 const HUB_FAQS = [
   {
     question: "What's the best free AI for resume writing in 2026?",
@@ -46,78 +69,60 @@ const HUB_FAQS = [
   },
 ];
 
-const COMPARISON_ROWS = [
+const COMPARISON_ROWS: ComparisonRow[] = [
   {
+    kind: "rating",
     useCase: "Rewriting experience bullets",
-    Claude: "★★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★",
-    Grok: "★★★",
-    Copilot: "★★★",
-    DeepSeek: "★★",
+    cells: { Claude: 5, ChatGPT: 4, Gemini: 3, Grok: 3, Copilot: 3, DeepSeek: 2 },
   },
   {
+    kind: "rating",
     useCase: "Writing a professional summary",
-    Claude: "★★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★★",
-    Grok: "★★★",
-    Copilot: "★★★",
-    DeepSeek: "★★★",
+    cells: { Claude: 5, ChatGPT: 4, Gemini: 4, Grok: 3, Copilot: 3, DeepSeek: 3 },
   },
   {
+    kind: "rating",
     useCase: "Tailoring resume to a JD",
-    Claude: "★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★★★",
-    Grok: "★★★",
-    Copilot: "★★★",
-    DeepSeek: "★★",
+    cells: { Claude: 4, ChatGPT: 4, Gemini: 5, Grok: 3, Copilot: 3, DeepSeek: 2 },
   },
   {
+    kind: "rating",
     useCase: "Quantifying achievements",
-    Claude: "★★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★",
-    Grok: "★★★",
-    Copilot: "★★",
-    DeepSeek: "★★",
+    cells: { Claude: 5, ChatGPT: 4, Gemini: 3, Grok: 3, Copilot: 2, DeepSeek: 2 },
   },
   {
+    kind: "rating",
     useCase: "ATS keyword extraction",
-    Claude: "★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★★",
-    Grok: "★★★",
-    Copilot: "★★★",
-    DeepSeek: "★★",
+    cells: { Claude: 4, ChatGPT: 4, Gemini: 4, Grok: 3, Copilot: 3, DeepSeek: 2 },
   },
   {
+    kind: "rating",
     useCase: "Cover letter drafts",
-    Claude: "★★★★★",
-    ChatGPT: "★★★★",
-    Gemini: "★★★★",
-    Grok: "★★★",
-    Copilot: "★★★",
-    DeepSeek: "★★★",
+    cells: { Claude: 5, ChatGPT: 4, Gemini: 4, Grok: 3, Copilot: 3, DeepSeek: 3 },
   },
   {
+    kind: "text",
     useCase: "Free tier availability",
-    Claude: "Yes",
-    ChatGPT: "Limited",
-    Gemini: "Yes",
-    Grok: "Yes",
-    Copilot: "Yes",
-    DeepSeek: "Yes",
+    cells: {
+      Claude: "Yes",
+      ChatGPT: "Limited",
+      Gemini: "Yes",
+      Grok: "Yes",
+      Copilot: "Yes",
+      DeepSeek: "Yes",
+    },
   },
   {
+    kind: "text",
     useCase: "Privacy / no training on your input",
-    Claude: "Claude.ai opt-out",
-    ChatGPT: "Data controls",
-    Gemini: "Workspace edition",
-    Grok: "Limited controls",
-    Copilot: "Commercial controls",
-    DeepSeek: "Limited controls",
+    cells: {
+      Claude: "Claude.ai opt-out",
+      ChatGPT: "Data controls",
+      Gemini: "Workspace edition",
+      Grok: "Limited controls",
+      Copilot: "Commercial controls",
+      DeepSeek: "Limited controls",
+    },
   },
 ];
 
@@ -270,24 +275,22 @@ export default function AIResumePromptsHub() {
                 <thead className="bg-chalk-dark text-left text-ink">
                   <tr>
                     <th scope="col" className="px-4 py-3 font-bold">Use case</th>
-                    <th scope="col" className="px-4 py-3 font-bold">Claude</th>
-                    <th scope="col" className="px-4 py-3 font-bold">ChatGPT</th>
-                    <th scope="col" className="px-4 py-3 font-bold">Gemini</th>
-                    <th scope="col" className="px-4 py-3 font-bold">Grok</th>
-                    <th scope="col" className="px-4 py-3 font-bold">Copilot</th>
-                    <th scope="col" className="px-4 py-3 font-bold">DeepSeek</th>
+                    {PROVIDERS.map((provider) => (
+                      <th key={provider} scope="col" className="px-4 py-3 font-bold">{provider}</th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>
                   {COMPARISON_ROWS.map((row) => (
                     <tr key={row.useCase} className="border-t border-black/[0.06]">
                       <th scope="row" className="px-4 py-3 text-left font-semibold text-ink">{row.useCase}</th>
-                      <td className="px-4 py-3 text-stone-warm">{row.Claude}</td>
-                      <td className="px-4 py-3 text-stone-warm">{row.ChatGPT}</td>
-                      <td className="px-4 py-3 text-stone-warm">{row.Gemini}</td>
-                      <td className="px-4 py-3 text-stone-warm">{row.Grok}</td>
-                      <td className="px-4 py-3 text-stone-warm">{row.Copilot}</td>
-                      <td className="px-4 py-3 text-stone-warm">{row.DeepSeek}</td>
+                      {PROVIDERS.map((provider) => (
+                        <td key={provider} className="px-4 py-3 text-ink/85">
+                          {row.kind === "rating"
+                            ? <StarRating value={row.cells[provider]} />
+                            : row.cells[provider]}
+                        </td>
+                      ))}
                     </tr>
                   ))}
                 </tbody>

--- a/resume-builder-ui/src/components/blog/AIResumeReview.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumeReview.tsx
@@ -298,8 +298,8 @@ export default function AIResumeReview() {
 
         <ul className="list-disc list-inside space-y-2 text-lg text-stone-warm">
           <li>
-            <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">
-              25+ ChatGPT Prompts for Resume Writing
+            <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">
+              AI Resume Prompts Hub — Compare All Tools
             </Link>
           </li>
           <li>

--- a/resume-builder-ui/src/components/blog/AIResumeWritingGuide.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumeWritingGuide.tsx
@@ -404,8 +404,8 @@ export default function AIResumeWritingGuide() {
 
         <ul className="list-disc list-inside space-y-2 text-lg text-stone-warm">
           <li>
-            <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">
-              25+ ChatGPT Prompts for Resume Writing
+            <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">
+              AI Resume Prompts Hub — Compare All Tools
             </Link>
           </li>
           <li>

--- a/resume-builder-ui/src/components/blog/ChatGPTResumePrompts.tsx
+++ b/resume-builder-ui/src/components/blog/ChatGPTResumePrompts.tsx
@@ -444,6 +444,10 @@ export default function ChatGPTResumePrompts() {
               <h3 className="font-bold text-ink mb-1">Copilot Prompts</h3>
               <p className="text-sm text-stone-warm">Best for Microsoft 365 integration and Word users</p>
             </Link>
+            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
+              <p className="text-sm text-stone-warm">All six AI tools compared — pick the right one for bullets, summaries, ATS keywords, and cover letters</p>
+            </Link>
           </div>
         </div>
 

--- a/resume-builder-ui/src/components/blog/ClaudeResumePrompts.tsx
+++ b/resume-builder-ui/src/components/blog/ClaudeResumePrompts.tsx
@@ -625,7 +625,7 @@ export default function ClaudeResumePrompts() {
             Use <strong>Claude for writing and tailoring</strong> (summaries, bullets, cover letters, career change narratives) where tone and nuance matter most. Use <strong>ChatGPT for analysis tasks</strong> (keyword extraction, ATS scanning, formatting checks) where speed matters more than prose quality. Or use both — many successful job seekers draft with Claude and verify with ChatGPT.
           </p>
           <p className="text-ink/80 mt-3">
-            Want ChatGPT-specific prompts? See our <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline font-medium">25+ ChatGPT prompts for resume writing</Link>.
+            Want prompts for other AI tools? See our <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline font-medium">AI Resume Prompts Hub</Link>.
           </p>
         </div>
 
@@ -686,29 +686,17 @@ export default function ClaudeResumePrompts() {
           <h2 className="text-2xl font-bold text-ink mb-2">Explore Other AI Resume Tools</h2>
           <p className="text-stone-warm font-extralight mb-6">Each AI has different strengths for resume writing. Try multiple tools to find what works best for you.</p>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Link to="/blog/chatgpt-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">ChatGPT Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for creative writing and natural language</p>
+            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
+              <p className="text-sm text-stone-warm">Compare all AI tools side by side</p>
             </Link>
             <Link to="/blog/gemini-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
               <h3 className="font-bold text-ink mb-1">Gemini Resume Prompts</h3>
               <p className="text-sm text-stone-warm">Best for research and Google ecosystem integration</p>
             </Link>
-            <Link to="/blog/grok-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">Grok Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for conversational iteration and real-time feedback</p>
-            </Link>
-            <Link to="/blog/deepseek-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">DeepSeek Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for technical roles and coding resumes</p>
-            </Link>
-            <Link to="/blog/copilot-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">Copilot Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for Microsoft 365 integration and Word users</p>
-            </Link>
-            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
-              <p className="text-sm text-stone-warm">Compare all six tools side by side — ratings, prompts, and use-case picks in one place</p>
+            <Link to="/blog/ai-cover-letter-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Cover Letter Prompts</h3>
+              <p className="text-sm text-stone-warm">Prompts for writing tailored cover letters</p>
             </Link>
           </div>
         </div>
@@ -734,8 +722,8 @@ export default function ClaudeResumePrompts() {
 
         <ul className="list-disc list-inside space-y-2 text-lg text-stone-warm">
           <li>
-            <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">
-              25+ ChatGPT Prompts for Resume Writing
+            <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">
+              AI Resume Prompts Hub — Compare All Tools
             </Link>
           </li>
           <li>
@@ -746,11 +734,6 @@ export default function ClaudeResumePrompts() {
           <li>
             <Link to="/blog/gemini-resume-prompts" className="text-accent hover:underline">
               Gemini Prompts for Resume Writing
-            </Link>
-          </li>
-          <li>
-            <Link to="/blog/grok-resume-prompts" className="text-accent hover:underline">
-              Grok AI Prompts for Resume Writing
             </Link>
           </li>
           <li>

--- a/resume-builder-ui/src/components/blog/ClaudeResumePrompts.tsx
+++ b/resume-builder-ui/src/components/blog/ClaudeResumePrompts.tsx
@@ -706,6 +706,10 @@ export default function ClaudeResumePrompts() {
               <h3 className="font-bold text-ink mb-1">Copilot Resume Prompts</h3>
               <p className="text-sm text-stone-warm">Best for Microsoft 365 integration and Word users</p>
             </Link>
+            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
+              <p className="text-sm text-stone-warm">Compare all six tools side by side — ratings, prompts, and use-case picks in one place</p>
+            </Link>
           </div>
         </div>
 

--- a/resume-builder-ui/src/components/blog/GeminiResumePrompts.tsx
+++ b/resume-builder-ui/src/components/blog/GeminiResumePrompts.tsx
@@ -214,29 +214,17 @@ export default function GeminiResumePrompts() {
           <h2 className="text-2xl font-bold text-ink mb-2">Explore Other AI Resume Tools</h2>
           <p className="text-stone-warm font-extralight mb-6">Each AI has different strengths for resume writing. Try multiple tools to find what works best for you.</p>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Link to="/blog/chatgpt-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">ChatGPT Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for creative writing and natural language</p>
+            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
+              <p className="text-sm text-stone-warm">Compare all AI tools side by side</p>
             </Link>
             <Link to="/blog/claude-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
               <h3 className="font-bold text-ink mb-1">Claude Resume Prompts</h3>
               <p className="text-sm text-stone-warm">Best for analysis, structured output, and nuance</p>
             </Link>
-            <Link to="/blog/grok-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">Grok Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for conversational iteration and real-time feedback</p>
-            </Link>
-            <Link to="/blog/deepseek-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">DeepSeek Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for technical roles and coding resumes</p>
-            </Link>
-            <Link to="/blog/copilot-resume-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">Copilot Resume Prompts</h3>
-              <p className="text-sm text-stone-warm">Best for Microsoft 365 integration and Word users</p>
-            </Link>
-            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
-              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
-              <p className="text-sm text-stone-warm">Side-by-side comparison of Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume tasks</p>
+            <Link to="/blog/ai-cover-letter-prompts" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Cover Letter Prompts</h3>
+              <p className="text-sm text-stone-warm">Prompts for writing tailored cover letters</p>
             </Link>
           </div>
         </div>
@@ -262,8 +250,8 @@ export default function GeminiResumePrompts() {
 
         <ul className="list-disc list-inside space-y-2 text-lg text-stone-warm">
           <li>
-            <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">
-              25+ ChatGPT Prompts for Resume Writing
+            <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">
+              AI Resume Prompts Hub — Compare All Tools
             </Link>
           </li>
           <li>

--- a/resume-builder-ui/src/components/blog/GeminiResumePrompts.tsx
+++ b/resume-builder-ui/src/components/blog/GeminiResumePrompts.tsx
@@ -234,6 +234,10 @@ export default function GeminiResumePrompts() {
               <h3 className="font-bold text-ink mb-1">Copilot Resume Prompts</h3>
               <p className="text-sm text-stone-warm">Best for Microsoft 365 integration and Word users</p>
             </Link>
+            <Link to="/blog/ai-resume-prompts-hub" className="bg-chalk-dark rounded-xl p-5 hover:bg-white hover:shadow-lg transition-all duration-300 border border-transparent hover:border-black/[0.04]">
+              <h3 className="font-bold text-ink mb-1">AI Resume Prompts Hub</h3>
+              <p className="text-sm text-stone-warm">Side-by-side comparison of Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume tasks</p>
+            </Link>
           </div>
         </div>
 

--- a/resume-builder-ui/src/components/blog/ZetyVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/ZetyVsEasyFreeResume.tsx
@@ -298,10 +298,10 @@ export default function ZetyVsEasyFreeResume() {
                   </Link>{" "}
                   or{" "}
                   <Link
-                    to="/blog/chatgpt-resume-prompts"
+                    to="/blog/ai-resume-prompts-hub"
                     className="text-accent underline"
                   >
-                    ChatGPT Resume Prompts
+                    AI Resume Prompts
                   </Link>
                   ) to write compelling, personalized content.
                 </p>

--- a/resume-builder-ui/src/components/seo/AIResumeBuilderFree.tsx
+++ b/resume-builder-ui/src/components/seo/AIResumeBuilderFree.tsx
@@ -109,8 +109,8 @@ export default function AIResumeBuilderFree() {
               <strong className="text-ink">Best for:</strong> Writing bullet points, professional summaries, cover letters, and tailoring content to specific job descriptions.
             </p>
             <div className="flex flex-wrap gap-4">
-              <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline font-medium">
-                ChatGPT resume prompts guide →
+              <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline font-medium">
+                AI resume prompts hub →
               </Link>
               <Link to="/blog/ai-cover-letter-prompts" className="text-accent hover:underline font-medium">
                 AI cover letter prompts →
@@ -213,9 +213,9 @@ export default function AIResumeBuilderFree() {
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
             {[
               {
-                title: 'ChatGPT Resume Prompts',
-                desc: '30+ copy-paste prompts to write bullet points, summaries, and cover letters with ChatGPT.',
-                href: '/blog/chatgpt-resume-prompts',
+                title: 'AI Resume Prompts Hub',
+                desc: '30+ copy-paste prompts for ChatGPT, Claude, Gemini, and more — compared side by side.',
+                href: '/blog/ai-resume-prompts-hub',
               },
               {
                 title: 'Claude Resume Prompts',

--- a/resume-builder-ui/src/components/seo/BestFreeResumeBuilderReddit.tsx
+++ b/resume-builder-ui/src/components/seo/BestFreeResumeBuilderReddit.tsx
@@ -303,7 +303,7 @@ export default function BestFreeResumeBuilderReddit() {
           <div className="bg-white rounded-2xl p-6 shadow-premium border-l-4 border-accent">
             <h3 className="font-display text-lg font-bold text-ink mb-2">Use AI to polish, not to write</h3>
             <p className="text-stone-warm text-sm leading-relaxed">
-              Reddit is split on AI resumes. The consensus: use <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">ChatGPT</Link> or <Link to="/blog/claude-resume-prompts" className="text-accent hover:underline">Claude</Link> to refine wording, but write the core content yourself. Recruiters can detect fully AI-generated resumes.
+              Reddit is split on AI resumes. The consensus: use <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">AI tools like ChatGPT or Claude</Link> to refine wording, but write the core content yourself. Recruiters can detect fully AI-generated resumes.
             </p>
           </div>
           <div className="bg-white rounded-2xl p-6 shadow-premium border-l-4 border-accent">

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
@@ -349,7 +349,7 @@ export default function FreeResumeBuilderNoSignUp() {
           <div className="bg-white rounded-2xl p-6 shadow-premium border-l-4 border-accent">
             <h3 className="font-display text-lg font-bold text-ink mb-2">Use AI to polish, not to write from scratch</h3>
             <p className="text-stone-warm text-sm leading-relaxed">
-              AI tools like <Link to="/blog/chatgpt-resume-prompts" className="text-accent hover:underline">ChatGPT</Link> and <Link to="/blog/claude-resume-prompts" className="text-accent hover:underline">Claude</Link> are
+              AI tools like <Link to="/blog/ai-resume-prompts-hub" className="text-accent hover:underline">ChatGPT, Claude, and Gemini</Link> are
               great for refining your resume language, but start with your own content. Recruiters can spot entirely AI-generated resumes.
             </p>
           </div>

--- a/resume-builder-ui/src/config/seoPages.ts
+++ b/resume-builder-ui/src/config/seoPages.ts
@@ -1602,7 +1602,7 @@ export const SEO_PAGES: Record<string, PageConfig> = {
       description:
         'Use the most powerful AI models — ChatGPT, Claude, and Gemini — alongside our free resume builder. Get AI-written bullet points, keyword optimization, and professional formatting without paying a cent.',
       primaryCTA: { text: 'Build My AI Resume', href: '/templates' },
-      secondaryCTA: { text: 'See AI Prompts', href: '/blog/chatgpt-resume-prompts', variant: 'outline' },
+      secondaryCTA: { text: 'See AI Prompts', href: '/blog/ai-resume-prompts-hub', variant: 'outline' },
     },
     steps: [
       { number: 1, title: 'Choose Your AI', description: 'Pick from ChatGPT, Claude, or Gemini. Each has unique strengths for different resume tasks — or use all three.' },

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -15,14 +15,6 @@ export interface BlogPost {
 export const blogPosts: BlogPost[] = [
   // New AI Blog Content (Featured)
   {
-    slug: "chatgpt-resume-prompts",
-    title: "25+ ChatGPT Prompts for Resume Writing (Copy & Paste Ready)",
-    description: "Get the best ChatGPT prompts for writing resume summaries, experience bullets, skills sections, and more. Copy-paste ready prompts that actually work in 2026.",
-    publishDate: "2026-01-21",
-    readTime: "12 min",
-    category: "AI & Tools",
-  },
-  {
     slug: "ai-resume-prompts-hub",
     title: "AI Resume Prompts Hub: Best Prompts for ChatGPT, Claude, Gemini & More",
     description: "Compare Claude, ChatGPT, Gemini, Grok, Copilot, and DeepSeek for resume writing. Pick the best AI prompt for bullets, summaries, ATS keywords, and cover letters.",
@@ -57,14 +49,6 @@ export const blogPosts: BlogPost[] = [
     category: "AI & Tools",
   },
   {
-    slug: "grok-resume-prompts",
-    title: "Grok AI Prompts for Resume Writing (2026)",
-    description: "Use Grok AI (xAI) for fast resume writing with a conversational approach. Best prompts for quick iterations and real-time resume feedback.",
-    publishDate: "2026-01-21",
-    readTime: "7 min",
-    category: "AI & Tools",
-  },
-  {
     slug: "return-to-work-programs",
     title: "Return to Work Programs: 13 Top Companies Hiring Career Returners (2026)",
     description: "Return to work programs and returnships at JP Morgan, Goldman Sachs, Amazon, Microsoft, Meta, and more. Paid programs, eligibility, how to apply, and resume tips for career returners.",
@@ -94,22 +78,6 @@ export const blogPosts: BlogPost[] = [
     description: "AI cover letter prompts that actually work: tailored cover letters, opening hooks, career changes, follow-ups, and thank-you notes. Copy-paste ready for ChatGPT, Claude, Copilot, and Gemini.",
     publishDate: "2026-03-05",
     readTime: "16 min",
-    category: "AI & Tools",
-  },
-  {
-    slug: "copilot-resume-prompts",
-    title: "20+ Microsoft Copilot Prompts for Resume Writing (2026)",
-    description: "Best Microsoft Copilot prompts for resume writing: professional summaries, experience bullets, ATS keywords, skills, and cover letters. Copy-paste ready for Copilot in Bing, Edge, and Microsoft 365.",
-    publishDate: "2026-03-05",
-    readTime: "14 min",
-    category: "AI & Tools",
-  },
-  {
-    slug: "deepseek-resume-prompts",
-    title: "20+ DeepSeek Prompts for Resume Writing (Copy & Paste Ready) 2026",
-    description: "Best DeepSeek prompts for resume writing: professional summaries, experience bullets, ATS keywords, skills optimization, and cover letters. Copy-paste ready for DeepSeek V3 and R1.",
-    publishDate: "2026-03-05",
-    readTime: "14 min",
     category: "AI & Tools",
   },
   {

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -92,16 +92,12 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/quantify-resume-accomplishments', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
 
   // New AI Blog Posts (0.5) - recently created
-  { loc: '/blog/chatgpt-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-17' },
+  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-25' },
   { loc: '/blog/ai-resume-writing-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/claude-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-17' },
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/grok-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/ai-job-description-analyzer', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/ai-resume-review', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
-  { loc: '/blog/deepseek-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/copilot-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/ai-cover-letter-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
   { loc: '/blog/career-change-resume-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
   { loc: '/blog/resume-employment-gaps', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -93,7 +93,7 @@ export const STATIC_URLS: SitemapUrl[] = [
 
   // New AI Blog Posts (0.5) - recently created
   { loc: '/blog/chatgpt-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-13' },
+  { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-17' },
   { loc: '/blog/ai-resume-writing-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/claude-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-17' },
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -712,6 +712,16 @@ footer {
   color: inherit;
 }
 
+/* Design-system .btn-primary must keep its ink color inside .prose.
+   Without this, .prose a { color: #00d47e } wins by specificity (0,1,1)
+   over Tailwind's text-ink utility (0,1,0), making the button text
+   invisible (green-on-green). */
+.prose a.btn-primary,
+.prose a.btn-primary:hover {
+  color: #0c0c0c;
+  text-decoration: none;
+}
+
 /* Mobile-optimized blog tables */
 @media (max-width: 639px) {
   .prose table th,


### PR DESCRIPTION
## Summary

First enhancement pass for `/blog/ai-resume-prompts-hub` (newly shipped via #526). **Visual quality only** — no copy edits, no schema cardinality change. Content enrichment (per-section answer blocks + atomicized FAQ answers) is held for **PR B**, shipping ≥48h after this PR lands cleanly in dev, so GSC impression movement can be attributed cleanly to either bucket.

Chained off `release/post-cliff-bundle` per PR-chain pattern.

## What's in this PR

### Two confirmed visible bugs fixed (atomic, in order)

**1. `fix(blog): repair invisible CTA on AI prompts hub (prose cascade)`** — `9f82ff24`

The dark-CTA `<Link>` rendered as green text on a green button — invisible. The real root cause was **selector specificity**, not the local className cocktail: `BlogLayout` wraps blog children in `<div className="prose prose-lg">`, and `styles.css:694` declares `.prose a { color: #00d47e }`. That rule (0,1,1) beats every Tailwind `text-X` utility (0,1,0), so even `text-white` / `text-ink` lose to the prose rule. The existing dark-CTA escape hatch at `styles.css:706` covers `h2/h3/h4/p/li` inside `.prose .text-white` but not `a`.

- Replaced the bespoke className with the design-system `.btn-primary` (per CLAUDE.md mandate for primary CTAs).
- Added a `.prose a.btn-primary` color override in `styles.css` so the design-system class always wins inside blog prose. Defence-in-depth for any future `.btn-primary` placed inside a `BlogLayout` child.

Browser-verified: `computed color rgb(12, 12, 12)` on `backgroundColor rgb(0, 212, 126)` over `ancestor bg rgb(12, 12, 12)`. WCAG AA pass.

**2. `fix(blog): render comparison ratings as filled+empty stars`** — `8f570761`

The `<td>` inherited `text-stone-warm` (#8a8680) onto pre-formed `★★★★★` glyph strings, muting the rating into an unscannable grey blob. Mixed-data complication: rows 1–6 are ratings; rows 7–8 are text (Yes / Limited, privacy notes).

- `COMPARISON_ROWS` migrated to a discriminated union (`kind: "rating"` rows carry 1–5 numerics; `kind: "text"` rows keep strings).
- New `StarRating` helper renders 5 glyphs total — accent-filled + `text-black/15` empty — wrapped in `<span role="img" aria-label="N out of 5">` so screen readers announce the value **once**, not five times.
- New `PROVIDERS` const drives both the column headers and the per-row iteration so ordering is explicit.

Test updated to assert 36 `[role="img"][aria-label*="out of 5"]` cells (6 rating rows × 6 providers) and that no raw `★★★★★` string text remains. The existing 9-row count, scope attributes, and use-case label assertions all hold.

### Design-system migration (LandingPage 2026 recipe)

**3. `style(blog): apply 2026 design system to AI prompts hub`** — `751515ec`

Per the `frontend-design` skill audit, applied per-section deltas against `LandingPage.tsx` as the reference implementation:

- **Answer-first intro:** lifted to `bg-white rounded-2xl shadow-premium card-gradient-border` with an accent-mono "THE SHORT ANSWER" eyebrow. No reveal wrapper (above-fold).
- **Comparison table:** `rounded-2xl shadow-premium` wrapper, `bg-chalk/40` zebra stripes, "TOOL × USE CASE" eyebrow, lighter `black/[0.04]` dividers.
- **"How we reviewed":** 2-column layout (H2 left, methodology right) + a 3-card "Best for X" row using `card-gradient-border` + `shadow-premium-hover` + hover lift.
- **6 per-tool sections:** `rounded-2xl` cards with `shadow-premium` + hover lift, numbered `0X / 06` mono index above each H3, accent-coloured ordered-list markers, arrow glyph on the Claude/Gemini standalone-guide CTAs.
- **Related Resources grid:** `bg-chalk-dark` cards that brighten to white on hover with arrow affordance.
- **Provider References:** mono pill chips with `↗` glyph.
- **FAQ list:** `<details>` / `<summary>` using the existing `details .faq-content` grid-template-rows transition (`0fr → 1fr @ 0.35s cubic-bezier(0.16, 1, 0.3, 1)`). Plus icon rotates to `×` via `group-open:rotate-45`.
- **Final CTA:** LandingPage recipe — `bg-ink rounded-3xl py-16 md:py-20`, radial accent glow (`w-[600px] blur-3xl bg-accent/[0.07]`), accent "Ready?" eyebrow, white headline, body, `.btn-primary`.

Every below-fold section wrapped in `<RevealSection>` (variants: `fade-up`, `fade-in`, `scale-in`). The intro callout renders immediately.

**4. `chore(seo): bump ai-resume-prompts-hub sitemap lastmod to 2026-05-17`** — `660d0d60`

Visible content surface changed → `lastmod` bumped. Companion `seo-tracking/changelog.md` entry recorded locally (dir is gitignored per CLAUDE.md SEO Governance).

## What's NOT in this PR (deferred to PR B)

- **Per-section 40–60 word answer blocks** (Enrichment A from 2026-05-17 Gemini Deep Research).
- **Atomicized FAQ answer prose** preserving 8-FAQ count and question text (Enrichment C).

**Dropped after pushback review** (logged in `seo-tracking/changelog.md`):

- ~~Per-tool "Last verified" markers~~ — six identical dates on the same page-level review date would read as boilerplate honesty-laundering, the same pattern the `33f423ed` dev-meta cleanup eliminated.
- ~~Free-tier monthly-limits comparison row~~ — quarterly drift would silently invalidate the page; only ships with `(as of YYYY-MM)` per-cell qualifier + a calendar reminder to re-verify.

## Iron Rules respected

- [x] No Tier 1 page touched
- [x] No title / H1 / canonical URL changed
- [x] No copy or schema changes (visual quality only)
- [x] FAQ count stays 8; FAQPage schema validates with same 8 entries
- [x] Exactly ONE `Last reviewed 2026-05-13` (page-level); NO `Last verified` markers anywhere
- [x] Exactly ONE `FAQPage` JSON-LD block in prerendered HTML
- [x] No `Last tested` / `Reviewed as` dev-meta strings (prior `33f423ed` cleanup preserved)
- [x] `sameAs` entity URLs unchanged
- [x] No new ad slots introduced

## Test plan

End-to-end verification on `localhost:5173/blog/ai-resume-prompts-hub` via Chrome DevTools MCP at desktop and mobile 375×667:

- [x] `npx vitest run src/__tests__/AIResumePromptsHub.test.tsx` — 4/4 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build:prerender` — succeeds; sitemap regenerates with bumped lastmod
- [x] Comparison table: 36 `span[role="img"][aria-label*="out of 5"]`; 9 rows total; thead 7 `th[scope=col]`, tbody 8 `th[scope=row]`
- [x] Dark CTA: `getComputedStyle(button).color === 'rgb(12, 12, 12)'`, `backgroundColor === 'rgb(0, 212, 126)'`, ancestor bg `rgb(12, 12, 12)` — WCAG AA
- [x] FAQ expand: `<details>` open transitions `grid-template-rows: 0fr → 357.75px` over `0.35s cubic-bezier(0.16, 1, 0.3, 1)`; `+` rotates to `×`
- [x] 7 H2s all carry `font-display text-3xl md:text-4xl font-extrabold tracking-tight` (test contract intact)
- [x] 17 H3s all carry `font-display text-xl font-bold text-ink` (test contract intact)
- [x] 10 `[data-reveal]` elements (8 mine + 2 from BlogLayout)
- [x] Prerendered HTML: 1 `"@type":"FAQPage"`, 1 `Last reviewed`, 0 `Last tested`, 0 `Reviewed as`, btn-primary + rounded-3xl present
- [x] `prefers-reduced-motion: reduce` CSS guard ships in bundle (content visible without animation)
- [x] Mobile 375 renders clean (no body overflow; table uses `overflow-x-auto` as designed for `min-w-[760px]`)
- [ ] **Post-deploy on dev.easyfreeresume.com**: Rich Results Test confirms FAQPage schema validates; spot-check no Lighthouse a11y regressions

## Risk & Rollback

- **Risk:** Low — pure visual refactor. No schema cardinality change, no copy change, no URL change. The `.prose a.btn-primary` CSS override is additive and only kicks in when `.btn-primary` is used inside a `.prose` wrapper, so it can't regress other pages.
- **Monitoring:** Hold PR B for ≥48h after this lands cleanly in dev. Spot-check the dev URL once in that window. Three-week GSC watch after PR B lands; if impressions cross 500 in a 30-day window, graduate to Tier 2 in `protected-pages.md`.
- **Rollback:** Revert this PR. The hub returns to the pre-enhancement layout. The two bug-fix commits (`9f82ff24`, `8f570761`) are independent and could be cherry-picked if the visual revert alone is desired.
