### PR TITLE
🎨 Palette: Improve keyboard accessibility for ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - ResponsiveConfirmDialog Keyboard Accessibility
+**Learning:** Custom dialog action buttons (Confirm/Cancel) styled with Tailwind classes like `bg-accent` or `shadow-md` often lose default browser focus outlines, making keyboard navigation difficult for visually impaired users. Modals also often lack `Escape` key support to close them.
+**Action:** Always explicitly add focus visibility classes (`focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`) with appropriate contextual colors (e.g., `ring-red-500` for destructive actions or `ring-accent`) to custom buttons. Ensure custom modals handle the `Escape` key via a `keydown` event listener.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,22 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen && !isLoading) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose, isLoading]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -97,7 +113,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +139,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -134,7 +150,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What: Added `Escape` key support to close the modal and explicit keyboard focus styles (`focus-visible:ring-2`) to all interactive buttons inside `ResponsiveConfirmDialog`.
🎯 Why: Custom styled buttons were missing default browser focus indicators, making it difficult for keyboard users to determine which action was currently focused. The modal could also not be closed easily with the keyboard.
📸 Before/After: Visual focus rings are now clear when navigating via keyboard (tabbing).
♿ Accessibility: Improved keyboard navigation (WCAG 2.1.1 Keyboard) and focus visibility (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [2677060117371936790](https://jules.google.com/task/2677060117371936790) started by @aafre*