### PR TITLE
feat(seo): T4 — add "Humanize an AI-Written Resume" blog page

### DIFF
--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -91,6 +91,7 @@ const ATSOptimization = lazy(() => import("./components/blog/ATSOptimization"));
 const ResumeNoExperience = lazy(() => import("./components/blog/ResumeNoExperience"));
 const ProfessionalSummaryExamples = lazy(() => import("./components/blog/ProfessionalSummaryExamples"));
 const ResumeKeywordsGuide = lazy(() => import("./components/blog/ResumeKeywordsGuide"));
+const HumanizeAIResume = lazy(() => import("./components/blog/HumanizeAIResume"));
 const CoverLetterGuide = lazy(() => import("./components/blog/CoverLetterGuide"));
 const RemoteWorkResume = lazy(() => import("./components/blog/RemoteWorkResume"));
 const ResumeLengthGuide = lazy(() => import("./components/blog/ResumeLengthGuide"));
@@ -581,6 +582,14 @@ function AppContent() {
             element={
               <Suspense fallback={<BlogLoadingSkeleton />}>
                 <ResumeKeywordsGuide />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/blog/humanize-ai-resume"
+            element={
+              <Suspense fallback={<BlogLoadingSkeleton />}>
+                <HumanizeAIResume />
               </Suspense>
             }
           />

--- a/resume-builder-ui/src/components/blog/AIResumeWritingGuide.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumeWritingGuide.tsx
@@ -423,6 +423,11 @@ export default function AIResumeWritingGuide() {
               AI Resume Builders: Are They Worth It?
             </Link>
           </li>
+          <li>
+            <Link to="/blog/humanize-ai-resume" className="text-accent hover:underline">
+              How to Humanize an AI-Written Resume
+            </Link>
+          </li>
         </ul>
       </div>
     </BlogLayout>

--- a/resume-builder-ui/src/components/blog/HumanizeAIResume.tsx
+++ b/resume-builder-ui/src/components/blog/HumanizeAIResume.tsx
@@ -1,0 +1,296 @@
+import { Link } from "react-router-dom";
+import BlogLayout from "../BlogLayout";
+
+const FAQS = [
+  {
+    question: "Do applicant tracking systems (ATS) run AI detectors on resumes?",
+    answer:
+      "No. Mainstream ATS platforms like Workday, Greenhouse, and Lever parse text and match keywords — they do not run AI-content detectors. The real risk with AI-written resumes isn't a detector flag; it's that generic, low-specificity content loses to concrete, specific content once a human recruiter reads it.",
+  },
+  {
+    question: "Can recruiters actually tell a resume was written by AI?",
+    answer:
+      "Experienced recruiters often can, not because they run software, but because AI drafts share a recognizable texture: uniform sentence length, corporate filler like 'spearheaded' and 'leveraged synergies,' round-number metrics with no context, and every bullet opening the same way. Specific, varied, verifiable detail reads as human because only you know those details.",
+  },
+  {
+    question: "What are perplexity and burstiness?",
+    answer:
+      "Perplexity measures how predictable text is — AI tends to pick the most likely next word, so its writing is low-perplexity and 'smooth.' Burstiness measures variation in sentence length and complexity. Human writing mixes short and long sentences (high burstiness); AI drafts are uniform (low burstiness). Detectors and readers both notice the flatness.",
+  },
+  {
+    question: "Is it dishonest to humanize an AI-written resume?",
+    answer:
+      "Not if you're editing toward truth. Humanizing means replacing vague, generic claims with specific, accurate details from your real experience. That's the opposite of dishonest. It only becomes a problem if you invent numbers or accomplishments — so anchor every edit to something you actually did.",
+  },
+  {
+    question: "How do I add metrics if I never tracked numbers in my job?",
+    answer:
+      "Use honest estimates and context instead of inventing precise figures. 'Reduced ticket backlog' can become 'cleared a two-week support backlog to same-day response across a team of four.' Scope, scale, timeframe, and team size are all quantifiable without fabricating a percentage you can't defend in an interview.",
+  },
+  {
+    question: "Should I just avoid AI entirely when writing my resume?",
+    answer:
+      "No — AI is a useful first-draft and brainstorming tool. The mistake is shipping the raw output. Use AI to structure and get unstuck, then rewrite each bullet with your specific projects, tools, numbers, and voice. The goal is a truthful, specific, well-written resume, not a machine-perfect one.",
+  },
+];
+
+export default function HumanizeAIResume() {
+  return (
+    <BlogLayout
+      title="How to Humanize an AI-Written Resume (Beat AI Detectors)"
+      description="AI resumes get rejected when they read as generic and machine-written. Learn the tells recruiters and AI detectors catch, and how to rewrite them into specific, human copy."
+      publishDate="2026-07-01"
+      lastUpdated="2026-07-01"
+      readTime="9 min"
+      keywords={[
+        "humanize ai resume",
+        "remove ai tells from resume",
+        "ai resume detector",
+        "ai written resume",
+        "resume perplexity burstiness",
+        "ats ai detection",
+      ]}
+      ctaType="resume"
+      faqs={FAQS}
+    >
+      <div className="space-y-8">
+        {/* Answer-first intro (<=50 words) */}
+        <p className="text-xl leading-relaxed text-stone-warm font-medium">
+          <strong>Humanizing an AI-written resume</strong> means editing the
+          generic, uniform text that AI produces into specific, varied,
+          verifiable copy that reads as written by a real person. The one-line
+          how: replace vague claims and round-number metrics with concrete
+          detail from your actual work, and break up robotic sentence rhythm.
+        </p>
+
+        {/* Table of Contents */}
+        <nav className="bg-chalk-dark border border-black/[0.06] rounded-xl p-6 my-8">
+          <h2 className="font-bold text-ink mb-4 text-lg">Table of Contents</h2>
+          <ol className="space-y-2 text-ink/80 list-decimal list-inside">
+            <li><a href="#why-flagged" className="text-accent hover:underline">Why AI-Written Resumes Get Flagged</a></li>
+            <li><a href="#the-tells" className="text-accent hover:underline">The Tells That Give AI Away</a></li>
+            <li><a href="#fix-by-fix" className="text-accent hover:underline">Fix-by-Fix: Before and After Rewrites</a></li>
+            <li><a href="#honest-goal" className="text-accent hover:underline">The Honest Goal (It's Not Tricking a Detector)</a></li>
+            <li><a href="#faq" className="text-accent hover:underline">Frequently Asked Questions</a></li>
+          </ol>
+        </nav>
+
+        <h2 id="why-flagged" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Why AI-Written Resumes Get Flagged and Rejected
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          AI language models work by predicting the most likely next word. That
+          makes their output smooth, grammatical — and predictable. Two
+          properties describe this, and both AI detectors and experienced
+          recruiters key off them:
+        </p>
+
+        <div className="grid md:grid-cols-2 gap-6 my-8">
+          <div className="bg-white border border-black/[0.06] rounded-xl p-6 shadow-sm">
+            <h3 className="text-xl font-bold text-ink mb-2">Perplexity</h3>
+            <p className="text-stone-warm text-sm">
+              How surprising the word choices are. Because AI reaches for the
+              statistically likeliest phrasing, its text is{" "}
+              <strong>low-perplexity</strong> — every sentence feels like the
+              expected one. Human writing takes more unpredictable turns.
+            </p>
+          </div>
+          <div className="bg-white border border-black/[0.06] rounded-xl p-6 shadow-sm">
+            <h3 className="text-xl font-bold text-ink mb-2">Burstiness</h3>
+            <p className="text-stone-warm text-sm">
+              How much sentence length and complexity vary. Humans mix a
+              three-word punch with a long, winding clause. AI drafts are{" "}
+              <strong>low-burstiness</strong> — uniform, even, and flat. On a
+              resume, that shows up as bullets of nearly identical length.
+            </p>
+          </div>
+        </div>
+
+        <p className="text-lg leading-relaxed text-stone-warm">
+          The honest version: low-variance, generic text reads as machine-written
+          to software <em>and</em> to a person who screens resumes all day. You
+          don't have to beat a detector to lose — a recruiter skimming twenty
+          near-identical, filler-heavy bullets will simply move on to the
+          candidate whose resume says something specific.
+        </p>
+
+        <h2 id="the-tells" className="text-3xl font-bold text-ink mt-12 mb-6">
+          The Tells That Give AI Away
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm mb-6">
+          Before you can fix an AI draft, you have to spot the patterns. Here are
+          the ones that show up most often:
+        </p>
+
+        <div className="space-y-4">
+          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+            <h3 className="font-bold text-ink mb-2">Generic, round-number metrics with no context</h3>
+            <p className="text-stone-warm">
+              "Increased efficiency by 30%." Thirty percent of what, measured how,
+              over what period? AI loves clean numbers precisely because it has no
+              real data to anchor them.
+            </p>
+          </div>
+          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+            <h3 className="font-bold text-ink mb-2">Uniform sentence rhythm</h3>
+            <p className="text-stone-warm">
+              Every bullet runs 12–15 words and follows the same shape. Real
+              accomplishments come in different sizes, so real bullets should too.
+            </p>
+          </div>
+          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+            <h3 className="font-bold text-ink mb-2">Corporate filler</h3>
+            <p className="text-stone-warm">
+              "Spearheaded," "leveraged synergies," "spearheaded cross-functional
+              initiatives to drive impactful outcomes." Words that sound like work
+              but describe nothing.
+            </p>
+          </div>
+          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+            <h3 className="font-bold text-ink mb-2">Hallucinated specifics</h3>
+            <p className="text-stone-warm">
+              AI will confidently invent a tool, a certification, or a metric you
+              never had. These are the most dangerous tells because they can
+              collapse in an interview.
+            </p>
+          </div>
+          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+            <h3 className="font-bold text-ink mb-2">Em-dash overuse and identical bullet openers</h3>
+            <p className="text-stone-warm">
+              A cascade of em dashes, and every bullet starting with the same verb
+              ("Led… Led… Led…"). Vary your openers and punctuation.
+            </p>
+          </div>
+        </div>
+
+        <h2 id="fix-by-fix" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Fix-by-Fix: Before and After Rewrites
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm mb-6">
+          The rewrites below are illustrative examples we wrote to show the
+          technique — not real people's resumes. Notice how each "after" trades a
+          generic claim for a specific, verifiable one.
+        </p>
+
+        <div className="space-y-6">
+          <div className="bg-white border border-black/[0.06] rounded-xl p-6 shadow-sm">
+            <p className="font-mono text-xs tracking-[0.15em] text-red-500 uppercase mb-2">Before (AI)</p>
+            <p className="text-ink mb-4">
+              "Spearheaded cross-functional initiatives that increased team
+              efficiency by 30% and drove impactful business outcomes."
+            </p>
+            <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-2">After (Humanized)</p>
+            <p className="text-ink">
+              "Reorganized the weekly release process with QA and support, cutting
+              our average bug-fix turnaround from nine days to three across a team
+              of five engineers."
+            </p>
+          </div>
+
+          <div className="bg-white border border-black/[0.06] rounded-xl p-6 shadow-sm">
+            <p className="font-mono text-xs tracking-[0.15em] text-red-500 uppercase mb-2">Before (AI)</p>
+            <p className="text-ink mb-4">
+              "Leveraged data-driven strategies to optimize marketing performance
+              and enhance customer engagement."
+            </p>
+            <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-2">After (Humanized)</p>
+            <p className="text-ink">
+              "Rebuilt our abandoned-cart email flow in Klaviyo after noticing most
+              drop-offs happened at shipping cost — recovered roughly one in six
+              carts we'd been losing."
+            </p>
+          </div>
+
+          <div className="bg-white border border-black/[0.06] rounded-xl p-6 shadow-sm">
+            <p className="font-mono text-xs tracking-[0.15em] text-red-500 uppercase mb-2">Before (AI)</p>
+            <p className="text-ink mb-4">
+              "Utilized strong communication skills to facilitate seamless
+              collaboration and deliver exceptional results."
+            </p>
+            <p className="font-mono text-xs tracking-[0.15em] text-accent uppercase mb-2">After (Humanized)</p>
+            <p className="text-ink">
+              "Ran the daily standup for a remote team split across three time
+              zones and wrote the handoff notes that kept the night shift
+              unblocked."
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-accent/[0.06] border border-accent/20 rounded-xl p-6 my-8">
+          <h3 className="font-bold text-ink mb-3">The humanizing checklist</h3>
+          <ul className="list-disc pl-6 space-y-2 text-ink/80">
+            <li>Swap every vague verb for what you actually did (a real action, tool, or decision).</li>
+            <li>Anchor numbers to scope: team size, timeframe, volume, or a before/after.</li>
+            <li>Vary bullet length and opening words deliberately.</li>
+            <li>Delete filler that survives without changing meaning ("impactful," "seamless," "robust").</li>
+            <li>Fact-check every specific — if you can't defend it in an interview, cut it.</li>
+          </ul>
+        </div>
+
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Once your bullets are specific, make sure they still carry the terms
+          employers scan for. Run the draft through our free{" "}
+          <Link to="/resume-keyword-scanner" className="text-accent hover:underline font-medium">
+            resume keyword scanner
+          </Link>{" "}
+          to check coverage against a real job posting, and start from an{" "}
+          <Link to="/templates/ats-friendly" className="text-accent hover:underline font-medium">
+            ATS-friendly template
+          </Link>{" "}
+          so your specific, humanized content actually parses.
+        </p>
+
+        <h2 id="honest-goal" className="text-3xl font-bold text-ink mt-12 mb-6">
+          The Honest Goal: Specific and True, Not Detector-Proof
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          It's tempting to treat this as a game of beating an AI detector. It
+          isn't. Here's the reality worth internalizing:
+        </p>
+
+        <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-6 my-6">
+          <p className="text-yellow-800">
+            <strong>ATS software does not run AI-content detectors.</strong> The
+            real risk isn't being flagged as "AI-written" — it's that generic
+            content loses to specific content in front of a human reviewer.
+            Humanizing wins because specificity is more persuasive, not because it
+            evades a scanner.
+          </p>
+        </div>
+
+        <p className="text-lg leading-relaxed text-stone-warm">
+          So the target is a resume that is <strong>truthful, specific, and well
+          written</strong>. AI is a genuinely useful drafting and brainstorming
+          partner — for structuring sections, getting unstuck, and turning notes
+          into first-pass bullets. The mistake is shipping the raw output. Use it
+          to start, then rewrite in your own detail and voice. For a full
+          walkthrough of using AI well from the first draft, see our{" "}
+          <Link to="/blog/ai-resume-writing-guide" className="text-accent hover:underline font-medium">
+            AI resume writing guide
+          </Link>.
+        </p>
+
+        <h2 id="faq" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Frequently Asked Questions
+        </h2>
+        <div className="space-y-4 my-6">
+          {FAQS.map((faq, i) => (
+            <div key={i} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-4">
+              <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
+              <p className="text-stone-warm text-sm">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">The Bottom Line</h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Humanizing an AI resume isn't about fooling anyone. It's editing toward
+          the truth: replacing smooth, generic filler with the specific,
+          verifiable details only you can supply. Do that, and you'll read as
+          human to detectors and recruiters alike — because you'll actually be
+          saying something real.
+        </p>
+      </div>
+    </BlogLayout>
+  );
+}

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -42,6 +42,15 @@ export const blogPosts: BlogPost[] = [
     category: "AI & Tools",
   },
   {
+    slug: "humanize-ai-resume",
+    title: "How to Humanize an AI-Written Resume (Beat AI Detectors)",
+    description: "AI resumes get rejected when they read as generic and machine-written. Learn the tells recruiters and AI detectors catch, and how to rewrite them into specific, human copy.",
+    publishDate: "2026-07-01",
+    lastUpdated: "2026-07-01",
+    readTime: "9 min",
+    category: "AI & Tools",
+  },
+  {
     slug: "claude-resume-prompts",
     title: "25+ Claude AI Resume Prompts (Copy-Paste Ready) 2026",
     description: "Best Claude prompts for resume writing: professional summary, experience bullets, cover letters, career change, ATS optimization. Copy-paste ready for Claude 3.5 Sonnet and Opus.",

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -95,6 +95,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   // New AI Blog Posts (0.5) - recently created
   { loc: '/blog/ai-resume-prompts-hub', priority: 0.5, changefreq: 'monthly', lastmod: '2026-05-25' },
   { loc: '/blog/ai-resume-writing-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },
+  { loc: '/blog/humanize-ai-resume', priority: 0.5, changefreq: 'monthly', lastmod: '2026-07-01' },
   { loc: '/blog/claude-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-17' },
   { loc: '/blog/gemini-resume-prompts', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/ai-job-description-analyzer', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-21' },


### PR DESCRIPTION
## T4 — New page: How to Humanize an AI-Written Resume (Beat AI Detectors)

**Base:** `integration/seo-revenue-recovery` · **Merge is owner-gated.**
Net-new, high-intent, AIO-resistant page (Gemini #2). Target: "humanize ai resume", "remove ai tells from resume".

### What changed (all additions — 5 files, 0 deletions)
- **`HumanizeAIResume.tsx`** (new) — `BlogLayout`-wrapped page. Answer-first intro (≤50 words), sections on perplexity/burstiness (honestly framed), the AI tells, three self-authored before→after rewrites (explicitly labelled illustrative), and honest framing that ATS does **not** run AI-detectors. Visible FAQ (6 Q&A) + matching `faqs` schema prop.
- **`App.tsx`** — lazy import + `/blog/humanize-ai-resume` route (confirmed not a redirect source).
- **`blogPosts.ts`** — BlogPost entry (category "AI & Tools").
- **`sitemapUrls.ts`** — sitemap entry (priority 0.5, lastmod 2026-07-01; auto-adds to prerender list).
- **`AIResumeWritingGuide.tsx`** — one inbound "Related Resources" link.
- Internal links out: `/resume-keyword-scanner`, `/templates/ats-friendly`, `/blog/ai-resume-writing-guide`.

### Reviewer verification (I checked the diff, not just the agent's word)
- **Honesty guardrail: clean.** The only numbers ("30%") appear *inside* before/after examples critiquing vague AI metrics — no fabricated study stats, percentages, quotes, or credentials.
- **FAQ pattern correct:** `faqs` prop (JSON-LD) **and** visible FAQ JSX both present (per `BlogLayout.tsx:99-105`, the prop emits schema only).
- `npx tsc --noEmit` clean; file-scoped eslint clean; no new errors in `npm run lint` baseline.

Built by subagent, reviewed/validated by orchestrator. Branch 1 commit behind integration; no file overlap, merges clean.