### PR TITLE
chore(seo): T3 — noindex + de-sitemap ai-cover-letter-prompts thin sibling

### DIFF
--- a/resume-builder-ui/src/components/BlogLayout.tsx
+++ b/resume-builder-ui/src/components/BlogLayout.tsx
@@ -31,6 +31,8 @@ interface BlogLayoutProps {
   showBreadcrumbs?: boolean;
   ctaType?: 'resume' | 'interview' | 'general';
   faqs?: BlogFAQ[];
+  /** When true, emit robots="noindex, follow" (deindex a thin/consolidated page while keeping link equity flowing). */
+  noindex?: boolean;
 }
 
 export default function BlogLayout({
@@ -43,7 +45,8 @@ export default function BlogLayout({
   keywords,
   showBreadcrumbs = true,
   ctaType = 'general',
-  faqs
+  faqs,
+  noindex
 }: BlogLayoutProps) {
   // Use hardcoded BASE_URL (not window.location.origin) so prerendered HTML
   // gets production canonical URLs instead of http://localhost:4173
@@ -59,6 +62,7 @@ export default function BlogLayout({
         keywords={keywords.join(', ')}
         canonicalUrl={currentUrl}
         ogType="article"
+        {...(noindex ? { robots: 'noindex, follow' } : {})}
         articleMeta={{
           publishedTime: publishDate,
           modifiedTime: lastUpdated,

--- a/resume-builder-ui/src/components/blog/AICoverLetterPrompts.tsx
+++ b/resume-builder-ui/src/components/blog/AICoverLetterPrompts.tsx
@@ -18,6 +18,7 @@ export default function AICoverLetterPrompts() {
         'cover letter chatgpt prompts',
       ]}
       ctaType="resume"
+      noindex
     >
       <div className="space-y-8">
         <p className="text-xl leading-relaxed text-stone-warm font-medium">

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -82,14 +82,9 @@ export const blogPosts: BlogPost[] = [
     readTime: "12 min",
     category: "Resume Writing",
   },
-  {
-    slug: "ai-cover-letter-prompts",
-    title: "25+ AI Cover Letter Prompts (Copy-Paste Ready for Any AI Tool)",
-    description: "AI cover letter prompts that actually work: tailored cover letters, opening hooks, career changes, follow-ups, and thank-you notes. Copy-paste ready for ChatGPT, Claude, Copilot, and Gemini.",
-    publishDate: "2026-03-05",
-    readTime: "16 min",
-    category: "AI & Tools",
-  },
+  // ai-cover-letter-prompts intentionally removed from index/sitemap — the page is
+  // noindexed as a thin, near-duplicate prompt-cluster sibling (post-Apr-2026 core-update
+  // quality pruning). Route kept in App.tsx so the live URL still serves the noindex tag.
   {
     slug: "ai-job-description-analyzer",
     title: "How to Use AI to Analyze Job Descriptions (Extract Keywords & Requirements)",

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -99,7 +99,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/ai-job-description-analyzer', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
   { loc: '/blog/ai-resume-review', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
-  { loc: '/blog/ai-cover-letter-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
+  // ai-cover-letter-prompts removed — noindexed thin prompt-cluster sibling (see AICoverLetterPrompts.tsx)
   { loc: '/blog/career-change-resume-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
   { loc: '/blog/resume-employment-gaps', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },
   { loc: '/blog/return-to-work-programs', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-05' },


### PR DESCRIPTION
## T3 — Prune dead prompt-cluster siblings (revenue-recovery workstream)

**Base:** `integration/seo-revenue-recovery` · **Merge is owner-gated** (do not merge without sign-off).

### Reconciliation note (important)
The handoff's T3 listed 5 siblings to prune, but 4 of them (`chatgpt`, `grok`, `deepseek`, `copilot` resume-prompts) are **already consolidated** — server-side 301 in `app.py:1424-1445` + client `<Navigate>` to the hub + already removed from the sitemap (done in a prior session). `claude` and `gemini` are real pages we keep. So the **only** live standalone sibling left to prune is `ai-cover-letter-prompts`. This PR handles exactly that.

> ⚠️ Guardrail contradiction to flag: the handoff says "no 301 for the prompt cluster — taint risk," but those 4 pages already 301 into the hub. That decision is shipped; this PR does **not** reverse it (reversing would churn more signals). Owner call whether to revisit later.

### What changed
- **`BlogLayout.tsx`** — new optional `noindex?: boolean` prop → emits `robots="noindex, follow"` via `SEOHead` (keeps link equity flowing while deindexing).
- **`AICoverLetterPrompts.tsx`** — passes `noindex`. Route kept in `App.tsx` so the live URL still serves the noindex tag to (JS-rendering) crawlers.
- **`blogPosts.ts`** — entry removed (drops it from the blog index + `RelatedArticles`).
- **`sitemapUrls.ts`** — URL removed (also drops it from the prerender route list, so the prerender build's noindex guard won't trip).

Contextual inbound links across the prompt cluster were **intentionally left** (harmless with `noindex, follow`, and stripping ~12 links across 10 files would churn many pages against the "one change at a time" guardrail).

### Verification
- `npx tsc --noEmit` → clean (exit 0)
- Targeted vitest: `blogPosts.test.ts`, `prerenderRoutes.test.ts`, `AIResumePromptsHub.test.tsx` → **15/15 pass** (hub→cover-letter link test still green; that link is untouched)
- `npm run lint` → no new errors from the 4 edited files (repo has a pre-existing ~186-error lint baseline in unrelated files)

Branch is 1 commit behind integration (base `a43946fc`; integration now `aecb6436`) — no file overlap, merges clean.