### PR TITLE
🎨 Palette: Add focus states and ARIA labels to TabbedHelpModal close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - Accessible custom modal close buttons
+**Learning:** Custom modal close buttons (e.g. `MdClose` wrapper) without explicit focus outlines fail accessibility standard, even when they have a hover state.
+**Action:** Always add explicit `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2`, `type="button"`, and `aria-label` to custom modal close icon-buttons to ensure keyboard navigation is visible and screen readers are informed.

--- a/resume-builder-ui/src/components/TabbedHelpModal.tsx
+++ b/resume-builder-ui/src/components/TabbedHelpModal.tsx
@@ -38,8 +38,10 @@ export default function TabbedHelpModal({
               Help & Tips
             </h2>
             <button
+              type="button"
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-lg"
+              aria-label="Close help modal"
             >
               <MdClose className="w-6 h-6" />
             </button>


### PR DESCRIPTION
💡 **What**: Added `type="button"`, an `aria-label="Close help modal"`, and explicit `focus-visible` styles to the custom `MdClose` button inside the `TabbedHelpModal`. Also created a `palette.md` journal entry detailing this learning.

🎯 **Why**: Custom icon-only modal close buttons without explicit focus outlines fail accessibility standards because they do not provide clear visual feedback to keyboard users (even if they have hover states). Without an `aria-label`, screen readers may not accurately describe the action. Adding `type="button"` ensures it doesn't accidentally trigger forms.

♿ **Accessibility**: 
- Added `aria-label="Close help modal"` for screen readers.
- Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2` for keyboard navigators.
- Added `type="button"` to avoid unintended form behavior.

---
*PR created automatically by Jules for task [14399274600887456440](https://jules.google.com/task/14399274600887456440) started by @aafre*