### PR TITLE
fix(a11y): improve contrast on mono labels for WCAG AA compliance

### DIFF
--- a/resume-builder-ui/src/components/BlogCTA.tsx
+++ b/resume-builder-ui/src/components/BlogCTA.tsx
@@ -115,7 +115,7 @@ const BlogCTA = ({ type = 'general' }: BlogCTAProps) => {
     <section className="mt-12 mb-8">
       <div className="bg-chalk-dark rounded-2xl p-8 md:p-10 border border-black/[0.04]">
         <div className="text-center mb-8">
-          <span className="font-mono text-[10px] tracking-[0.15em] text-accent uppercase">
+          <span className="font-mono text-[10px] tracking-[0.15em] text-accent-text uppercase">
             Next Steps
           </span>
           <h3 className="font-display text-2xl font-extrabold text-ink mt-2 mb-2">

--- a/resume-builder-ui/src/components/BlogIndex.tsx
+++ b/resume-builder-ui/src/components/BlogIndex.tsx
@@ -215,7 +215,7 @@ export default function BlogIndex() {
                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none" />
 
                 <div className="relative">
-                  <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">
+                  <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">
                     Ready?
                   </span>
                   <h2 className="font-display text-2xl md:text-3xl font-extrabold text-white mt-3 mb-4">

--- a/resume-builder-ui/src/components/BlogIndex.tsx
+++ b/resume-builder-ui/src/components/BlogIndex.tsx
@@ -32,7 +32,7 @@ export default function BlogIndex() {
           {/* Header */}
           <RevealSection variant="fade-up">
             <header className="text-center mb-12 md:mb-16">
-              <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">
+              <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">
                 Career Insights
               </span>
               <h1 className="font-display text-4xl md:text-5xl font-extrabold text-ink tracking-tight mt-3 mb-4">
@@ -215,7 +215,7 @@ export default function BlogIndex() {
                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none" />
 
                 <div className="relative">
-                  <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">
+                  <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">
                     Ready?
                   </span>
                   <h2 className="font-display text-2xl md:text-3xl font-extrabold text-white mt-3 mb-4">

--- a/resume-builder-ui/src/components/JobsPage.tsx
+++ b/resume-builder-ui/src/components/JobsPage.tsx
@@ -460,7 +460,7 @@ export default function JobsPage() {
       <div className="max-w-5xl mx-auto">
         {/* Hero */}
         <div className="text-center mb-8">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 inline-block">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 inline-block">
             Job Search
           </span>
           <h1 className="font-display text-3xl sm:text-4xl font-extrabold tracking-tight text-ink mb-2">
@@ -848,7 +848,7 @@ export default function JobsPage() {
         <RevealSection variant="fade-up">
           <div className="bg-white rounded-2xl shadow-premium card-gradient-border p-8 md:p-12 mb-8">
             <div className="text-center mb-8">
-              <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">How It Works</span>
+              <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">How It Works</span>
               <h2 className="font-display text-2xl md:text-3xl font-extrabold tracking-tight text-ink mt-2">
                 From Resume to Interview
               </h2>

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -196,7 +196,7 @@ const LandingPage: React.FC = () => {
         <div className="max-w-6xl mx-auto w-full grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           {/* Left: text */}
           <div>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-6 block">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-6 block">
               FREE FOREVER. NO SIGN-UP.
             </span>
             <h1 className="font-display text-[clamp(2.5rem,5.5vw,4.5rem)] font-extrabold leading-[1.08] tracking-tight text-ink mb-6">
@@ -222,7 +222,7 @@ const LandingPage: React.FC = () => {
               </button>
             </div>
 
-            <p className="font-mono text-xs tracking-wide text-stone-warm">
+            <p className="font-mono text-xs tracking-wide text-ink/60">
               100% free · No sign-up · No paywall
             </p>
           </div>
@@ -319,7 +319,7 @@ const LandingPage: React.FC = () => {
           <CompanyMarquee speed={12} pauseOnHover={true} />
 
           <div className="text-center mt-8">
-            <p className="text-xs text-stone-warm max-w-3xl mx-auto font-display font-extralight">
+            <p className="text-xs text-ink/60 max-w-3xl mx-auto font-display font-extralight">
               * We respect user privacy and don't track employment details. The
               companies shown represent professionals who have chosen our
               platform for building their resumes.
@@ -332,7 +332,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk py-20 px-4 cv-auto cv-h-600">
         <div className="max-w-4xl mx-auto">
           <RevealSection>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block">
               WHY US
             </span>
             <h2 className="font-display text-3xl md:text-5xl font-extrabold text-ink mb-4 tracking-tight">
@@ -372,7 +372,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk py-24 px-4 cv-auto cv-h-500">
         <div className="max-w-5xl mx-auto">
           <RevealSection className="text-center mb-16">
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block">
               HOW IT WORKS
             </span>
             <h2 className="font-display text-3xl md:text-5xl font-extrabold text-ink tracking-tight">
@@ -415,7 +415,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk py-20 px-4 cv-auto cv-h-400">
         <div className="max-w-6xl mx-auto">
           <RevealSection>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block">
               RESOURCES
             </span>
             <h2 className="font-display text-3xl md:text-4xl font-extrabold text-ink mb-12 tracking-tight">
@@ -479,7 +479,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk py-20 px-4 cv-auto cv-h-500">
         <div className="max-w-4xl mx-auto">
           <RevealSection>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block">
               THE EASYFREERESUME DIFFERENCE
             </span>
             <h2 className="font-display text-3xl md:text-5xl font-extrabold text-ink mb-12 tracking-tight">
@@ -531,7 +531,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk-dark py-20 px-4 cv-auto cv-h-400">
         <div className="max-w-4xl mx-auto">
           <RevealSection>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
               GET STARTED
             </span>
             <h2 className="font-display text-3xl md:text-5xl font-extrabold text-ink mb-12 tracking-tight text-center">
@@ -582,7 +582,7 @@ const LandingPage: React.FC = () => {
       <section className="bg-chalk py-20 px-4 cv-auto cv-h-500">
         <div className="max-w-3xl mx-auto">
           <RevealSection>
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
               FAQ
             </span>
             <h2 className="font-display text-3xl md:text-5xl font-extrabold text-ink mb-4 text-center tracking-tight">

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -29,7 +29,7 @@ function StarRating({ value }: { value: Rating }) {
 
 function SectionEyebrow({ children }: { children: string }) {
   return (
-    <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-3 block">
+    <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-3 block">
       {children}
     </span>
   );
@@ -814,7 +814,7 @@ export default function AIResumePromptsHub() {
                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none"
               />
               <div className="relative z-10">
-                <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-6 block">
+                <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-6 block">
                   Ready?
                 </span>
                 <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight leading-tight mb-4">

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -814,7 +814,7 @@ export default function AIResumePromptsHub() {
                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none"
               />
               <div className="relative z-10">
-                <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-6 block">
+                <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-6 block">
                   Ready?
                 </span>
                 <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight leading-tight mb-4">

--- a/resume-builder-ui/src/components/seo/CustomerServiceKeywords.tsx
+++ b/resume-builder-ui/src/components/seo/CustomerServiceKeywords.tsx
@@ -284,7 +284,7 @@ export default function CustomerServiceKeywords() {
       {/* Core Skills Section */}
       <RevealSection>
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Core Skills</span>
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Core Skills</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
             Core customer service skills (soft skills)
           </h2>
@@ -377,7 +377,7 @@ export default function CustomerServiceKeywords() {
       {/* Metrics Section */}
       <RevealSection>
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Metrics</span>
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Metrics</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
             Processes and metrics
           </h2>
@@ -421,7 +421,7 @@ export default function CustomerServiceKeywords() {
       {/* Keywords to Avoid */}
       <RevealSection>
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Common Mistakes</span>
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Common Mistakes</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
             Customer service keywords to avoid
           </h2>

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderDownload.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderDownload.tsx
@@ -32,7 +32,7 @@ export default function FreeResumeBuilderDownload() {
       {/* Supported download formats section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-600">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             File Formats
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -110,7 +110,7 @@ export default function FreeResumeBuilderDownload() {
       {/* How to download your resume step-by-step */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-600">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Step-by-Step
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -164,7 +164,7 @@ export default function FreeResumeBuilderDownload() {
       {/* Printing tips section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-500">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Print Guide
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -213,7 +213,7 @@ export default function FreeResumeBuilderDownload() {
       {/* Download vs online builders comparison */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-600">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Comparison
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -261,7 +261,7 @@ export default function FreeResumeBuilderDownload() {
       {/* Best format for ATS section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-400">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             ATS Advice
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -332,7 +332,7 @@ export default function FreeResumeBuilderDownload() {
       {/* Related Resources */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-400">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Related Resources
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderNoPayment.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderNoPayment.tsx
@@ -50,7 +50,7 @@ export default function FreeResumeBuilderNoPayment() {
       {/* Hidden fees other builders charge */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-600">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Price Breakdown
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -148,7 +148,7 @@ export default function FreeResumeBuilderNoPayment() {
       {/* What "free" actually means — freemium vs truly free */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-600">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Transparency
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -216,7 +216,7 @@ export default function FreeResumeBuilderNoPayment() {
       {/* Social proof / testimonial-style section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-500">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             User Experiences
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -245,7 +245,7 @@ export default function FreeResumeBuilderNoPayment() {
               },
             ].map((item) => (
               <div key={item.scenario} className="bg-white rounded-2xl p-6 shadow-premium border border-black/[0.06]">
-                <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-3">
+                <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-3">
                   {item.scenario}
                 </p>
                 <p className="text-ink font-medium leading-relaxed mb-4 italic">
@@ -270,7 +270,7 @@ export default function FreeResumeBuilderNoPayment() {
       {/* How we stay free */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-400">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Our Model
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -313,7 +313,7 @@ export default function FreeResumeBuilderNoPayment() {
       {/* Related Resources */}
       <RevealSection variant="fade-up">
         <div className="mb-16 cv-auto cv-h-400">
-          <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase text-center mb-4">
+          <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase text-center mb-4">
             Related Resources
           </p>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">

--- a/resume-builder-ui/src/components/seo/JobExamplePage.tsx
+++ b/resume-builder-ui/src/components/seo/JobExamplePage.tsx
@@ -476,7 +476,7 @@ export default function JobExamplePage() {
       {relatedJobs.length > 0 && (
         <RevealSection stagger>
           <section className="my-16 cv-auto cv-h-400">
-            <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">Related Examples</span>
+            <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">Related Examples</span>
             <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-6 text-center">
               Related Resume Examples
             </h2>

--- a/resume-builder-ui/src/components/seo/JobExamplesHub.tsx
+++ b/resume-builder-ui/src/components/seo/JobExamplesHub.tsx
@@ -206,7 +206,7 @@ export default function JobExamplesHub() {
       {/* How to Use Section */}
       <RevealSection>
         <div className="my-16 cv-auto cv-h-300">
-          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">How It Works</span>
+          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">How It Works</span>
           <StepByStep steps={howToSteps} title="" />
         </div>
       </RevealSection>
@@ -238,7 +238,7 @@ export default function JobExamplesHub() {
       {/* Quick Links by Popular Jobs */}
       <RevealSection>
         <section className="my-16 cv-auto cv-h-300">
-          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">Popular</span>
+          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">Popular</span>
           <h2 className="text-2xl md:text-3xl font-extrabold text-ink tracking-tight mb-6 text-center">
             Most Popular Resume Examples
           </h2>
@@ -264,7 +264,7 @@ export default function JobExamplesHub() {
       {/* Related Resources */}
       <RevealSection>
         <section className="my-16 cv-auto cv-h-300">
-          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">Resources</span>
+          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">Resources</span>
           <h2 className="text-2xl md:text-3xl font-extrabold text-ink tracking-tight mb-6 text-center">
             More Resume Resources
           </h2>

--- a/resume-builder-ui/src/components/seo/JobKeywordsPage.tsx
+++ b/resume-builder-ui/src/components/seo/JobKeywordsPage.tsx
@@ -128,7 +128,7 @@ export default function JobKeywordsPage() {
       {/* Core Skills Section */}
       <RevealSection>
         <div className="mb-16 cv-auto cv-h-500">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Core Skills</span>
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Core Skills</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
             Core {jobData.title.toLowerCase()} skills (soft skills)
           </h2>
@@ -267,7 +267,7 @@ export default function JobKeywordsPage() {
       {jobData.keywords.metrics && jobData.keywords.metrics.length > 0 && (
         <RevealSection>
           <div className="mb-16 cv-auto cv-h-400">
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Metrics</span>
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Metrics</span>
             <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
               Metrics and KPIs
             </h2>
@@ -331,7 +331,7 @@ export default function JobKeywordsPage() {
       {jobData.phrases && jobData.phrases.length > 0 && (
         <RevealSection>
           <div className="mb-16 cv-auto cv-h-400">
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Key Phrases</span>
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Key Phrases</span>
             <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
               Keyword phrases for {jobData.title.toLowerCase()} resumes
             </h2>
@@ -392,7 +392,7 @@ export default function JobKeywordsPage() {
       {jobData.commonMistakes && jobData.commonMistakes.length > 0 && (
         <RevealSection>
           <div className="mb-16 cv-auto cv-h-400">
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Common Mistakes</span>
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Common Mistakes</span>
             <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-8 mt-2">
               Common {jobData.title.toLowerCase()} resume mistakes
             </h2>

--- a/resume-builder-ui/src/components/seo/RelatedJobsSection.tsx
+++ b/resume-builder-ui/src/components/seo/RelatedJobsSection.tsx
@@ -24,7 +24,7 @@ export default function RelatedJobsSection({ job, limit = 6 }: RelatedJobsSectio
   return (
     <RevealSection stagger>
       <div className="mt-12 md:mt-20 mb-16">
-        <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">Related Keywords</span>
+        <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">Related Keywords</span>
         <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-4 text-center">
           Related Resume Keywords
         </h2>

--- a/resume-builder-ui/src/components/seo/ResumeBuilderForITProfessionals.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeBuilderForITProfessionals.tsx
@@ -32,7 +32,7 @@ export default function ResumeBuilderForITProfessionals() {
       {/* Tech resume tips */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             TECH RESUME TIPS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -57,7 +57,7 @@ export default function ResumeBuilderForITProfessionals() {
       {/* Common mistakes section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             AVOID THESE PITFALLS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-4 text-center">
@@ -136,7 +136,7 @@ export default function ResumeBuilderForITProfessionals() {
       {/* Inline FAQ section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             QUICK ANSWERS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-10 text-center">

--- a/resume-builder-ui/src/components/seo/ResumeBuilderForNurses.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeBuilderForNurses.tsx
@@ -32,7 +32,7 @@ export default function ResumeBuilderForNurses() {
       {/* Nursing resume tips */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             NURSING RESUME TIPS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -58,7 +58,7 @@ export default function ResumeBuilderForNurses() {
       {/* Common mistakes section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             AVOID THESE PITFALLS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-4 text-center">
@@ -137,7 +137,7 @@ export default function ResumeBuilderForNurses() {
       {/* Inline FAQ section */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             QUICK ANSWERS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-10 text-center">

--- a/resume-builder-ui/src/components/seo/ResumeBuilderForStudents.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeBuilderForStudents.tsx
@@ -67,7 +67,7 @@ export default function ResumeBuilderForStudents() {
       {/* Student-specific tips */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             STUDENT TIPS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -93,7 +93,7 @@ export default function ResumeBuilderForStudents() {
       {/* Common mistakes section */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             AVOID THESE
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -165,7 +165,7 @@ export default function ResumeBuilderForStudents() {
       {/* Inline FAQ section with student-specific questions */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             STUDENT FAQ
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-8 text-center">

--- a/resume-builder-ui/src/components/seo/ResumeBuilderForVeterans.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeBuilderForVeterans.tsx
@@ -68,7 +68,7 @@ export default function ResumeBuilderForVeterans() {
       {/* Military-to-civilian translation section */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             TRANSLATION GUIDE
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -117,7 +117,7 @@ export default function ResumeBuilderForVeterans() {
       {/* Common mistakes section */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             AVOID THESE
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -211,7 +211,7 @@ export default function ResumeBuilderForVeterans() {
       {/* Inline FAQ section with veteran-specific questions */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             VETERAN FAQ
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-8 text-center">

--- a/resume-builder-ui/src/components/seo/ResumeKeywordsHub.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeKeywordsHub.tsx
@@ -383,7 +383,7 @@ export default function ResumeKeywordsHub() {
           >
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[300px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none" />
             <div className="relative">
-              <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-3 block">FREE TOOL</span>
+              <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-3 block">FREE TOOL</span>
               <h2 className="font-display text-2xl md:text-3xl font-extrabold text-white mb-3">
                 ATS Resume Keyword Scanner
               </h2>

--- a/resume-builder-ui/src/components/seo/ResumeKeywordsHub.tsx
+++ b/resume-builder-ui/src/components/seo/ResumeKeywordsHub.tsx
@@ -181,7 +181,7 @@ export default function ResumeKeywordsHub() {
       <RevealSection>
         <div className="mb-16 max-w-4xl mx-auto cv-auto cv-h-500" id="popular-keywords">
           <div className="bg-white rounded-2xl p-8 md:p-10 shadow-premium border border-black/[0.06]">
-            <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Universal Keywords</span>
+            <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Universal Keywords</span>
             <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-6 mt-2">
               Most Popular Keywords Across All Industries
             </h2>
@@ -358,7 +358,7 @@ export default function ResumeKeywordsHub() {
 
       <RevealSection>
         <div className="mb-16 cv-auto cv-h-800">
-          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">By Industry</span>
+          <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">By Industry</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-12 text-center">
             Browse keywords by industry
           </h2>
@@ -383,7 +383,7 @@ export default function ResumeKeywordsHub() {
           >
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[300px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none" />
             <div className="relative">
-              <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-3 block">FREE TOOL</span>
+              <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-3 block">FREE TOOL</span>
               <h2 className="font-display text-2xl md:text-3xl font-extrabold text-white mb-3">
                 ATS Resume Keyword Scanner
               </h2>
@@ -400,7 +400,7 @@ export default function ResumeKeywordsHub() {
       </RevealSection>
 
       <div className="mb-16" id="how-to-find">
-        <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">The Process</span>
+        <span className="block text-center font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">The Process</span>
         <StepByStep steps={howToSteps} title="How to find keywords for your resume" />
       </div>
 

--- a/resume-builder-ui/src/components/shared/BulletPointBank.tsx
+++ b/resume-builder-ui/src/components/shared/BulletPointBank.tsx
@@ -49,7 +49,7 @@ export default function BulletPointBank({ categories, jobTitle }: BulletPointBan
     <RevealSection>
       <section className="my-12">
         <div className="text-center mb-8">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">Bullet Bank</span>
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">Bullet Bank</span>
           <h2 className="text-3xl md:text-4xl font-extrabold text-ink tracking-tight mb-4 mt-2">
             {jobTitle} Bullet Point Bank
           </h2>

--- a/resume-builder-ui/src/components/shared/PageHero.tsx
+++ b/resume-builder-ui/src/components/shared/PageHero.tsx
@@ -17,7 +17,7 @@ export default function PageHero({ config, className = '' }: PageHeroProps) {
     <div className={`text-center mb-16 ${className}`}>
       {/* Eyebrow */}
       {config.eyebrow && (
-        <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4">
+        <p className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4">
           {config.eyebrow}
         </p>
       )}

--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -146,7 +146,7 @@ function ModelStatusIndicator({
         />
         <span
           key={wordIndex}
-          className="font-mono text-xs tracking-[0.15em] text-accent uppercase"
+          className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase"
           style={{ animation: 'fadeIn 0.3s ease-out' }}
         >
           {NLP_WORDS[wordIndex]}...
@@ -191,7 +191,7 @@ function ModelStatusIndicator({
               />
             ))}
           </span>
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase">
             Ready
           </span>
         </div>
@@ -658,7 +658,7 @@ export default function ResumeKeywordScanner() {
       {/* How It Works */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             HOW IT WORKS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -709,7 +709,7 @@ export default function ResumeKeywordScanner() {
       {/* Tips for improving match */}
       <RevealSection variant="fade-up">
         <div className="mb-16">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             PRO TIPS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -753,7 +753,7 @@ export default function ResumeKeywordScanner() {
       {/* Step-by-Step Guide to Using the Scanner */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             STEP-BY-STEP GUIDE
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -936,7 +936,7 @@ export default function ResumeKeywordScanner() {
       {/* Why Keywords Matter for ATS */}
       <RevealSection variant="fade-up">
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             UNDERSTANDING ATS
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">
@@ -1001,7 +1001,7 @@ export default function ResumeKeywordScanner() {
       {/* Related resources */}
       <RevealSection>
         <div className="mb-16 max-w-4xl mx-auto">
-          <span className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-4 block text-center">
+          <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-4 block text-center">
             RESOURCES
           </span>
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-6 text-center">

--- a/resume-builder-ui/tailwind.config.js
+++ b/resume-builder-ui/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
         'stone-warm': '#8a8680',
         mist: '#a8a4a0',
         accent: '#00d47e',
+        'accent-text': '#007a48',
       },
       typography: ({ theme }) => ({
         DEFAULT: {


### PR DESCRIPTION
## Summary

Lighthouse mobile audit on the homepage flagged three WCAG AA contrast failures on small text. This PR fixes all three by introducing a higher-contrast green token for mono eyebrow labels and darkening two specific small-text instances that used `text-stone-warm` at `text-xs` size.

**Failing nodes (before):**
- `section.relative > … > span.font-mono` — `text-accent` (#00d47e) on chalk = ~1.87:1 ❌
- `section.relative > … > p.font-mono` — `text-stone-warm` (#8a8680) at text-xs on white = ~3.46:1 ❌
- `section.bg-chalk > … > p.text-xs` — `text-stone-warm` at text-xs on chalk = ~3.46:1 ❌

WCAG AA requires **4.5:1** for normal/small text (< 18px).

## Changes

| File | Change |
|------|--------|
| `tailwind.config.js` | Add `accent-text: '#007a48'` token (5.18:1 on chalk ✅) |
| 20 component files | Replace `text-accent` → `text-accent-text` in all 63 light-bg mono eyebrow labels |
| `LandingPage.tsx:631` | Preserved `text-accent` on dark CTA section (`bg-ink`) where it passes at ~10:1 |
| `LandingPage.tsx:225` | `text-stone-warm` → `text-ink/60` on hero trust badge (text-xs) |
| `LandingPage.tsx:322` | `text-stone-warm` → `text-ink/60` on company marquee disclaimer (text-xs) |

**Contrast ratios after fix:**
- `#007a48` on chalk (#fafaf8): **5.18:1** ✅ passes WCAG AA for small text
- `text-ink/60` on chalk: **~4.59:1** ✅ passes WCAG AA for small text
- `text-accent` on ink (#0c0c0c, dark CTA): **~10:1** ✅ unchanged

## Test plan

- [x] `npx vitest run` — 1445 tests pass, 0 failures
- [x] ESLint clean on all changed files (0 new issues)
- [x] Verified LandingPage.tsx:631 (dark CTA) preserved as `text-accent`
- [x] 63 light-bg mono labels confirmed replaced via grep
- [ ] **Reviewer manual smoke:** Run Lighthouse mobile audit on homepage — Accessibility score should reach 100 (was 96). Visual check: eyebrow labels still readable and on-brand.

## Risk: LOW

CSS color-only change across 21 files. Rollback = `git revert HEAD`. No layout, logic, or data changes.

## Note: 48h attribution gap

Per project convention, hold merge until ≥48h after PR #556 (VideoObject removal) merges so GSC impression movement can be cleanly attributed to each change.

## Related

- Context: `C:\Users\Amit\.claude\plans\stg-backlog-context.md`
- Release plan: C-1 (color contrast fix)