### PR TITLE
🎨 Palette: Add ARIA labels and focus outlines to modal close buttons

### DIFF
--- a/resume-builder-ui/src/components/TabbedHelpModal.tsx
+++ b/resume-builder-ui/src/components/TabbedHelpModal.tsx
@@ -39,7 +39,8 @@ export default function TabbedHelpModal({
             </h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-gray-400 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded-md"
+              aria-label="Close modal"
             >
               <MdClose className="w-6 h-6" />
             </button>

--- a/resume-builder-ui/src/components/UploadResumeModal.tsx
+++ b/resume-builder-ui/src/components/UploadResumeModal.tsx
@@ -99,7 +99,8 @@ export function UploadResumeModal({
           </div>
           <button
             onClick={handleCloseModal}
-            className="text-white/80 hover:text-white transition-colors"
+            className="text-white/80 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded-md"
+            aria-label="Close modal"
           >
             <XMarkIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label`s and visible focus outlines to the icon-only close buttons in `UploadResumeModal` and `TabbedHelpModal`.
🎯 Why: To ensure screen reader users understand the button's purpose, and keyboard users can clearly see when the button is focused.
📸 Before/After: Visual changes are only visible on keyboard focus. Screen reader now reads "Close modal" instead of "button".
♿ Accessibility: Added `aria-label` to provide an accessible name for the icon buttons. Added `focus-visible:ring-2` to provide a visible focus indicator, complying with WCAG requirements for keyboard accessibility and non-text contrast.

---
*PR created automatically by Jules for task [10813440307507742753](https://jules.google.com/task/10813440307507742753) started by @aafre*