### PR TITLE
🎨 Palette: Improve keyboard accessibility for ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2024-05-18 - Improve Keyboard Accessibility for ResponsiveConfirmDialog
+**Learning:** Custom dialog components and action buttons (Confirm/Cancel) styled with Tailwind classes like `shadow-md` or custom backgrounds often lose standard browser focus outlines. Furthermore, explicit `Escape` key handling and focus management on mount are essential for modal accessibility.
+**Action:** Explicitly add `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (with contextual ring colors) to custom buttons to restore keyboard accessibility. Ensure custom modals handle the `Escape` key to close via a `keydown` event listener, and use `tabIndex={-1}` with an auto-focus on the container to direct screen readers.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,24 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -42,10 +60,10 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-600"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
-  const confirmClass = confirmButtonClass || defaultConfirmClass;
+  const confirmClass = `${confirmButtonClass || defaultConfirmClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`;
 
   return (
     <>
@@ -62,6 +80,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
           bottom-0 left-0 right-0
           lg:inset-0 lg:flex lg:items-center lg:justify-center
           animate-slide-up lg:animate-fade-in"
+        ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
@@ -97,7 +117,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -122,7 +142,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
-                transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What
- Added `Escape` key handling to `ResponsiveConfirmDialog` to allow keyboard users to dismiss the modal intuitively.
- Implemented focus management by auto-focusing the dialog container on open, ensuring screen readers announce it immediately.
- Added explicit `focus-visible` styles to the Cancel, Confirm, and Close buttons to restore keyboard focus rings that were obscured by custom styling.

🎯 Why
- Custom modals and heavily styled Tailwind buttons often lose standard browser focus outlines and native behavior. Restoring explicit `focus-visible` rings, `Escape` to close, and initial focus improves keyboard navigation and screen reader compatibility.

📸 Before/After
Before: Navigating the dialog with 'Tab' showed no clear visual indicator on the action buttons. The dialog could not be closed with 'Escape'.
After: Pressing 'Tab' clearly highlights the currently focused button with a visible ring. Pressing 'Escape' closes the dialog.

♿ Accessibility
- Ensures WCAG compliance for modal dialogs (Focus Management, Keyboard Accessible).
- Improves visibility of focus states for sighted keyboard users.
- Ensures screen readers are directed to the dialog content immediately upon opening.

---
*PR created automatically by Jules for task [2469949119910305129](https://jules.google.com/task/2469949119910305129) started by @aafre*