### PR TITLE
🎨 Palette: Add confirmation dialog to section deletion

### DIFF
--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -53,11 +56,21 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsConfirmOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
+
+      <ResponsiveConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={deleteSection}
+        title="Delete Section?"
+        message="Are you sure you want to delete this entire section? This action cannot be undone."
+        confirmText="Delete Section"
+        isDestructive={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
💡 What: Wrapped the section deletion action in `SectionControls` with `ResponsiveConfirmDialog`.
🎯 Why: To prevent accidental deletion of entire sections, aligning with the pattern used for other destructive actions.
📸 Before/After: Before, clicking the trash icon deleted the section instantly. After, it prompts the user with a confirmation modal first.
♿ Accessibility: The new confirmation prompt relies on `ResponsiveConfirmDialog` which contains standard ARIA attributes (`role='dialog'`, `aria-modal`, `aria-labelledby`, etc.) and manages focus appropriately.

---
*PR created automatically by Jules for task [17989233337220988772](https://jules.google.com/task/17989233337220988772) started by @aafre*