### PR TITLE
feat(mobile): round 2 — My Resumes grid, template image height, editor Add Section FAB

### DIFF
--- a/resume-builder-ui/src/components/GhostCard.tsx
+++ b/resume-builder-ui/src/components/GhostCard.tsx
@@ -14,7 +14,7 @@ export function GhostCard({ isAtLimit, resumeCount, onCreateNew }: GhostCardProp
     // If over limit, show warning message instead of upgrade prompt
     if (isOverLimit) {
       return (
-        <div className="h-full min-h-[320px] bg-gradient-to-br from-red-50 via-orange-50 to-red-50 border-2 border-red-400 rounded-lg p-6 flex flex-col items-center justify-center">
+        <div className="h-full min-h-[200px] sm:min-h-[280px] bg-gradient-to-br from-red-50 via-orange-50 to-red-50 border-2 border-red-400 rounded-lg p-4 sm:p-6 flex flex-col items-center justify-center">
           <div className="bg-red-100 rounded-full p-4 mb-4">
             <AlertCircle className="w-12 h-12 text-red-600" />
           </div>
@@ -42,7 +42,7 @@ export function GhostCard({ isAtLimit, resumeCount, onCreateNew }: GhostCardProp
     // At exactly 5 resumes - show limit reached message
     return (
       <div
-        className="h-full min-h-[320px] bg-gradient-to-br from-gray-50 via-slate-50 to-gray-50 border-2 border-gray-400 rounded-lg p-6 flex flex-col items-center justify-center"
+        className="h-full min-h-[200px] sm:min-h-[280px] bg-gradient-to-br from-gray-50 via-slate-50 to-gray-50 border-2 border-gray-400 rounded-lg p-4 sm:p-6 flex flex-col items-center justify-center"
       >
         <div className="bg-gray-100 rounded-full p-4 mb-4">
           <Ban className="w-12 h-12 text-gray-600" />
@@ -71,7 +71,7 @@ export function GhostCard({ isAtLimit, resumeCount, onCreateNew }: GhostCardProp
   return (
     <div
       onClick={onCreateNew}
-      className="h-full min-h-[320px] border-2 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06]/20 transition-all duration-200 group"
+      className="h-full min-h-[200px] sm:min-h-[280px] border-2 border-dashed border-gray-300 rounded-lg p-4 sm:p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06]/20 transition-all duration-200 group"
     >
       <PlusCircle className="w-16 h-16 text-gray-400 mb-4 group-hover:text-accent group-hover:scale-110 transition-all duration-200" />
 

--- a/resume-builder-ui/src/components/GhostCard.tsx
+++ b/resume-builder-ui/src/components/GhostCard.tsx
@@ -71,7 +71,7 @@ export function GhostCard({ isAtLimit, resumeCount, onCreateNew }: GhostCardProp
   return (
     <div
       onClick={onCreateNew}
-      className="h-full min-h-[200px] sm:min-h-[280px] border-2 border-dashed border-gray-300 rounded-lg p-4 sm:p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06]/20 transition-all duration-200 group"
+      className="h-full min-h-[200px] sm:min-h-[280px] border-2 border-dashed border-gray-300 rounded-lg p-4 sm:p-6 flex flex-col items-center justify-center cursor-pointer hover:border-accent hover:bg-accent/[0.06] transition-all duration-200 group"
     >
       <PlusCircle className="w-16 h-16 text-gray-400 mb-4 group-hover:text-accent group-hover:scale-110 transition-all duration-200" />
 

--- a/resume-builder-ui/src/components/TemplateCarousel.tsx
+++ b/resume-builder-ui/src/components/TemplateCarousel.tsx
@@ -374,7 +374,7 @@ const TemplateCarousel: React.FC<TemplateCarouselProps> = ({ showHeader = true }
                       <img
                         src={template.image_url}
                         alt={template.name}
-                        className="w-full h-96 sm:h-[500px] object-contain p-4 group-hover:scale-105 transition-transform duration-500"
+                        className="w-full h-64 sm:h-80 md:h-96 lg:h-[500px] object-contain p-4 group-hover:scale-105 transition-transform duration-500"
                         width="400"
                         height="500"
                         /* Optimization: Eager load first 2 templates (LCP), lazy load the rest */
@@ -398,7 +398,7 @@ const TemplateCarousel: React.FC<TemplateCarouselProps> = ({ showHeader = true }
                     </div>
 
                     {/* Template Info - Compact but informative */}
-                    <div className="p-6 lg:p-8">
+                    <div className="p-4 sm:p-6 lg:p-8">
                       <div className="flex items-start justify-between mb-4">
                         <div className="flex-1">
                           <h3 className="font-display text-2xl font-bold text-ink mb-2 group-hover:text-accent transition-colors">
@@ -415,7 +415,7 @@ const TemplateCarousel: React.FC<TemplateCarouselProps> = ({ showHeader = true }
                         {isSelected ? (
                           <>
                             <button
-                              className="flex-1 inline-flex items-center justify-center bg-accent text-ink py-4 px-6 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                              className="flex-1 inline-flex items-center justify-center bg-accent text-ink py-3 px-4 sm:py-4 sm:px-6 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleUseTemplate(template.id);
@@ -441,7 +441,7 @@ const TemplateCarousel: React.FC<TemplateCarouselProps> = ({ showHeader = true }
                             </button>
                           </>
                         ) : (
-                          <button className="btn-primary w-full py-4 px-6">
+                          <button className="btn-primary w-full py-3 px-4 sm:py-4 sm:px-6">
                             <span className="relative z-10">Select This Template</span>
                           </button>
                         )}

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -452,7 +452,8 @@ export const EditorContent: React.FC<EditorContentProps> = ({
 
       {/* Add Section FAB — mobile only, floats above action bar */}
       <button
-        className="fixed bottom-[calc(var(--mobile-action-bar-height)+1rem)] right-4 z-30 lg:hidden w-14 h-14 rounded-full bg-accent shadow-lg flex items-center justify-center active:scale-95 transition-transform duration-150"
+        type="button"
+        className="fixed bottom-[calc(var(--mobile-action-bar-height)+1rem)] right-4 z-30 lg:hidden w-14 h-14 rounded-full bg-accent shadow-lg flex items-center justify-center active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 transition-transform duration-150"
         onClick={handleAddNewSectionClick}
         aria-label="Add section"
       >

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -2,7 +2,7 @@
 // Main content area for the Editor, including sections, drag-drop, toolbars
 
 import React, { RefObject, useMemo } from 'react';
-import { AlertCircle, X } from 'lucide-react';
+import { AlertCircle, Plus, X } from 'lucide-react';
 import {
   DndContext,
   DragOverlay,
@@ -449,6 +449,15 @@ export const EditorContent: React.FC<EditorContentProps> = ({
         </DragOverlay>
         </DndContext>
       </UnifiedDndContext.Provider>
+
+      {/* Add Section FAB — mobile only, floats above action bar */}
+      <button
+        className="fixed bottom-[calc(var(--mobile-action-bar-height)+1rem)] right-4 z-30 lg:hidden w-14 h-14 rounded-full bg-accent shadow-lg flex items-center justify-center active:scale-95 transition-transform duration-150"
+        onClick={handleAddNewSectionClick}
+        aria-label="Add section"
+      >
+        <Plus className="w-7 h-7 text-ink" />
+      </button>
 
       {/* Mobile Action Bar */}
       <MobileActionBar

--- a/resume-builder-ui/src/pages/MyResumes.tsx
+++ b/resume-builder-ui/src/pages/MyResumes.tsx
@@ -342,7 +342,7 @@ export default function MyResumes() {
     <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-8 max-w-[1200px]">
         {/* Resume Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
           {/* Ghost Card - Always first */}
           <GhostCard
             isAtLimit={resumes.length >= 5}


### PR DESCRIPTION
## Summary

Continues the mobile UX work from #561. Three targeted improvements:

- **My Resumes**: `sm:grid-cols-2` grid at 640px+ (was 768px — tablets were single-column), `gap-4 sm:gap-6` tighter on mobile. GhostCard `min-h` reduced from `320px` → `200px sm:280px` (was 85% of 375px viewport height) across all 3 states (create, limit, over-limit). Padding `p-4 sm:p-6` on mobile.
- **Templates**: Template card image height `h-64 sm:h-80 md:h-96 lg:h-[500px]` — was `h-96` (384px, taller than a 375px viewport). Card info padding `p-4 sm:p-6 lg:p-8`, CTA button padding `py-3 px-4 sm:py-4 sm:px-6`.
- **Editor**: Floating `+` Add Section FAB on mobile — `fixed`, bottom-right, above the action bar (`bottom-[calc(var(--mobile-action-bar-height)+1rem)]`), 56px accent circle, `lg:hidden`. One-tap shortcut so users don't have to open the nav drawer to add a section.

## Test plan

- [ ] My Resumes at 375px: GhostCard is ≤50% viewport height; at 480px+ layout shifts to 2-col
- [ ] Templates page at 375px: first template card image is fully visible without scrolling past it
- [ ] Editor at 375px: green `+` FAB visible in bottom-right corner above the action bar; tapping opens Add Section modal
- [ ] Editor at 1024px+: FAB is hidden (`lg:hidden`)
- [ ] No TypeScript errors (`npx tsc --noEmit`)