### PR TITLE
🎨 Palette: Improve AuthModal accessibility and keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Modal Keyboard Accessibility and Escape Key
+**Learning:** Custom modals like `AuthModal.tsx` initially lacked basic modal behavior traits, such as listening for the `Escape` key and standard ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`). Additionally, the `MdClose` icon buttons in such modals frequently missed keyboard focus styles.
+**Action:** When implementing or updating custom modals, always attach a `keydown` event listener via `useEffect` to handle the `Escape` key for closure. Add `role="dialog"`, `aria-modal="true"`, and link titles using `aria-labelledby`. Ensure all icon-only action buttons use `focus:outline-none focus-visible:ring-2` to provide clear feedback to keyboard users.

--- a/resume-builder-ui/src/components/AuthModal.tsx
+++ b/resume-builder-ui/src/components/AuthModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'react-hot-toast';
@@ -62,6 +62,22 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onSuccess }) => 
     }
   };
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   const modalContent = (
     <div
       className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 overflow-y-auto"
@@ -70,15 +86,18 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onSuccess }) => 
       <div
         className="bg-white rounded-2xl shadow-2xl max-w-md w-full my-auto max-h-[90vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auth-modal-title"
       >
         {/* Header */}
         <div className="bg-ink px-6 py-4 flex items-center justify-between flex-shrink-0 rounded-t-2xl">
-          <h2 className="text-2xl font-bold text-white">Save Your Resume to the Cloud</h2>
+          <h2 id="auth-modal-title" className="text-2xl font-bold text-white">Save Your Resume to the Cloud</h2>
           <button
             onClick={onClose}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-sm"
             disabled={loading}
-            aria-label="Close"
+            aria-label="Close modal"
           >
             <MdClose size={24} />
           </button>


### PR DESCRIPTION
**What**: Added `Escape` key functionality to close the AuthModal, added `role="dialog"` and `aria-modal="true"`, and improved the focus visibility on the close button.
**Why**: To ensure users relying on keyboards and screen readers can properly interact with and dismiss the authentication modal.
**Before/After**: The modal now correctly acts as an accessible dialog and closes on `Escape`. The close button shows a clear focus ring.
**Accessibility**: Added standard dialog ARIA attributes and a visible focus ring to the icon-only close button.

---
*PR created automatically by Jules for task [16116905777940714228](https://jules.google.com/task/16116905777940714228) started by @aafre*