### PR TITLE
🎨 Palette: Improve keyboard accessibility for ResponsiveConfirmDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Custom Modal Accessibility
+**Learning:** Custom modals and confirmation dialogs styled with Tailwind classes often lose default browser focus outlines and lack keyboard interaction support (like closing on Escape).
+**Action:** Explicitly implement a `keydown` event listener for the Escape key to close custom modals, and restore keyboard focus visibility on all action buttons (close, cancel, confirm) using explicit `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (with contextual colors like `ring-red-500` or `ring-accent`).

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,22 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -97,7 +113,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,6 +139,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
@@ -134,6 +151,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                ${isDestructive ? 'focus-visible:ring-red-600' : 'focus-visible:ring-accent'}
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}


### PR DESCRIPTION
💡 **What:** Added a `keydown` event listener for the Escape key to close `ResponsiveConfirmDialog` and applied explicit `focus-visible` styling to all actionable buttons. Also recorded these learnings in `.jules/palette.md`.
🎯 **Why:** Custom modal dialogs typically lose default focus indicators when styled with Tailwind utility classes, reducing keyboard accessibility. Missing Escape key handlers further degrade the usability of custom modals for power users and assistive tech.
♿ **Accessibility:** Users navigating with a keyboard or screen reader can now easily see which action button is focused (via `ring-2`) and predictably close the modal using the Escape key.

---
*PR created automatically by Jules for task [13521146412014794073](https://jules.google.com/task/13521146412014794073) started by @aafre*