### PR TITLE
🎨 Palette: Add accessibility attributes and focus states to SectionEditor controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Explicit button types and focus states in generic editors
+**Learning:** In dynamically generated editor components (like `SectionEditor`), inline action buttons that use emojis or icons often lack `type="button"`, causing unintended form submissions if wrapped in a `<form>` later. Additionally, these custom controls frequently lose default keyboard focus visibility due to Tailwind resets.
+**Action:** Always add `type="button"`, descriptive `aria-label`s, and explicit focus classes (`focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded`) to all custom inline editor controls.

--- a/resume-builder-ui/src/components/SectionEditor.tsx
+++ b/resume-builder-ui/src/components/SectionEditor.tsx
@@ -46,18 +46,22 @@ const SectionEditor: React.FC<{
                 autoFocus
               />
               <button
+                type="button"
                 onClick={handleSaveName}
-                className="ml-2 text-green-500 hover:text-green-600"
+                className="ml-2 text-green-500 hover:text-green-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded p-1"
                 title="Save Section Name"
+                aria-label="Save Section Name"
               >
-                💾
+                <span role="img" aria-hidden="true">💾</span>
               </button>
               <button
+                type="button"
                 onClick={handleCancelEdit}
-                className="ml-2 text-red-500 hover:text-red-600"
+                className="ml-2 text-red-500 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded p-1"
                 title="Cancel Edit"
+                aria-label="Cancel Edit"
               >
-                ❌
+                <span role="img" aria-hidden="true">❌</span>
               </button>
             </>
           ) : (
@@ -65,11 +69,13 @@ const SectionEditor: React.FC<{
               Section: {section.name}
               {!isFixedSection && (
                 <button
+                  type="button"
                   onClick={() => setIsEditingName(true)}
-                  className="ml-2 text-accent hover:text-accent"
+                  className="ml-2 text-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded p-1"
                   aria-label="Edit Section Name"
+                  title="Edit Section Name"
                 >
-                  ✏️
+                  <span role="img" aria-hidden="true">✏️</span>
                 </button>
               )}
             </h2>
@@ -149,12 +155,14 @@ const SectionEditor: React.FC<{
                 placeholder="Enter item text"
               />
               <button
+                type="button"
                 onClick={() => {
                   const updatedSections = [...sections];
                   updatedSections[sectionIndex].content.splice(itemIndex, 1);
                   setSections(updatedSections);
                 }}
-                className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+                className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-1"
+                aria-label={`Remove item ${itemIndex + 1}`}
               >
                 Remove
               </button>
@@ -173,6 +181,7 @@ const SectionEditor: React.FC<{
         )}
         {Array.isArray(section.content) && (
           <button
+            type="button"
             onClick={() => {
               const updatedSections = [...sections];
               updatedSections[sectionIndex].content.push({
@@ -181,7 +190,8 @@ const SectionEditor: React.FC<{
               });
               setSections(updatedSections);
             }}
-            className="bg-accent text-ink px-4 py-2 mt-2 rounded hover:bg-accent"
+            className="bg-accent text-ink px-4 py-2 mt-2 rounded hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            aria-label="Add new item to list"
           >
             Add Item
           </button>


### PR DESCRIPTION
💡 **What:** Added explicit `type="button"`, descriptive `aria-label`s, and focus visibility rings to all action buttons in the `SectionEditor` component. Wrapped emoji icons in spans with `role="img"` and `aria-hidden="true"`.
🎯 **Why:** Prevents accidental form submissions if the editor is ever wrapped in a form, ensures keyboard users can clearly see which control has focus, and provides proper screen reader context for icon-only buttons.
📸 **Before/After:** No visual changes for mouse users; keyboard users now see clear focus rings around interactive elements.
♿ **Accessibility:** Added explicit semantic labeling (`aria-label`) to icon/emoji-only buttons, hid the raw emojis from screen readers to prevent confusing readouts, and improved keyboard navigation visibility with Tailwind's `focus-visible` classes.

---
*PR created automatically by Jules for task [5915761666690341594](https://jules.google.com/task/5915761666690341594) started by @aafre*