### PR TITLE
fix(blog): copy buttons on prompts hub + numbering fix

### DIFF
--- a/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
+++ b/resume-builder-ui/src/__tests__/AIResumePromptsHub.test.tsx
@@ -150,7 +150,7 @@ describe("AIResumePromptsHub", () => {
       ).toBeInTheDocument();
     });
 
-    expect(container.querySelectorAll("pre code")).toHaveLength(5);
+    expect(screen.getAllByRole("heading", { level: 4, name: "Prompt" })).toHaveLength(5);
     expect(
       screen.getByRole("table", {
         name: /AI resume privacy controls by provider/i,

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
+import CopyablePrompt from "../shared/CopyablePrompt";
 import RevealSection from "../shared/RevealSection";
 
 const REVIEW_DATE = "2026-05-25";
@@ -338,44 +338,6 @@ Do not compliment the draft. Only flag problems and provide the corrected text.`
   },
 ];
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="absolute right-3 top-3 flex items-center gap-1 text-white/50 hover:text-white text-xs font-medium bg-white/10 hover:bg-white/20 px-2.5 py-1.5 rounded-lg transition-colors"
-      aria-label={copied ? "Copied" : "Copy prompt"}
-    >
-      {copied ? (
-        <>
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
-          Copied!
-        </>
-      ) : (
-        <>
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-          </svg>
-          Copy
-        </>
-      )}
-    </button>
-  );
-}
-
 const PRIVACY_ROWS = [
   {
     provider: "Claude",
@@ -608,11 +570,10 @@ export default function AIResumePromptsHub() {
                   <article key={step.title} className="bg-white rounded-2xl p-6 md:p-8 shadow-premium card-gradient-border">
                     <h3 className="font-display text-xl font-bold text-ink">{step.title}</h3>
                     <p className="mt-3 text-stone-warm leading-relaxed">{step.description}</p>
-                    <div className="relative mt-4">
-                      <CopyButton text={step.code} />
-                      <pre className="bg-ink text-white/90 rounded-xl p-4 md:p-6 pr-20 text-sm leading-relaxed overflow-x-auto">
-                        <code>{step.code}</code>
-                      </pre>
+                    <div className="mt-4 not-prose">
+                      <CopyablePrompt title="Prompt" copyText={step.code}>
+                        <span className="whitespace-pre-wrap">{step.code}</span>
+                      </CopyablePrompt>
                     </div>
                   </article>
                 ))}

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -572,7 +572,7 @@ export default function AIResumePromptsHub() {
                     <p className="mt-3 text-stone-warm leading-relaxed">{step.description}</p>
                     <div className="mt-4 not-prose">
                       <CopyablePrompt title="Prompt" copyText={step.code}>
-                        <span className="whitespace-pre-wrap">{step.code}</span>
+                        <code className="whitespace-pre-wrap">{step.code}</code>
                       </CopyablePrompt>
                     </div>
                   </article>

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
 import RevealSection from "../shared/RevealSection";
@@ -337,6 +338,44 @@ Do not compliment the draft. Only flag problems and provide the corrected text.`
   },
 ];
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="absolute right-3 top-3 flex items-center gap-1 text-white/50 hover:text-white text-xs font-medium bg-white/10 hover:bg-white/20 px-2.5 py-1.5 rounded-lg transition-colors"
+      aria-label={copied ? "Copied" : "Copy prompt"}
+    >
+      {copied ? (
+        <>
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          Copied!
+        </>
+      ) : (
+        <>
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+          Copy
+        </>
+      )}
+    </button>
+  );
+}
+
 const PRIVACY_ROWS = [
   {
     provider: "Claude",
@@ -569,9 +608,12 @@ export default function AIResumePromptsHub() {
                   <article key={step.title} className="bg-white rounded-2xl p-6 md:p-8 shadow-premium card-gradient-border">
                     <h3 className="font-display text-xl font-bold text-ink">{step.title}</h3>
                     <p className="mt-3 text-stone-warm leading-relaxed">{step.description}</p>
-                    <pre className="mt-4 bg-ink text-white/90 rounded-xl p-4 md:p-6 text-sm leading-relaxed overflow-x-auto">
-                      <code>{step.code}</code>
-                    </pre>
+                    <div className="relative mt-4">
+                      <CopyButton text={step.code} />
+                      <pre className="bg-ink text-white/90 rounded-xl p-4 md:p-6 pr-20 text-sm leading-relaxed overflow-x-auto">
+                        <code>{step.code}</code>
+                      </pre>
+                    </div>
                   </article>
                 ))}
               </div>

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -603,7 +603,7 @@ export default function BestFreeResumeBuilders2026() {
                 {i + 1}
               </div>
               <div>
-                <h3 className="font-bold text-ink mb-1">{rec.scenario}</h3>
+                <p className="font-bold text-ink mb-1">{rec.scenario}</p>
                 <p className="text-stone-warm">
                   <strong>Pick: </strong>
                   {rec.link ? (


### PR DESCRIPTION
## Summary
- **Prompts hub** (`/blog/ai-resume-prompts-hub`): Replace bare `<pre><code>` blocks with the shared `CopyablePrompt` component so users can copy workflow prompts with one click — consistent with all other prompt blog pages
- **Best builders** (`/blog/best-free-resume-builders-2026`): Change `<h3>` → `<p>` for recommendation labels in the "Our Honest Recommendation" section — `prose-lg` was adding ~26px top margin to h3 elements, misaligning the green numbered circles

## Test plan
- [x] All 1445 unit tests pass
- [ ] Visit `/blog/ai-resume-prompts-hub` → "How to Build an AI Resume Workflow" — each of the 5 steps shows a Copy button, clicking copies prompt text, "Copied!" feedback appears for 2s
- [ ] Visit `/blog/best-free-resume-builders-2026` → "Our Honest Recommendation" — green numbered circles are tightly aligned with bold text, no large gaps