### PR TITLE
🎨 Palette: Add keyboard focus indicators to confirmation dialogs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Dialog Button Accessibility
+**Learning:** Custom dialog action buttons often lose default browser focus outlines due to custom Tailwind styling (like `bg-accent` or `shadow-md`), creating a critical accessibility trap for keyboard users in modals.
+**Action:** Explicitly add `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (using appropriate contextual colors like `ring-red-500` or `ring-accent`) to all custom interactive elements, especially in shared dialog components.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -96,8 +96,9 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               </div>
             </div>
             <button
+              type="button"
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -118,22 +119,28 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
           {/* Actions - Mobile: Stack vertically, Desktop: Side by side */}
           <div className="p-6 border-t border-gray-200 space-y-3 lg:space-y-0 lg:flex lg:gap-3 lg:justify-end">
             <button
+              type="button"
               onClick={onClose}
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
             </button>
             <button
+              type="button"
               onClick={handleConfirm}
               disabled={isLoading}
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
+                  isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'
+                }
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}


### PR DESCRIPTION
💡 **What:** Added proper `focus-visible` states to action buttons in `ResponsiveConfirmDialog`. Also added the explicit `type="button"` attribute.
🎯 **Why:** To improve keyboard accessibility. Custom styled Tailwind buttons often lose their native browser focus outline, making it difficult or impossible for keyboard users to navigate modal actions.
♿ **Accessibility:**
- Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to all action and close buttons.
- Styled destructive confirm buttons with `focus-visible:ring-red-500` and normal actions with `focus-visible:ring-accent`.
- Added `type="button"` to ensure screen readers properly announce the elements and to prevent unintended form submissions.

---
*PR created automatically by Jules for task [1778306127933000535](https://jules.google.com/task/1778306127933000535) started by @aafre*