### PR TITLE
🎨 Palette: Add keyboard accessibility to ResponsiveConfirmDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-18 - Keyboard Accessibility in Custom Dialogs
+**Learning:** Custom dialog action buttons styled with Tailwind classes like `bg-accent` often lose default browser focus outlines. Modal components also need an Escape key listener.
+**Action:** Explicitly add `focus:outline-none focus-visible:ring-2` to buttons, and `useEffect` for `keydown` with `Escape` handler to close custom dialogs.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,18 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isLoading) {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isLoading, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -42,8 +54,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-600"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +109,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -121,7 +133,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               onClick={onClose}
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
-                hover:bg-gray-50 active:bg-gray-100
+                hover:bg-gray-50 active:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -131,7 +143,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={handleConfirm}
               disabled={isLoading}
-              className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
+              className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]


### PR DESCRIPTION
"💡 What: Added keyboard accessibility to ResponsiveConfirmDialog by adding explicit focus states to buttons and implementing an Escape key listener to close the modal.
🎯 Why: Custom modal components require explicit focus management and keyboard handling to be accessible to screen reader and keyboard-only users.
📸 Before/After: Visual focus rings are now visible on buttons when navigating with the keyboard.
♿ Accessibility: Ensures custom dialog action buttons (Confirm/Cancel/Close) have visible focus outlines, and the dialog can be closed via the `Escape` key."

---
*PR created automatically by Jules for task [13634837639126085845](https://jules.google.com/task/13634837639126085845) started by @aafre*