### PR TITLE
🎨 Palette: Restore browser focus outlines on custom modal dialogs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Restoring default browser focus outlines on custom modal dialog components
+
+**Learning:** Custom dialog action buttons (Confirm/Cancel) styled with Tailwind classes like `bg-accent` or `shadow-md` often lose default browser focus outlines, severely impacting keyboard accessibility. Icon-only close buttons in modals also need explicit aria-labels, `aria-hidden` attributes on the icons, and keyboard event handlers (like "Escape" to close the modal) to ensure a fully accessible UX for all users.
+
+**Action:** Whenever creating or editing custom modal dialog components with custom styled buttons, explicitly add `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (using contextual colors like `ring-red-500` for destructive actions or `ring-accent`) to restore keyboard accessibility. Ensure all icon-only buttons have descriptive `aria-label`s, `type="button"` to prevent form submissions, and `aria-hidden="true"` on the icon itself. Modals should also include a `useEffect` hook to handle the `Escape` keydown event to close the dialog.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -33,6 +33,22 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  React.useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen && !isLoading) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isLoading, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -96,12 +112,13 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               </div>
             </div>
             <button
+              type="button"
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label="Close dialog"
               disabled={isLoading}
             >
-              <MdClose className="text-2xl" />
+              <MdClose className="text-2xl" aria-hidden="true" />
             </button>
           </div>
 
@@ -118,10 +135,11 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
           {/* Actions - Mobile: Stack vertically, Desktop: Side by side */}
           <div className="p-6 border-t border-gray-200 space-y-3 lg:space-y-0 lg:flex lg:gap-3 lg:justify-end">
             <button
+              type="button"
               onClick={onClose}
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
-                hover:bg-gray-50 active:bg-gray-100
+                hover:bg-gray-50 active:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -129,10 +147,11 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               {cancelText}
             </button>
             <button
+              type="button"
               onClick={handleConfirm}
               disabled={isLoading}
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
-                shadow-md hover:shadow-lg active:scale-95
+                shadow-md hover:shadow-lg active:scale-95 focus:outline-none focus-visible:ring-2 ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'} focus-visible:ring-offset-2
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}

--- a/resume-builder-ui/src/components/__tests__/ResponsiveConfirmDialog.test.tsx
+++ b/resume-builder-ui/src/components/__tests__/ResponsiveConfirmDialog.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ResponsiveConfirmDialog from '../ResponsiveConfirmDialog';
+
+describe('ResponsiveConfirmDialog Accessibility', () => {
+  it('closes when Escape key is pressed', () => {
+    const handleClose = vi.fn();
+    render(
+      <ResponsiveConfirmDialog
+        isOpen={true}
+        onClose={handleClose}
+        onConfirm={vi.fn()}
+        title="Test"
+        message="Test message"
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- **💡 What**: Added focus-visible classes (`focus-visible:ring-2`, `focus-visible:ring-offset-2`) to the action buttons and close button in `ResponsiveConfirmDialog`. Also added a `useEffect` to support closing the modal via the `Escape` key, and explicitly set `type="button"` and `aria-hidden="true"` attributes for the close icon.
- **🎯 Why**: Custom styled buttons in custom modals lose default browser focus outlines, causing keyboard accessibility issues. Providing explicit focus rings and `Escape` key support ensures users navigating via keyboard can easily use and dismiss the modal.
- **📸 Before/After**: Added visible focus rings on the confirm, cancel, and close buttons when navigating via keyboard. Modal now natively responds to the `Escape` key.
- **♿ Accessibility**: Improved keyboard navigation focus visibility and added `Escape` key closing for better usability. Recorded this standard in `.jules/palette.md`.

---
*PR created automatically by Jules for task [5432299709132532125](https://jules.google.com/task/5432299709132532125) started by @aafre*