### PR TITLE
🎨 Palette: Improve keyboard accessibility for ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2024-06-10 - Keyboard Accessibility for Custom Dialogs
+**Learning:** Custom dialog action buttons (Confirm/Cancel) styled with Tailwind classes like `bg-accent` or `shadow-md` lose default browser focus outlines. This makes keyboard navigation difficult or impossible for visually impaired users or those who rely on a keyboard. Also, custom modals must explicitly handle the `Escape` key.
+**Action:** Explicitly add `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (using contextual colors like `ring-red-500` for destructive actions or `ring-accent`) to restore keyboard accessibility on custom buttons. Ensure custom modals handle the `Escape` key to close via a `keydown` event listener.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,19 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isLoading) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose, isLoading]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -42,8 +55,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-500"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +110,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -122,6 +135,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -133,6 +147,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               disabled={isLoading}
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}


### PR DESCRIPTION
💡 What: Added `Escape` key support to close the modal and added explicit focus states (`focus-visible:ring-*`) to action buttons.
🎯 Why: Custom styled buttons drop default browser outlines, making keyboard navigation inaccessible. The `Escape` key is a standard expectation for closing dialogs.
📸 Before/After: Visual change is visible when navigating via keyboard (tabbing through the UI).
♿ Accessibility: Greatly improves keyboard navigation and standardizes modal interaction.

---
*PR created automatically by Jules for task [13287495525638216080](https://jules.google.com/task/13287495525638216080) started by @aafre*