### PR TITLE
🎨 Palette: Improve Add Description button UX and a11y focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-10-24 - Sub-item Visual Hierarchy & Keyboard Focus
+**Learning:** Using heavy accent buttons for inline sub-item additions breaks visual hierarchy and creates a noisy interface. Additionally, custom padded inline icon buttons often lose browser default focus rings.
+**Action:** Always use the `GhostButton` pattern for adding repeatable sub-items to maintain a "Quiet by Default" interface, and explicitly apply `focus-visible:ring-2 focus-visible:ring-offset-1` with appropriate contextual colors (e.g., `ring-red-500` for destructive actions) to icon-only buttons.

--- a/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
+++ b/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
@@ -194,7 +194,7 @@ describe("ExperienceSection", { timeout: 5000 }, () => {
     render(<ExperienceSection {...props} />, { wrapper: DndWrapper });
 
     // For the first experience, click the Add Description Point button.
-    const addDescButton = screen.getAllByText("+ Add Description Point")[0];
+    const addDescButton = screen.getAllByText("Add Description Point")[0];
     fireEvent.click(addDescButton);
 
     expect(onUpdateMock).toHaveBeenCalledTimes(1);

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -6,6 +6,7 @@ import IconManager from './IconManager';
 import ItemDndContext from './ItemDndContext';
 import SortableItem from './SortableItem';
 import { arrayMove } from '@dnd-kit/sortable';
+import GhostButton from './shared/GhostButton';
 
 export interface ExperienceItemData {
   company: string;
@@ -94,8 +95,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
       <div className="flex justify-between items-center">
         <h3 className="text-lg font-medium">Experience #{index + 1}</h3>
         <button
+          type="button"
           onClick={() => onDelete(index)}
-          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
           aria-label="Delete experience entry"
           title="Delete this experience"
         >
@@ -178,11 +180,13 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                             />
                           </div>
                           <button
+                            type="button"
                             onClick={() => handleDescRemove(descIndex)}
-                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2"
+                            className="text-red-600 hover:text-red-800 p-2 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0 mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
+                            aria-label="Remove description point"
                             title="Remove description point"
                           >
-                            ✕
+                            <span aria-hidden="true">✕</span>
                           </button>
                         </div>
                       </SortableItem>
@@ -192,12 +196,11 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
               </ItemDndContext>
             )}
           </div>
-          <button
-            onClick={handleDescAdd}
-            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2"
-          >
-            + Add Description Point
-          </button>
+          <div className="mt-3">
+            <GhostButton onClick={handleDescAdd}>
+              Add Description Point
+            </GhostButton>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What:
Replaced the visually heavy accent button for adding description points with the existing `GhostButton` component. Additionally, enhanced the keyboard accessibility of the inline description point remove button and the top-level section delete button.

🎯 Why:
The previous design used a bright, solid-color accent button for adding a sub-item (description points), which broke the visual hierarchy within the form, drawing too much attention away from the primary user inputs. Using the `GhostButton` pattern follows the "Quiet by Default" principle. Furthermore, the custom-padded inline icon buttons for deleting items lacked standard browser focus rings, making it difficult for keyboard users to navigate the form effectively.

📸 Before/After:
Before: The "Add Description Point" button was a solid accent color box. When tabbing to the delete/remove icons, no visible focus indicator was present.
After: The "Add Description Point" button is now a subtle dashed ghost button. When navigating with the keyboard, the delete/remove icons now show a clear red focus ring.

♿ Accessibility:
- Added explicit `focus-visible:ring-2 focus-visible:ring-red-500` classes to the delete and remove buttons to restore keyboard focus outlines.
- Added explicit `type="button"` to icon buttons to prevent accidental form submission.
- Replaced the raw '✕' character with an `aria-hidden` span and provided a descriptive `aria-label` ("Remove description point") for screen readers.

---
*PR created automatically by Jules for task [14586588128275718728](https://jules.google.com/task/14586588128275718728) started by @aafre*