### PR TITLE
🎨 Palette: Enhance button accessibility in UploadResumeModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2025-02-14 - Icon-Only Button Accessibility
+**Learning:** Custom modal close buttons implemented with icon-only components (e.g., `XMarkIcon`, `MdClose`) often lack accessible names for screen readers and default focus outlines for keyboard users, leading to hidden accessibility violations.
+**Action:** Always include an `aria-label` (e.g., "Close modal") and explicit focus outline classes (e.g., `focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50`) when creating icon-only interactive elements. Also add `type="button"` to prevent accidental form submissions within the modal.

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -98,8 +98,10 @@ export function UploadResumeModal({
             <h2 className="text-xl font-bold text-white">Upload Resume</h2>
           </div>
           <button
+            type="button"
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 rounded-lg p-1"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>
@@ -244,12 +246,17 @@ export function UploadResumeModal({
         {parseResult && (
           <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end gap-3">
             <button
+              type="button"
               onClick={handleCloseModal}
-              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors"
+              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               Cancel
             </button>
-            <button onClick={handleContinue} className="btn-primary px-6 py-2">
+            <button
+              type="button"
+              onClick={handleContinue}
+              className="btn-primary px-6 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
+            >
               Continue to Editor
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `type="button"`, `aria-label="Close modal"`, and focus styles to the `UploadResumeModal` close button. Added `type="button"` to footer buttons.
🎯 Why: Prevents accidental form submissions within modals and ensures screen readers can identify the close button.
📸 Before/After: N/A
♿ Accessibility: Improved keyboard accessibility with visible focus rings and provided accessible name for an icon-only button.

---
*PR created automatically by Jules for task [2327301063698384042](https://jules.google.com/task/2327301063698384042) started by @aafre*