### PR TITLE
feat(seo): rewrite Reddit page title/meta for CTR recovery

### DIFF
--- a/resume-builder-ui/src/config/seoPages.ts
+++ b/resume-builder-ui/src/config/seoPages.ts
@@ -1033,9 +1033,9 @@ export const SEO_PAGES: Record<string, PageConfig> = {
   // /best-free-resume-builder-reddit
   redditRecommended: {
     seo: {
-      title: `Best Free Resume Builder ${CURRENT_YEAR} (Reddit-Tested, Actually Free)`,
+      title: `EasyFreeResume: Free Resume Builder Reddit Recommends (${CURRENT_YEAR})`,
       description:
-        `What r/resumes and r/jobs actually recommend in ${CURRENT_YEAR}. We analyzed 100+ Reddit threads. No paywalls, no watermarks, no sign-up. Here's what passed the test.`,
+        `Tired of "free" builders that charge at download? We read 100+ r/resumes threads. EasyFreeResume passes every test — no paywall, no watermark, no sign-up.`,
       keywords: [
         'best free resume builder reddit',
         'reddit resume builder',

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -25,7 +25,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/free-resume-builder-no-payment', priority: 0.9, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/ai-resume-builder-free', priority: 0.9, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/zety-free-alternative', priority: 0.9, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/best-free-resume-builder-reddit', priority: 0.9, changefreq: 'monthly', lastmod: '2026-02-17' },
+  { loc: '/best-free-resume-builder-reddit', priority: 0.9, changefreq: 'monthly', lastmod: '2026-06-17' },
 
   // ATS Keyword Scanner Tool (0.8)
   { loc: '/resume-keyword-scanner', priority: 0.8, changefreq: 'monthly', lastmod: '2026-03-22' },


### PR DESCRIPTION
## Summary

`/best-free-resume-builder-reddit` sits at **avg position 9.9 with 614 impressions but only 1 click (0.16% CTR)** over the trailing 28 days (GSC, 2026-06-17). At a page-1 position the expected CTR is 2–3%, so a 0.16% CTR is a **snippet / search-intent mismatch problem, not a ranking problem**. This PR rewrites the meta title + description to recover CTR without touching on-page content or position.

## Changes

| | Before | After |
|---|---|---|
| **Title** | `Best Free Resume Builder 2026 (Reddit-Tested, Actually Free)` | `EasyFreeResume: Free Resume Builder Reddit Recommends (2026)` |
| **Description** | "What r/resumes and r/jobs actually recommend in 2026…" | "Tired of \"free\" builders that charge at download? We read 100+ r/resumes threads. EasyFreeResume passes every test — no paywall, no watermark, no sign-up." |

- **Title:** old title had **no brand at all** — non-compliant with the brand-first title governance rule. New title leads with `EasyFreeResume` and keeps the `free resume builder reddit` keyword + "Reddit Recommends" proof angle.
- **Description:** rewritten to lead with the searcher's actual pain (paywalled "free" builders) and the proof angle (100+ r/resumes threads).
- **Sitemap:** `lastmod` for this URL bumped `2026-02-17` → `2026-06-17`.

## Files
- `resume-builder-ui/src/config/seoPages.ts` (`redditRecommended.seo`)
- `resume-builder-ui/src/data/sitemapUrls.ts` (lastmod)

## Verification
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (sitemap regenerated, 117 URLs, lastmod confirmed)

## Governance
- Tier 2 page (changes allowed, logging required — **not** Tier 1, no owner sign-off needed).
- Logged in `seo-tracking/changelog.md` with before-stats.
- Confirmed canonical (not a redirect source; `app.py:1403` redirects *to* this URL).

## Risk
**Low** — meta-only; no URL, routing, schema, H1, or content change.

## Post-merge
- [ ] Re-check GSC CTR for this page at +2 weeks (~2026-07-01) and +3 weeks; flag if position moves >5 spots (regression signal).