### PR TITLE
🎨 Palette: Improve keyboard accessibility for confirm dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2024-06-19 - Accessible Dialog Patterns
+**Learning:** Custom dialogs styled with utility classes often lose default browser focus outlines on action buttons. Additionally, standard accessibility requires explicit Escape key handling and modal container focus management for screen readers and keyboard users.
+**Action:** When building or updating dialogs, always include `focus-visible:ring-2` on buttons, add `keydown` listeners for Escape to close, and use `tabIndex={-1}` with `useRef` to auto-focus the dialog wrapper on mount.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,29 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus management
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
+  // Escape key handling
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -42,8 +65,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-500"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -58,10 +81,12 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
       {/* Dialog Container - Bottom sheet on mobile, center modal on desktop */}
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className="fixed z-[9999]
           bottom-0 left-0 right-0
           lg:inset-0 lg:flex lg:items-center lg:justify-center
-          animate-slide-up lg:animate-fade-in"
+          animate-slide-up lg:animate-fade-in outline-none"
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
@@ -97,7 +122,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-md"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +148,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -134,7 +159,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
**💡 What:** Added explicit focus-visible classes to dialog action buttons, implemented Escape key handling to close the dialog, and added focus management for the modal container wrapper.
**🎯 Why:** To prevent custom styled buttons from losing default browser focus outlines, and to allow users to navigate and dismiss dialogs natively via keyboard.
**📸 Before/After:** Buttons lacked keyboard focus outlines. The modal couldn't be closed with the Escape key or initially focused by screen readers.
**♿ Accessibility:** Enhanced keyboard accessibility by adding `focus-visible` outlines, enabling Escape key support, and auto-focusing the dialog container on mount for screen reader clarity.

---
*PR created automatically by Jules for task [1599526127876018350](https://jules.google.com/task/1599526127876018350) started by @aafre*