### PR TITLE
🎨 Palette: Make DuplicateResumeModal accessible and responsive to keyboard input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Custom Modal Accessibility
+**Learning:** Custom modals (like `DuplicateResumeModal`) must include standard accessibility attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) and keyboard event handlers (such as listening for the `Escape` key) to ensure they behave predictably for keyboard and screen reader users.
+**Action:** Always verify that newly created custom modals include proper ARIA roles, an `aria-labelledby` referencing the title ID, `tabIndex={-1}`, and keyboard accessibility (like 'Escape' to close and auto-focusing on mount).

--- a/resume-builder-ui/src/components/DuplicateResumeModal.tsx
+++ b/resume-builder-ui/src/components/DuplicateResumeModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ResumeListItem } from '../types';
 
 interface DuplicateResumeModalProps {
@@ -17,12 +17,19 @@ export function DuplicateResumeModal({
   isDuplicating = false
 }: DuplicateResumeModalProps) {
   const [newTitle, setNewTitle] = useState('');
+  const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (resume) {
       setNewTitle(`Copy of ${resume.title}`);
     }
   }, [resume]);
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
 
   if (!isOpen || !resume) return null;
 
@@ -33,9 +40,23 @@ export function DuplicateResumeModal({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && !isDuplicating) {
+      onCancel();
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+      <div
+        ref={modalRef}
+        className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 outline-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-modal-title"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+      >
         <div className="p-6">
           <div className="flex items-center gap-3 mb-4">
             <div className="flex-shrink-0">
@@ -54,7 +75,7 @@ export function DuplicateResumeModal({
               </svg>
             </div>
             <div>
-              <h2 className="text-xl font-bold text-gray-900">Duplicate Resume</h2>
+              <h2 id="duplicate-modal-title" className="text-xl font-bold text-gray-900">Duplicate Resume</h2>
               <p className="text-sm text-gray-500 mt-1">Create a copy with a new name</p>
             </div>
           </div>


### PR DESCRIPTION
💡 What: Added standard ARIA modal attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) and keyboard accessibility (`Escape` key to close, auto-focus container) to the `DuplicateResumeModal`.
🎯 Why: To ensure the modal is fully accessible to screen readers and provides standard keyboard navigation for all users.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Enhances keyboard navigation by allowing the modal to be closed with the Escape key, properly focus on mount, and improves screen reader context by properly labeling the container as a dialog.

---
*PR created automatically by Jules for task [16085065665146569433](https://jules.google.com/task/16085065665146569433) started by @aafre*