### PR TITLE
🎨 Palette: Add accessible close button to UploadResumeModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Accessible Close Buttons in Dialogs
+**Learning:** Icon-only close buttons in custom modals (like `UploadResumeModal`) often miss `aria-label`, `type="button"`, and explicit focus styling, leading to an inaccessible keyboard and screen reader experience.
+**Action:** Ensure all icon-only modal close buttons use `type="button"`, provide a descriptive `aria-label`, and include `focus-visible:outline-none focus-visible:ring-2` styling.

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -98,8 +98,10 @@ export function UploadResumeModal({
             <h2 className="text-xl font-bold text-white">Upload Resume</h2>
           </div>
           <button
+            type="button"
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            aria-label="Close upload modal"
+            className="text-white/80 hover:text-white transition-colors rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
**What**: Added `aria-label="Close upload modal"`, `type="button"`, and keyboard focus styling (`focus-visible`) to the `UploadResumeModal` close button.
**Why**: Improves screen reader accessibility for icon-only buttons and ensures keyboard users can visually track focus.
**Before/After**: The close button previously had no accessible name or visible focus ring. Now it is clearly identifiable by assistive tech and keyboard navigation.
**Accessibility**: Added descriptive ARIA label, prevented accidental form submission with `type="button"`, and added Tailwind `focus-visible` classes.

---
*PR created automatically by Jules for task [18364583551958395533](https://jules.google.com/task/18364583551958395533) started by @aafre*