### PR TITLE
fix(cls): reduce CLS via shell alignment + synchronous React mount + web-vitals instrumentation

### DIFF
--- a/resume-builder-ui/index.html
+++ b/resume-builder-ui/index.html
@@ -82,8 +82,6 @@
     <style>
       .shell-header{height:64px}
       @media(min-width:640px){.shell-header{height:72px}}
-      .shell-mobile-ad{display:block}
-      @media(min-width:768px){.shell-mobile-ad{display:none}}
       .not-home #shell-landing{display:none}
       #shell-generic{display:none}
       .not-home #shell-generic{display:block}

--- a/resume-builder-ui/index.html
+++ b/resume-builder-ui/index.html
@@ -77,6 +77,18 @@
     <!-- LLM-readable site description (llmstxt.org) -->
     <link rel="author" type="text/plain" href="/llms.txt" />
 
+    <!-- Shell layout CSS: lives in <head> so it persists through React mount
+         and cannot be removed when React replaces #root children. -->
+    <style>
+      .shell-header{height:64px}
+      @media(min-width:640px){.shell-header{height:72px}}
+      .shell-mobile-ad{display:block}
+      @media(min-width:768px){.shell-mobile-ad{display:none}}
+      .not-home #shell-landing{display:none}
+      #shell-generic{display:none}
+      .not-home #shell-generic{display:block}
+    </style>
+
     <!-- Title -->
     <title>EasyFreeResume — 100% Free Resume Builder (No Paywall, No Sign-Up)</title>
 
@@ -99,29 +111,10 @@
         <div class="shell-header" style="background:#fff;border-bottom:1px solid rgba(0,0,0,.06);position:relative">
           <div style="position:absolute;top:0;left:0;right:0;height:2px;background:#00d47e"></div>
         </div>
-        <!-- Main content area matching LandingPage layout -->
-        <!-- Hide mobile-top ad placeholder on desktop (matches Tailwind md:hidden) -->
-        <style>
-          .shell-mobile-ad{display:block}
-          @media(min-width:768px){.shell-mobile-ad{display:none}}
-          /* Shell header: responsive height matching React Header (h-16 sm:h-[72px]) */
-          .shell-header{height:64px}
-          @media(min-width:640px){.shell-header{height:72px}}
-          /* Route-aware shell visibility */
-          .not-home #shell-landing{display:none}
-          #shell-generic{display:none}
-          .not-home #shell-generic{display:block}
-        </style>
         <main style="flex:1 1 0%;padding:0 1rem">
           <!-- SideRailLayout wrapper (matches React when explicit ads enabled) -->
           <div style="display:flex;justify-content:center;gap:1.5rem">
             <div style="flex:1 1 0%;min-width:0">
-              <!-- Mobile-top ad placeholder (matches SideRailLayout block md:hidden InContentAd) -->
-              <div class="shell-mobile-ad">
-                <div style="margin:16px 0;overflow:hidden">
-                  <div style="min-height:250px"></div>
-                </div>
-              </div>
               <!-- Landing page content (hidden on non-home routes) -->
               <!-- Must match LandingPage.tsx hero section: pt-12 pb-20 = 3rem/5rem, clamp(2.5rem,5.5vw,4.5rem), mb-6 -->
               <div id="shell-landing" style="position:relative;padding:3rem 0 5rem;background:#fafaf8">

--- a/resume-builder-ui/package-lock.json
+++ b/resume-builder-ui/package-lock.json
@@ -40,7 +40,8 @@
         "react-hot-toast": "^2.6.0",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.0.2",
-        "tiptap-markdown": "^0.9.0"
+        "tiptap-markdown": "^0.9.0",
+        "web-vitals": "^5.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -10027,6 +10028,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -48,7 +48,8 @@
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.0.2",
-    "tiptap-markdown": "^0.9.0"
+    "tiptap-markdown": "^0.9.0",
+    "web-vitals": "^5.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/resume-builder-ui/src/main.tsx
+++ b/resume-builder-ui/src/main.tsx
@@ -1,14 +1,33 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
 import { HelmetProvider } from 'react-helmet-async';
+import { onCLS } from 'web-vitals/attribution';
 import App from "./App.tsx";
 
 import "./styles.css";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <HelmetProvider>
-      <App />
-    </HelmetProvider>
-  </StrictMode>
-);
+// Log CLS with attribution for field debugging.
+// Wire to PostHog when that integration ships.
+onCLS((metric) => {
+  console.log('[CLS]', {
+    value: metric.value,
+    rating: metric.rating,
+    largestShiftTarget: metric.attribution?.largestShiftTarget,
+    largestShiftTime: metric.attribution?.largestShiftTime,
+    loadState: metric.attribution?.loadState,
+  });
+});
+
+// flushSync forces the initial React render to be synchronous, eliminating
+// the intermediate DOM state (shell-header gone, H1 still visible) that
+// causes the 64px CLS shift measured by Codex at ~181ms.
+flushSync(() => {
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <HelmetProvider>
+        <App />
+      </HelmetProvider>
+    </StrictMode>
+  );
+});


### PR DESCRIPTION
## Summary

Reduces lab CLS from **0.11 → 0.00** (measured at mobile 375×667 with 4× CPU throttle and at tablet 768×1024) by addressing the two root causes identified in the Codex forensic audit, plus adds web-vitals attribution logging for field debugging.

Three changes, two commits:

**Commit 1 — HTML shell alignment (`index.html`):**
1. Move the `.shell-header` / `.shell-mobile-ad` / route-aware CSS block from inside `#root` to `<head>`. When React calls `createRoot().render()` and wipes `#root`'s children, the `<style>` tag was removed first, collapsing `.shell-header` height to 0 while `#shell-landing` content was still visible — a 64 px upward jump. CSS in `<head>` cannot be removed by React.
2. Remove the unconditional `shell-mobile-ad` placeholder (reserves 250 px + 32 px margin = 282 px). `VITE_ENABLE_EXPLICIT_ADS` is `false` in PROD so React never renders the mobile-top ad slot; the shell was reserving space React always removed, causing a 282 px shift on every mobile load.

**Commit 2 — JS entry point (`main.tsx` + `package.json`):**
3. Wrap the initial `createRoot().render()` in `flushSync()` so React's first render commits synchronously, eliminating any intermediate DOM state (shell-header partially removed, H1 still visible) that could cause the 64 px shift.
4. Install `web-vitals@5` and wire `onCLS` with attribution to console. Logs `largestShiftTarget`, `largestShiftTime`, and `loadState` for field debugging. Ready to wire to PostHog when that integration ships.

## Changes

| File | Change |
|------|--------|
| `resume-builder-ui/index.html` | Move shell CSS to `<head>`; remove `shell-mobile-ad` placeholder |
| `resume-builder-ui/src/main.tsx` | Add `flushSync` on initial render; add `onCLS` web-vitals logging |
| `resume-builder-ui/package.json` | Add `web-vitals@^5.3.0` |

## Test plan

- [x] `npx vitest run` — 1445 tests pass, 0 failures
- [x] ESLint clean on changed files (`npx eslint src/main.tsx --max-warnings 0`)
- [x] Lab CLS mobile (375×667, 4× CPU throttle): **0.00** (was 0.11 / 0.0952 field p75)
- [x] Lab CLS tablet (768×1024): **0.00**
- [x] DevTools performance traces captured in `test-screenshots/after-fix-mobile-375.png` and `after-fix-tablet-768.png`
- [x] Manual smoke: no visible header jump on homepage load
- [ ] **Reviewer manual smoke:** load https://easyfreeresume.com (after merge) on a slow mobile connection — verify no visible upward jump of the H1 at ~200ms mark

## Before / After

| Metric | Before | After (lab) |
|--------|--------|-------------|
| CLS mobile 375px (4× CPU) | 0.11 field / 0.0952 lab | **0.00** |
| CLS tablet 768px | not measured | **0.00** |

## Risk: MEDIUM

Touches `index.html` and `main.tsx` — the two entry points. `flushSync` is an intentional React escape hatch for this use case (forcing synchronous initial mount); it does not affect subsequent re-renders or Concurrent Mode features. Rollback = `git revert HEAD~1` or `git revert HEAD`.

**Note — 48h attribution gap:** Do not merge until ≥48h after PR #556 (VideoObject schema removal) merges, per SEO attribution policy.

## Related

- Context: `C:\Users\Amit\.claude\plans\stg-backlog-context.md`
- Codex forensic audit: shift at 181ms (score 0.0952), 64px header collapse + 282px mobile-ad reservation
- Release plan: Release C-2