### PR TITLE
fix(seo): remove VideoObject schema from 3 non-video pages

### DIFF
--- a/resume-builder-ui/src/components/AboutUs.tsx
+++ b/resume-builder-ui/src/components/AboutUs.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import SEOHead from "./SEOHead";
-import { generateVideoObjectSchema, wrapInGraph } from "../utils/schemaGenerators";
+import { wrapInGraph } from "../utils/schemaGenerators";
 import { TUTORIAL_VIDEO } from "../config/videoContent";
 
 export default function AboutUs() {
@@ -25,13 +25,6 @@ export default function AboutUs() {
                 "Democratize career opportunities by providing free professional resume tools",
             },
           },
-          generateVideoObjectSchema(
-            TUTORIAL_VIDEO.name,
-            TUTORIAL_VIDEO.description,
-            TUTORIAL_VIDEO.thumbnailUrl,
-            TUTORIAL_VIDEO.uploadDate,
-            TUTORIAL_VIDEO.embedUrl
-          ),
         ])}
       />
       <div className="min-h-screen bg-chalk">

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import CountUp from "react-countup";
 import SEOHead from "./SEOHead";
-import { generateSoftwareApplicationSchema, generateWebSiteSchema, generateFAQPageSchema, generateVideoObjectSchema, wrapInGraph } from "../utils/schemaGenerators";
+import { generateSoftwareApplicationSchema, generateWebSiteSchema, generateFAQPageSchema, wrapInGraph } from "../utils/schemaGenerators";
 import CompanyMarquee from "./CompanyMarquee";
 import RevealSection from "./shared/RevealSection";
 import { useAuth } from "../contexts/AuthContext";
@@ -181,13 +181,6 @@ const LandingPage: React.FC = () => {
           generateSoftwareApplicationSchema(),
           generateWebSiteSchema(),
           generateFAQPageSchema(faqs),
-          generateVideoObjectSchema(
-            TUTORIAL_VIDEO.name,
-            TUTORIAL_VIDEO.description,
-            TUTORIAL_VIDEO.thumbnailUrl,
-            TUTORIAL_VIDEO.uploadDate,
-            TUTORIAL_VIDEO.embedUrl
-          ),
         ])}
       />
 

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
@@ -15,7 +15,6 @@ import DownloadCTA from '../shared/DownloadCTA';
 import RevealSection from '../shared/RevealSection';
 import { InContentAd, AD_CONFIG } from '../ads';
 import { usePageSchema } from '../../hooks/usePageSchema';
-import { generateVideoObjectSchema } from '../../utils/schemaGenerators';
 import { SEO_PAGES } from '../../config/seoPages';
 import { TUTORIAL_VIDEO } from '../../config/videoContent';
 
@@ -24,20 +23,10 @@ export default function FreeResumeBuilderNoSignUp() {
   const [videoPlaying, setVideoPlaying] = useState(false);
   const handlePlayVideo = useCallback(() => setVideoPlaying(true), []);
 
-  const baseSchemas = usePageSchema({
+  const schemas = usePageSchema({
     type: 'software',
     faqs: config.faqs,
   });
-  const schemas = [
-    ...baseSchemas,
-    generateVideoObjectSchema(
-      TUTORIAL_VIDEO.name,
-      TUTORIAL_VIDEO.description,
-      TUTORIAL_VIDEO.thumbnailUrl,
-      TUTORIAL_VIDEO.uploadDate,
-      TUTORIAL_VIDEO.embedUrl
-    ),
-  ];
 
   return (
     <SEOPageLayout seoConfig={config.seo} schemas={schemas}>


### PR DESCRIPTION
## Summary

Clears the GSC **"Video isn't on a watch page"** warning by removing `VideoObject` JSON-LD schema from 3 pages that embed a tutorial video but aren't primarily video watch pages.

| Page | File | Line |
|------|------|------|
| `/` | `resume-builder-ui/src/components/LandingPage.tsx` | 184 (removed) |
| `/about` | `resume-builder-ui/src/components/AboutUs.tsx` | 28 (removed) |
| `/free-resume-builder-no-sign-up` | `resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx` | 33 (removed) |

## Why

GSC's Video Indexing report shows 3 affected URLs (all the same YouTube video `JU3QgmXpfQg` embedded on different pages). Google's "Video isn't on a watch page" status means Google found a video embedded on these pages but won't index them as video results because the page isn't primarily a video watch page (like YouTube).

By emitting `VideoObject` JSON-LD, we're sending a conflicting signal: claiming the page should rank as a video search result on pages that are clearly informational/marketing content. Google correctly rejects this, so the schema serves no purpose and adds noise to GSC reports.

**The iframe embeds stay** — users still see and play the video. The YouTube video itself is indexed on YouTube's domain (where it belongs). We just stop asking Google to treat these pages as video results.

## Changes

- Removed `generateVideoObjectSchema(...)` call from 3 page components
- Removed `generateVideoObjectSchema` from imports (kept `TUTORIAL_VIDEO` since it's still used for the iframe `src`)
- `FreeResumeBuilderNoSignUp.tsx`: simplified the `schemas` variable now that the extra schema is gone (was `[...baseSchemas, generateVideoObjectSchema(...)]`, now just `usePageSchema({...})`)

3 files changed, **3 insertions(+), 28 deletions(-)**

## Test plan

- [x] `npx vitest run` — 1445 tests pass, 0 failures, 23 skipped (no regressions)
- [x] ESLint clean on all 3 modified files
- [x] No new imports/usages of `generateVideoObjectSchema` remain in these files
- [ ] **Reviewer manual smoke**: visit `/`, `/about`, `/free-resume-builder-no-sign-up` in browser → video iframe still renders and plays
- [ ] **Post-merge GSC verification (2-week window)**: GSC Video Indexing report shows "Video isn't on a watch page" warnings clearing for the 3 affected URLs

## SEO context

Part of the GSC stabilization release plan post-v3.25.0:
- SEO recovery is in critical phase (positions trending worse, only 147 clicks/28d post-cliff)
- This is a noise-reduction fix — clears a GSC false positive that's been adding clutter to monitoring
- Per memory `feedback_seo_thoughtful_planning`: one targeted change at a time with clear rollback criteria
- Per memory `feedback_seo_pr_split_attribution`: this is the visual/structural change in a 2-PR split; content/CWV changes follow ≥48h later

**Rollback:** `git revert HEAD` — restores the schema. Zero data dependencies, zero migration risk.

## Risk: LOW

- Schema-only change, no rendering changes
- No UI changes, no CWV impact
- Tests green, lint clean
- 3 lines added (kept import logic), 28 lines removed (the schema blocks)
- Reverse is one revert away