### PR TITLE
perf(lcp): hydrate prerendered homepage so the shell H1 is the credited LCP element (C4)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1739,8 +1739,21 @@ def serve(path):
         # Check if the path matches a known SPA route prefix
         first_segment = path.split("/")[0] if path else ""
         if first_segment in VALID_SPA_ROUTES:
-            # For bots: serve prerendered HTML if available
             user_agent = request.headers.get("User-Agent", "")
+
+            # C4 LCP spike: serve prerendered HTML to ALL users on the homepage so
+            # the already-painted H1 is the credited LCP element (main.tsx hydrates
+            # it in place via hydrateRoot). Route-limited to "/" for now. Served
+            # with no-cache so a stale prerender can never outlive its JS bundle —
+            # the #1 hydration-mismatch risk for prerender-to-all.
+            if path == "":
+                prerendered = _get_prerendered_path(path)
+                if prerendered:
+                    resp = send_file(prerendered, mimetype="text/html")
+                    resp.headers["Cache-Control"] = "no-cache, must-revalidate"
+                    return resp
+
+            # For bots on other routes: serve prerendered HTML if available
             if _is_bot(user_agent):
                 prerendered = _get_prerendered_path(path)
                 if prerendered:

--- a/resume-builder-ui/scripts/prerender.ts
+++ b/resume-builder-ui/scripts/prerender.ts
@@ -71,7 +71,13 @@ function buildRoutesToPrerender(): string[] {
   return Array.from(routes);
 }
 
-const ROUTES_TO_PRERENDER = buildRoutesToPrerender();
+// Allow scoping the prerender to a subset of routes for fast local iteration
+// (e.g. PRERENDER_ONLY="/" to prerender just the homepage). Comma-separated.
+// When unset, prerender the full route list.
+const PRERENDER_ONLY = process.env.PRERENDER_ONLY;
+const ROUTES_TO_PRERENDER = PRERENDER_ONLY
+  ? PRERENDER_ONLY.split(',').map((r) => r.trim()).filter(Boolean)
+  : buildRoutesToPrerender();
 
 /**
  * Simple static file server for the dist directory.
@@ -274,6 +280,11 @@ async function prerender() {
       // Strip duplicate meta tags: remove original index.html tags when
       // react-helmet-async has injected page-specific replacements (data-rh="true")
       html = cleanPrerenderedHtml(html, port);
+
+      // Mark the root so the client entry (main.tsx) uses hydrateRoot instead of
+      // createRoot. Prerendered HTML is React's real output, so hydration adopts
+      // it in place and the already-painted H1 keeps LCP credit.
+      html = html.replace('<div id="root">', '<div id="root" data-prerendered="true">');
 
       // Validate: reject prerendered pages that accidentally contain noindex
       // (Only ErrorPage and NotFound should have noindex, never valid pages)

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -44,13 +44,10 @@ const LandingPage: React.FC = () => {
     // No auto-redirect for authenticated users - let them see landing page
   }, [searchParams, navigate]);
 
-  const resumeCountValue = useMemo(() => {
-    const launchDate = new Date("2019-01-01T00:00:00Z");
-    const now = new Date();
-    const msPerDay = 24 * 60 * 60 * 1000;
-    const daysSinceLaunch = Math.floor((now.getTime() - launchDate.getTime()) / msPerDay);
-    return 52000 + daysSinceLaunch * 28;
-  }, []);
+  // Static approximate count — kept constant (no new Date()) so the prerendered
+  // HTML and the first client render are byte-identical. This is what lets the
+  // landing route hydrate cleanly under hydrateRoot. Bump manually over time.
+  const resumeCountValue = 150000;
 
   const prefersReducedMotion = useMemo(
     () =>

--- a/resume-builder-ui/src/main.tsx
+++ b/resume-builder-ui/src/main.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { flushSync } from "react-dom";
 import { HelmetProvider } from 'react-helmet-async';
 import { onCLS } from 'web-vitals/attribution';
@@ -19,15 +19,33 @@ onCLS((metric) => {
   });
 });
 
-// flushSync forces the initial React render to be synchronous, eliminating
-// the intermediate DOM state (shell-header gone, H1 still visible) that
-// causes the 64px CLS shift measured by Codex at ~181ms.
-flushSync(() => {
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <HelmetProvider>
-        <App />
-      </HelmetProvider>
-    </StrictMode>
-  );
-});
+const rootEl = document.getElementById("root")!;
+const app = (
+  <StrictMode>
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  </StrictMode>
+);
+
+if (rootEl.dataset.prerendered === "true") {
+  // Prerendered route (e.g. "/"): the served HTML is React's real output, so
+  // the H1 is already painted from HTML and is the credited LCP element.
+  // hydrateRoot ADOPTS that DOM in place (no innerHTML wipe), so the H1 keeps
+  // LCP credit. No flushSync here: hydration preserves the existing DOM, so
+  // there is no shell-header→React-header swap and thus no 64px CLS shift.
+  hydrateRoot(rootEl, app, {
+    onRecoverableError: (error) => {
+      // Surface hydration mismatches loudly during the spike so we can prove
+      // the first client render matches the prerendered snapshot.
+      console.error("[hydration]", error);
+    },
+  });
+} else {
+  // Shell path (non-prerendered routes): flushSync forces a synchronous initial
+  // render, eliminating the intermediate DOM state (shell-header gone, H1 still
+  // visible) that causes the 64px CLS shift measured at ~181ms.
+  flushSync(() => {
+    createRoot(rootEl).render(app);
+  });
+}


### PR DESCRIPTION
## What & why (C4 of the mobile-CWV plan)

Homepage field p75 **LCP is 3956ms** because `createRoot` wipes `#root` and rebuilds it, so the LCP credit goes to the **JS-built React H1** (render-delay ~97%) rather than the byte-identical shell H1 that already paints at FCP. This PR makes the **already-painted H1 the credited LCP element** by serving the existing prerendered HTML to all users on `/` and mounting with `hydrateRoot` (which adopts the DOM in place instead of discarding it).

This was validated against two independent external reviews (Codex + Gemini/Antigravity), both of which recommended *prerender-to-all + `hydrateRoot`* and both confirmed pure-CSR shell-H1-as-LCP is impossible (the browser invalidates the shell H1 as an LCP candidate the moment `createRoot` removes it).

## Changes

| File | Change |
|---|---|
| `app.py` | `serve()`: homepage `/` serves prerendered HTML to **all** users (was bot-only UA gate), `Cache-Control: no-cache, must-revalidate` so a stale prerender can never outlive its JS bundle. Other routes unchanged (still shell + bot-gated prerender). |
| `resume-builder-ui/src/main.tsx` | `hydrateRoot` when `#root` has `data-prerendered="true"` (no `flushSync` — hydration preserves the DOM, so there's no shell-header→React-header swap and thus no 64px CLS shift). Falls back to `createRoot`+`flushSync` for non-prerendered routes (shell path unchanged). |
| `resume-builder-ui/scripts/prerender.ts` | Tags `#root` with `data-prerendered="true"`; adds `PRERENDER_ONLY` env var to scope prerendering to a route subset for fast local iteration (defaults to full list when unset). |
| `resume-builder-ui/src/components/LandingPage.tsx` | Hero "Resumes Created" stat changed from a `new Date()`-derived number (drifted daily) to a static `150,000+`. This was the **one deterministic hydration mismatch** — a date-derived value differs from the build-time prerender on every later load. |

## Why `hydrateRoot` is coherent here (vs the earlier dismissal)

The earlier "hydrateRoot not viable" note was about hydrating the **hand-built shell** (not React's output). This PR hydrates the **prerendered HTML**, which *is* React's exact output — so React adopts it cleanly. The `flushSync` CLS fix is only needed on the shell path, which is untouched.

## Evidence (local same-server A/B, Slow-4G + 4× CPU, 390×844)

> ⚠️ Absolute numbers are compression-distorted (local spike server serves uncompressed). The **relative** A/B and the **qualitative** results are what matter; real compressed numbers come from the pending dev deploy.

| | OLD (shell + `createRoot`) | NEW (prerender + `hydrateRoot`) |
|---|---|---|
| LCP | 6741 ms (JS-gated) | **4964 ms (CSS-gated)** |
| LCP element | React H1, post-bundle | H1 painted from HTML, kept |
| CLS | 0.00 | **0.00** |
| Hydration errors | n/a | **none** (`onRecoverableError` silent, zero React warnings) |

**−1777 ms** on the same server — that delta is the JS download+execute gating that hydration removes; in the field (JS-download-dominated on slow connections) the delta is larger.

## Risks / reviewer focus

- **Serving-path change on the SEO-primary page.** Prerendered HTML is React's exact output (same content bots already saw); title/meta/schema/canonical unchanged. `no-cache` on the HTML prevents stale-prerender/JS-bundle skew (the #1 hydration risk).
- **New LCP gate = render-blocking external CSS** (prerendered HTML lacks the inline critical CSS the shell had). Follow-on (deferred until we see dev numbers): inline critical CSS into the prerendered `<head>` to push LCP toward TTFB.
- Hydration verified clean locally, but **real auth/Supabase** (anonymous→authed transition) is only exercised on dev — part of the pending validation.

## Verification

- `tsc -b` clean · **1456 vitest pass / 0 fail**
- Prerendered `/` HTML confirmed: `<div id="root" data-prerendered="true">`, real H1 present, counter `<span>150,000+</span>`
- SEO changelog entry added (`seo-tracking/changelog.md`, 2026-06-21)

## Not done in this PR (intentionally)

- ❌ Not merged to main — **dev CrUX validation + sign-off required first**
- ❌ Critical-CSS inlining — decide after dev LCP
- Next: deploy to dev → I re-run the throttled before/after trace (compressed) → decide critical-CSS → PR to main only after sign-off.