### PR TITLE
feat(ui): resume builder UI/UX polish pass

### DIFF
--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -231,7 +231,8 @@ function AppContent() {
           isEditorPage ? "px-0" : "px-4 sm:px-6 md:px-8"
         }`}
       >
-        <SideRailLayout enabled={!isEditorPage}>
+        {/* Landing page renders its own mobile-top ad below the hero */}
+        <SideRailLayout enabled={!isEditorPage} showMobileTop={location.pathname !== "/"}>
         <Routes>
           {/* Landing page — inlined to eliminate Suspense CLS */}
           <Route path="/" element={<LandingPage />} />

--- a/resume-builder-ui/src/__tests__/AdContainer.test.tsx
+++ b/resume-builder-ui/src/__tests__/AdContainer.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
   mockMutationObserver.mockClear();
 
   // Setup IntersectionObserver mock
-  mockIntersectionObserver.mockImplementation((callback) => {
+  mockIntersectionObserver.mockImplementation(() => {
     return {
       observe: mockObserve,
       disconnect: mockDisconnect,
@@ -55,7 +55,9 @@ describe("AdContainer", () => {
   it("renders ad container with correct test id", () => {
     render(<AdContainer adSlot="1234567890" testId="test-ad" />);
 
-    expect(screen.getByTestId("test-ad")).toBeInTheDocument();
+    const container = screen.getByTestId("test-ad");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass("ad-surface");
   });
 
   it("applies minimum height for CLS prevention", () => {

--- a/resume-builder-ui/src/__tests__/ResumeCard.test.tsx
+++ b/resume-builder-ui/src/__tests__/ResumeCard.test.tsx
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ResumeCard } from "../components/ResumeCard";
@@ -75,13 +74,10 @@ describe("ResumeCard", () => {
   });
 
   describe("Edit Resume button loading state", () => {
-    it("shows spinner when isEditButtonLoading is true", () => {
-      const { container } = render(
-        <ResumeCard {...defaultProps} isEditButtonLoading={true} />
-      );
+    it("shows loading indicator when isEditButtonLoading is true", () => {
+      render(<ResumeCard {...defaultProps} isEditButtonLoading={true} />);
 
-      const spinner = container.querySelector(".animate-spin");
-      expect(spinner).toBeInTheDocument();
+      expect(screen.getByTestId("edit-loading-indicator")).toBeInTheDocument();
     });
 
     it("shows 'Opening...' text when loading", () => {
@@ -245,7 +241,7 @@ describe("ResumeCard", () => {
 
   describe("combined loading states", () => {
     it("can have both edit button and preview loading states simultaneously", () => {
-      const { container } = render(
+      render(
         <ResumeCard
           {...defaultProps}
           isEditButtonLoading={true}
@@ -257,9 +253,8 @@ describe("ResumeCard", () => {
       expect(screen.getByText("Opening...")).toBeInTheDocument();
       expect(screen.getByText("Opening preview...")).toBeInTheDocument();
 
-      // Both spinners should be present
-      const spinners = container.querySelectorAll(".animate-spin");
-      expect(spinners.length).toBe(2);
+      expect(screen.getByTestId("edit-loading-indicator")).toBeInTheDocument();
+      expect(screen.getByTestId("preview-loading-spinner")).toBeInTheDocument();
     });
   });
 

--- a/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
+++ b/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
@@ -27,9 +27,10 @@ describe("ad slot references", () => {
     }
   });
 
-  it("places the mobile top slot after landing hero, not in the global side-rail wrapper", () => {
+  it("keeps the global mobile top slot, suppressed only on landing which places it below the hero", () => {
     const landing = readFileSync(join(srcDir, "components/LandingPage.tsx"), "utf8");
     const sideRail = readFileSync(join(srcDir, "components/ads/SideRailLayout.tsx"), "utf8");
+    const app = readFileSync(join(srcDir, "App.tsx"), "utf8");
     const heroHeadline = landing.indexOf("Free Resume Builder");
     const statsStart = landing.indexOf("{/* ═══════════ STATS");
     const mobileTop = landing.indexOf("AD_CONFIG.slots.mobileTop");
@@ -38,8 +39,14 @@ describe("ad slot references", () => {
     expect(statsStart, "stats section marker").toBeGreaterThan(-1);
     expect(mobileTop, "mobile top slot reference").toBeGreaterThan(-1);
 
+    // Landing renders its own mobile-top below the hero (UX: hero stays ad-free)
     expect(mobileTop).toBeGreaterThan(heroHeadline);
     expect(mobileTop).toBeLessThan(statsStart);
-    expect(sideRail).not.toContain("AD_CONFIG.slots.mobileTop");
+
+    // All other non-editor pages keep the global mobile-top (revenue inventory)
+    expect(sideRail).toContain("AD_CONFIG.slots.mobileTop");
+
+    // Landing must opt out of the global one to avoid double-serving the slot
+    expect(app).toContain('showMobileTop={location.pathname !== "/"}');
   });
 });

--- a/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
+++ b/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
@@ -1,10 +1,12 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const srcDir = join(process.cwd(), "src");
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 const adConfig = readFileSync(join(srcDir, "config/ads.ts"), "utf8");
-const slotNames = Array.from(adConfig.matchAll(/^\s{4}([a-zA-Z0-9]+):\s"[^"]+"/gm), ([, name]) => name);
+const slotsBlock = adConfig.match(/slots:\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+const slotNames = Array.from(slotsBlock.matchAll(/^\s*([a-zA-Z0-9]+):\s*"[^"]+"/gm), ([, name]) => name);
 
 const walk = (dir: string): string[] =>
   readdirSync(dir).flatMap((entry) => {

--- a/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
+++ b/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
@@ -34,6 +34,10 @@ describe("ad slot references", () => {
     const statsStart = landing.indexOf("{/* ═══════════ STATS");
     const mobileTop = landing.indexOf("AD_CONFIG.slots.mobileTop");
 
+    expect(heroHeadline, "hero headline marker").toBeGreaterThan(-1);
+    expect(statsStart, "stats section marker").toBeGreaterThan(-1);
+    expect(mobileTop, "mobile top slot reference").toBeGreaterThan(-1);
+
     expect(mobileTop).toBeGreaterThan(heroHeadline);
     expect(mobileTop).toBeLessThan(statsStart);
     expect(sideRail).not.toContain("AD_CONFIG.slots.mobileTop");

--- a/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
+++ b/resume-builder-ui/src/__tests__/adSlotReferences.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const srcDir = join(process.cwd(), "src");
+const adConfig = readFileSync(join(srcDir, "config/ads.ts"), "utf8");
+const slotNames = Array.from(adConfig.matchAll(/^\s{4}([a-zA-Z0-9]+):\s"[^"]+"/gm), ([, name]) => name);
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    return statSync(fullPath).isDirectory() ? walk(fullPath) : [fullPath];
+  });
+
+describe("ad slot references", () => {
+  it("keeps every configured slot referenced by UI source", () => {
+    const source = walk(srcDir)
+      .filter((file) => /\.(ts|tsx)$/.test(file))
+      .filter((file) => !file.replace(/\\/g, "/").endsWith("config/ads.ts"))
+      .map((file) => readFileSync(file, "utf8"))
+      .join("\n");
+
+    expect(slotNames.length).toBeGreaterThan(0);
+
+    for (const slotName of slotNames) {
+      expect(source, slotName).toContain(`AD_CONFIG.slots.${slotName}`);
+    }
+  });
+
+  it("places the mobile top slot after landing hero, not in the global side-rail wrapper", () => {
+    const landing = readFileSync(join(srcDir, "components/LandingPage.tsx"), "utf8");
+    const sideRail = readFileSync(join(srcDir, "components/ads/SideRailLayout.tsx"), "utf8");
+    const heroHeadline = landing.indexOf("Free Resume Builder");
+    const statsStart = landing.indexOf("{/* ═══════════ STATS");
+    const mobileTop = landing.indexOf("AD_CONFIG.slots.mobileTop");
+
+    expect(mobileTop).toBeGreaterThan(heroHeadline);
+    expect(mobileTop).toBeLessThan(statsStart);
+    expect(sideRail).not.toContain("AD_CONFIG.slots.mobileTop");
+  });
+});

--- a/resume-builder-ui/src/components/Footer.tsx
+++ b/resume-builder-ui/src/components/Footer.tsx
@@ -62,7 +62,7 @@ function FooterColumn({
   links: { path: string; label: string; external?: boolean }[];
   scrollToTop: (path: string) => () => void;
 }) {
-  const linkClass = "inline-flex min-h-9 items-center rounded-md text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
+  const linkClass = "inline-flex min-h-11 items-center rounded-md text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
   return (
     <nav aria-label={title}>
       <h3 className="font-bold text-gray-900 mb-4 text-sm md:text-base">{title}</h3>

--- a/resume-builder-ui/src/components/Footer.tsx
+++ b/resume-builder-ui/src/components/Footer.tsx
@@ -62,7 +62,7 @@ function FooterColumn({
   links: { path: string; label: string; external?: boolean }[];
   scrollToTop: (path: string) => () => void;
 }) {
-  const linkClass = "text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm";
+  const linkClass = "inline-flex min-h-9 items-center rounded-md text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
   return (
     <nav aria-label={title}>
       <h3 className="font-bold text-gray-900 mb-4 text-sm md:text-base">{title}</h3>
@@ -107,8 +107,8 @@ export default function Footer() {
   };
 
   return (
-    <div className="bg-transparent">
-      <div className="container mx-auto px-4 py-12">
+    <div className="bg-white/70 border-t border-slate-200/70">
+      <div className="container mx-auto px-4 py-10 md:py-12">
         {/* Main Footer Content - Responsive Grid Layout */}
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6 md:gap-8 mb-8">
           <FooterColumn title="Resume Builder" links={footerLinks.resumeBuilder} scrollToTop={scrollToTop} />
@@ -134,11 +134,11 @@ export default function Footer() {
 
             {/* Trust Badges */}
             <div className="flex flex-wrap justify-center gap-4 text-xs">
-              <div className="flex items-center gap-2 bg-green-50 px-3 py-2 rounded-full">
+              <div className="flex items-center gap-2 bg-green-50 px-3 py-2 rounded-lg">
                 <FaShieldAlt className="text-green-600" />
                 <span className="text-green-700 font-medium">GDPR</span>
               </div>
-              <div className="flex items-center gap-2 bg-accent/[0.06] px-3 py-2 rounded-full">
+              <div className="flex items-center gap-2 bg-accent/[0.06] px-3 py-2 rounded-lg">
                 <FaLock className="text-accent" />
                 <span className="text-ink/80 font-medium">SSL</span>
               </div>
@@ -146,7 +146,7 @@ export default function Footer() {
                 href="https://www.trustpilot.com/review/easyfreeresume.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 bg-emerald-50 px-3 py-2 rounded-full hover:bg-emerald-100 transition-colors duration-200"
+                className="flex items-center gap-2 bg-emerald-50 px-3 py-2 rounded-lg hover:bg-emerald-100 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               >
                 <FaStar className="text-emerald-600" />
                 <span className="text-emerald-700 font-medium">Trustpilot</span>

--- a/resume-builder-ui/src/components/FormattingHelp.tsx
+++ b/resume-builder-ui/src/components/FormattingHelp.tsx
@@ -93,7 +93,7 @@ const FormattingHelp: React.FC = () => {
               icon={MdMoreHoriz}
               title="Drag & Organize"
               primaryTip={
-                <div className="bg-accent/[0.06]/80 rounded-lg px-3 py-2 flex items-center gap-2">
+                <div className="bg-accent/[0.06] rounded-lg px-3 py-2 flex items-center gap-2">
                   {isTouchDevice ? (
                     <>
                       <MdTouchApp

--- a/resume-builder-ui/src/components/Header.tsx
+++ b/resume-builder-ui/src/components/Header.tsx
@@ -17,17 +17,8 @@ export default function Header() {
   // Get resume count for mobile badge (lightweight count-only query)
   const { data: resumeCount = 0 } = useResumeCount();
 
-  // Safely get editor context (might not be available)
   const isEditorPage = location.pathname.startsWith("/editor");
-  let editorContext = null;
-
-  try {
-    // Always call the hook to maintain hook order
-    editorContext = useEditorContext();
-  } catch {
-    // Context not available, which is fine for non-editor pages
-    editorContext = null;
-  }
+  const editorContext = useEditorContext();
 
   const getPageTitle = () => {
     switch (location.pathname) {
@@ -54,16 +45,13 @@ export default function Header() {
   };
 
   return (
-    <header className="bg-white/95 backdrop-blur-xl border-b border-black/[0.06] sticky top-0 z-50 relative">
-      {/* Accent line at top */}
-      <div className="absolute top-0 left-0 right-0 h-[2px] bg-accent" />
-
+    <header className="bg-white/95 backdrop-blur-xl border-b border-slate-200/80 sticky top-0 z-50 relative">
       <div className="max-w-[1800px] mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 sm:h-[72px] transition-all duration-200">
           {/* Logo and Home Navigation */}
           <Link
             to="/"
-            className="group flex items-center transition-all duration-200 relative flex-shrink-0"
+            className="group flex min-h-11 min-w-11 items-center rounded-lg transition-all duration-200 relative flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             aria-label="Go to homepage"
           >
             <LogoMark
@@ -81,7 +69,7 @@ export default function Header() {
               <Link
                 to="/my-resumes"
                 id="tour-my-resumes-link"
-                className={`relative px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 ${
+                className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                   location.pathname === '/my-resumes'
                     ? 'bg-ink text-white shadow-sm'
                     : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -96,7 +84,7 @@ export default function Header() {
               </Link>
               <Link
                 to="/templates"
-                className={`px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 ${
+                className={`inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                   location.pathname === '/templates'
                     ? 'bg-ink text-white shadow-sm'
                     : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -107,7 +95,7 @@ export default function Header() {
               {affiliateConfig.jobSearch.enabled && (
                 <Link
                   to="/jobs"
-                  className={`relative px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 ${
+                  className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                     location.pathname === '/jobs'
                       ? 'bg-ink text-white shadow-sm'
                       : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -148,7 +136,7 @@ export default function Header() {
                 {/* My Resumes Icon with Badge */}
                 <Link
                   to="/my-resumes"
-                  className="relative p-2 rounded-lg hover:bg-black/5 transition-all duration-200"
+                  className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg hover:bg-black/5 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
                   aria-label={`My Resumes${resumeCount > 0 ? ` (${resumeCount})` : ''}`}
                 >
                   <div className="relative">
@@ -191,7 +179,7 @@ export default function Header() {
                   <button
                     id="tour-sign-in-button"
                     onClick={showAuthModal}
-                    className="flex items-center gap-2 py-2 font-semibold text-sm transition-all duration-300 text-ink hover:text-accent hover:underline lg:hover:no-underline lg:py-2.5 lg:px-5 lg:bg-ink lg:text-white lg:rounded-xl lg:shadow-sm lg:hover:shadow-md lg:hover:scale-[1.02]"
+                    className="flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 font-semibold text-sm transition-all duration-200 text-ink hover:text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 lg:hover:no-underline lg:px-5 lg:bg-ink lg:text-white lg:shadow-sm lg:hover:shadow-md"
                   >
                     <span>Sign In</span>
                   </button>
@@ -203,7 +191,7 @@ export default function Header() {
             {!isEditorPage && !isAuthenticated && location.pathname !== "/templates" && (
               <Link
                 to="/templates"
-                className="bg-accent text-ink py-2.5 px-5 sm:py-3 sm:px-6 rounded-xl text-sm font-bold shadow-sm hover:shadow-md hover:shadow-accent/20 hover:scale-[1.02] transition-all duration-300 active:scale-[0.98]"
+                className="btn-primary px-5 sm:px-6 text-sm font-bold"
               >
                 <span className="hidden sm:inline">Create Free Resume</span>
                 <span className="sm:hidden">Create Resume</span>

--- a/resume-builder-ui/src/components/Header.tsx
+++ b/resume-builder-ui/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useLocation, Link } from "react-router-dom";
 import { FileText } from "lucide-react";
-import { useEditorContext } from "../contexts/EditorContext";
+import { useOptionalEditorContext } from "../contexts/EditorContext";
 import { useAuth } from "../contexts/AuthContext";
 import { useResumeCount } from "../hooks/useResumeCount";
 import AutoSaveIndicator from "./AutoSaveIndicator";
@@ -18,7 +18,7 @@ export default function Header() {
   const { data: resumeCount = 0 } = useResumeCount();
 
   const isEditorPage = location.pathname.startsWith("/editor");
-  const editorContext = useEditorContext();
+  const editorContext = useOptionalEditorContext();
 
   const getPageTitle = () => {
     switch (location.pathname) {

--- a/resume-builder-ui/src/components/KebabMenu.tsx
+++ b/resume-builder-ui/src/components/KebabMenu.tsx
@@ -3,7 +3,6 @@ import { MoreVertical, Edit2, Copy, Trash2 } from 'lucide-react';
 
 interface KebabMenuProps {
   resumeId: string;
-  resumeTitle: string;
   onRename: (id: string) => void;
   onDuplicate: (id: string) => void;
   onDelete: (id: string) => void;
@@ -11,7 +10,6 @@ interface KebabMenuProps {
 
 export function KebabMenu({
   resumeId,
-  resumeTitle: _resumeTitle,
   onRename,
   onDuplicate,
   onDelete
@@ -61,7 +59,7 @@ export function KebabMenu({
           e.stopPropagation();
           setIsOpen(!isOpen);
         }}
-        className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         title="More options"
         aria-label="More options"
         aria-haspopup="menu"
@@ -72,13 +70,13 @@ export function KebabMenu({
 
       {isOpen && (
         <div
-          className="absolute right-0 top-full mt-1 w-48 bg-white/95 backdrop-blur-xl rounded-lg shadow-xl border border-gray-200 py-1 z-50"
+          className="absolute right-0 top-full mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
           role="menu"
           aria-orientation="vertical"
         >
           <button
             onClick={handleRename}
-            className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none flex items-center gap-3 transition-colors"
+            className="flex min-h-11 w-full items-center gap-3 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none transition-colors"
             role="menuitem"
           >
             <Edit2 className="w-4 h-4" />
@@ -87,7 +85,7 @@ export function KebabMenu({
 
           <button
             onClick={handleDuplicate}
-            className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none flex items-center gap-3 transition-colors"
+            className="flex min-h-11 w-full items-center gap-3 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none transition-colors"
             role="menuitem"
           >
             <Copy className="w-4 h-4" />
@@ -98,7 +96,7 @@ export function KebabMenu({
 
           <button
             onClick={handleDelete}
-            className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none flex items-center gap-3 transition-colors"
+            className="flex min-h-11 w-full items-center gap-3 px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none transition-colors"
             role="menuitem"
           >
             <Trash2 className="w-4 h-4" />

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -346,7 +346,7 @@ const LandingPage: React.FC = () => {
                     { px: '-22px', py: '26px', size: 5, color: '#00d47e' },
                   ].map((p, i) => (
                     <span
-                      key={i}
+                      key={`particle-${i}`}
                       className="hero-particle"
                       style={{
                         '--px': p.px,

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -7,12 +7,19 @@ import CompanyMarquee from "./CompanyMarquee";
 import RevealSection from "./shared/RevealSection";
 import { useAuth } from "../contexts/AuthContext";
 import { useResumeCount } from "../hooks/useResumeCount";
+import { useScrollReveal } from "../hooks/useScrollReveal";
 import { InContentAd, AD_CONFIG } from "./ads";
 import {
+  ArrowDownTrayIcon,
   ArrowRightIcon,
+  CheckIcon,
   ChevronDownIcon,
 } from "@heroicons/react/24/solid";
 import { TUTORIAL_VIDEO } from "../config/videoContent";
+
+// Animation-delay for the hero build sequence (consumed by hero-* classes in styles.css).
+// Static values only — the landing route must prerender/hydrate byte-identical.
+const d = (delay: string) => ({ "--d": delay }) as React.CSSProperties;
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
@@ -48,6 +55,10 @@ const LandingPage: React.FC = () => {
   // HTML and the first client render are byte-identical. This is what lets the
   // landing route hydrate cleanly under hydrateRoot. Bump manually over time.
   const resumeCountValue = 150000;
+
+  // Starts the hero build sequence when the card scrolls into view (mobile:
+  // the card sits below the CTAs, so a load-triggered run would finish unseen)
+  const heroVisualRef = useScrollReveal<HTMLDivElement>({ threshold: 0.3 });
 
   const prefersReducedMotion = useMemo(
     () =>
@@ -190,15 +201,32 @@ const LandingPage: React.FC = () => {
 
       {/* ═══════════ HERO — light, asymmetric ═══════════ */}
       <section className="relative pt-12 pb-20 md:pt-20 md:pb-28">
-        <div className="max-w-6xl mx-auto w-full grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-          {/* Left: text */}
+        <div className="max-w-6xl mx-auto w-full grid lg:grid-cols-2 gap-y-10 gap-x-12 lg:gap-x-16 items-center">
+          {/* Eyebrow + headline (mobile: card follows immediately, so both share the first viewport) */}
           <div>
             <span className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase mb-6 block">
               FREE FOREVER. NO SIGN-UP.
             </span>
-            <h1 className="font-display text-[clamp(2.5rem,5.5vw,4.5rem)] font-extrabold leading-[1.08] tracking-tight text-ink mb-6">
-              Free Resume Builder — Build Resumes That Get You Hired
+            {/* Two-tier headline. Line sizes use per-breakpoint fluid clamps and
+                [text-wrap:balance] so the promise line always breaks cleanly
+                (no orphaned words); the highlighted phrase is an unbreakable
+                inline-block so the underline never splits across lines. */}
+            <h1 className="font-display tracking-tight text-ink">
+              <span className="hero-title-scan block text-[clamp(1.5rem,7.8vw,2.25rem)] lg:text-[clamp(1.75rem,3vw,2.5rem)] font-bold leading-tight mb-2 lg:mb-3">
+                Free Resume Builder
+              </span>{' '}
+              <span className="block text-[clamp(2rem,8.9vw,3.25rem)] lg:text-[clamp(2.5rem,4.45vw,4rem)] font-extrabold leading-[1.08] [text-wrap:balance]">
+                Build Resumes That{' '}
+                <span className="relative inline-block">
+                  <span className="relative z-10">Get You Hired</span>
+                  <span className="hero-underline absolute left-0 bottom-1 lg:bottom-2 w-full h-3 lg:h-4 bg-accent/30 rounded-sm" aria-hidden="true" />
+                </span>
+              </span>
             </h1>
+          </div>
+
+          {/* Subtitle + CTAs (mobile: rendered after the visual via order-last) */}
+          <div className="order-last lg:order-none lg:col-start-1 lg:row-start-2">
             <p className="font-display text-lg md:text-xl font-extralight text-stone-warm max-w-lg leading-relaxed mb-8">
               Build your resume for free online with ATS-friendly templates. Download as PDF instantly — no sign up, no payment, no watermarks.
             </p>
@@ -226,48 +254,117 @@ const LandingPage: React.FC = () => {
             </p>
           </div>
 
-          {/* Right: CSS-only floating resume mockup */}
-          <div className="hidden lg:flex items-center justify-center" aria-hidden="true">
+          {/* CSS-only "builds itself" resume mockup (run-once sequence, delays
+              via --d; all animation classes defined in styles.css). Desktop:
+              right column spanning both text rows. Mobile: directly below H1,
+              inside the first viewport so the sequence plays on load. */}
+          <div
+            ref={heroVisualRef}
+            className="hero-seq flex items-center justify-center lg:col-start-2 lg:row-start-1 lg:row-span-2 lg:self-center"
+            aria-hidden="true"
+          >
             <div className="relative" style={{ perspective: '1000px' }}>
-              {/* Shadow copy behind */}
-              <div
-                className="absolute top-4 left-4 w-[280px] h-[380px] bg-ink/[0.04] rounded-xl"
-                style={{ transform: 'rotateY(-3deg)' }}
-              />
-              {/* Main mockup */}
-              <div
-                className="hero-mockup relative w-[280px] h-[380px] bg-white rounded-xl p-6 flex flex-col gap-3 border border-black/[0.06]"
-                style={{
-                  animation: prefersReducedMotion ? 'none' : 'float 4s ease-in-out infinite',
-                  transform: 'rotateY(-3deg)',
-                  boxShadow: '0 8px 40px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04)',
-                }}
-              >
-                {/* Name bar */}
-                <div className="h-5 w-32 bg-ink rounded-sm" />
-                <div className="h-2.5 w-20 bg-accent/60 rounded-sm" />
-                {/* Divider */}
-                <div className="h-px w-full bg-gray-200 my-1" />
-                {/* Section: experience */}
-                <div className="h-2 w-16 bg-ink/40 rounded-sm" />
-                <div className="space-y-1.5">
-                  <div className="h-1.5 w-full bg-gray-200 rounded-sm" />
-                  <div className="h-1.5 w-[90%] bg-gray-200 rounded-sm" />
-                  <div className="h-1.5 w-[75%] bg-gray-200 rounded-sm" />
+              {/* Radial accent glow */}
+              <div className="hero-glow absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[380px] h-[380px] lg:w-[480px] lg:h-[480px] rounded-full bg-accent/[0.07] blur-3xl pointer-events-none" />
+              <div className="hero-card-in relative" style={d('0.15s')}>
+                {/* Shadow copy behind */}
+                <div
+                  className="absolute top-4 left-4 w-full h-full bg-ink/[0.04] rounded-xl"
+                  style={{ transform: 'rotateY(-3deg)' }}
+                />
+                {/* Main mockup */}
+                <div
+                  className="hero-mockup relative w-[240px] h-[330px] lg:w-[280px] lg:h-[380px] bg-white rounded-xl p-5 lg:p-6 flex flex-col gap-2.5 lg:gap-3 border border-black/[0.06]"
+                  style={{
+                    transform: 'rotateY(-3deg)',
+                    boxShadow: '0 8px 40px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04)',
+                  }}
+                >
+                  {/* Build progress bar along the card's top edge */}
+                  <div className="hero-progress absolute top-0 left-0 w-full h-0.5 bg-accent/70 rounded-t-xl" style={d('0.4s')} />
+                  {/* Name types in */}
+                  <div className="hero-type hero-type-caret self-start" style={d('0.5s')}>
+                    <span className="font-display text-lg lg:text-xl font-extrabold text-ink leading-none whitespace-nowrap">
+                      John Doe
+                    </span>
+                  </div>
+                  <div className="hero-draw h-2.5 w-24 lg:w-28 bg-accent/60 rounded-sm" style={d('1.25s')} />
+                  {/* Divider */}
+                  <div className="h-px w-full bg-gray-200 my-1" />
+                  {/* Section: experience */}
+                  <div className="hero-draw font-mono text-[8px] lg:text-[9px] tracking-[0.15em] text-ink/50 uppercase" style={d('1.45s')}>
+                    Experience
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="hero-draw h-1.5 w-full bg-gray-200 rounded-sm" style={d('1.6s')} />
+                    <div className="hero-draw h-1.5 w-[90%] bg-gray-200 rounded-sm" style={d('1.75s')} />
+                    <div className="hero-draw h-1.5 w-[75%] bg-gray-200 rounded-sm" style={d('1.9s')} />
+                  </div>
+                  {/* Section: skills */}
+                  <div className="hero-draw font-mono text-[8px] lg:text-[9px] tracking-[0.15em] text-ink/50 uppercase mt-1.5 lg:mt-2" style={d('2.15s')}>
+                    Skills
+                  </div>
+                  <div className="flex gap-1.5 flex-wrap">
+                    {['React', 'SQL', 'Python', 'Figma'].map((skill, i) => (
+                      <span
+                        key={skill}
+                        className="hero-pop inline-flex items-center h-4 px-2 bg-accent/15 rounded-full font-mono text-[8px] lg:text-[9px] text-accent-text leading-none"
+                        style={d(`${(2.25 + i * 0.12).toFixed(2)}s`)}
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                  {/* Section: education */}
+                  <div className="hero-draw font-mono text-[8px] lg:text-[9px] tracking-[0.15em] text-ink/50 uppercase mt-1.5 lg:mt-2" style={d('2.7s')}>
+                    Education
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="hero-draw h-1.5 w-[85%] bg-gray-200 rounded-sm" style={d('2.85s')} />
+                    <div className="hero-draw h-1.5 w-[60%] bg-gray-200 rounded-sm" style={d('3s')} />
+                  </div>
+                  {/* ATS scan beam sweeps down the finished resume */}
+                  <div className="absolute inset-0 rounded-xl overflow-hidden pointer-events-none">
+                    <div
+                      className="hero-scan absolute -top-12 left-0 w-full h-12 bg-gradient-to-b from-transparent via-accent/10 to-accent/30"
+                      style={d('3.1s')}
+                    />
+                  </div>
                 </div>
-                {/* Section: skills */}
-                <div className="h-2 w-12 bg-ink/40 rounded-sm mt-2" />
-                <div className="flex gap-1.5 flex-wrap">
-                  <div className="h-4 w-14 bg-accent/15 rounded-full" />
-                  <div className="h-4 w-10 bg-accent/15 rounded-full" />
-                  <div className="h-4 w-16 bg-accent/15 rounded-full" />
-                  <div className="h-4 w-12 bg-accent/15 rounded-full" />
+                {/* Floating proof chips */}
+                <div
+                  className="hero-stamp absolute -top-4 -right-8 lg:-top-5 lg:-right-10 flex items-center gap-1.5 bg-white rounded-full px-3 py-1.5 border border-black/[0.06] shadow-lg"
+                  style={d('3.7s')}
+                >
+                  <CheckIcon className="w-3.5 h-3.5 text-accent" />
+                  <span className="font-mono text-[10px] lg:text-xs tracking-wide font-semibold text-ink">ATS 100%</span>
+                  {/* Particle burst on badge stamp (reuses dcm-particle-burst) */}
+                  {[
+                    { px: '30px', py: '-22px', size: 5, color: '#00d47e' },
+                    { px: '-26px', py: '-24px', size: 4, color: '#34d399' },
+                    { px: '24px', py: '20px', size: 4, color: '#2dd4bf' },
+                    { px: '-22px', py: '26px', size: 5, color: '#00d47e' },
+                  ].map((p, i) => (
+                    <span
+                      key={i}
+                      className="hero-particle"
+                      style={{
+                        '--px': p.px,
+                        '--py': p.py,
+                        '--d': '4s',
+                        width: p.size,
+                        height: p.size,
+                        background: p.color,
+                      } as React.CSSProperties}
+                    />
+                  ))}
                 </div>
-                {/* Section: education */}
-                <div className="h-2 w-14 bg-ink/40 rounded-sm mt-2" />
-                <div className="space-y-1.5">
-                  <div className="h-1.5 w-[85%] bg-gray-200 rounded-sm" />
-                  <div className="h-1.5 w-[60%] bg-gray-200 rounded-sm" />
+                <div
+                  className="hero-chip absolute -bottom-4 -left-8 lg:-bottom-5 lg:-left-10 flex items-center gap-1.5 bg-white rounded-full px-3 py-1.5 border border-black/[0.06] shadow-lg"
+                  style={d('3.95s')}
+                >
+                  <ArrowDownTrayIcon className="w-3.5 h-3.5 text-accent" />
+                  <span className="font-mono text-[10px] lg:text-xs tracking-wide font-semibold text-ink">PDF ready</span>
                 </div>
               </div>
             </div>

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -208,14 +208,16 @@ const LandingPage: React.FC = () => {
 
             <div className="flex flex-wrap gap-4 mb-8">
               <button
-                className="group inline-flex items-center justify-center bg-accent text-ink py-3.5 px-8 rounded-xl text-base font-bold shadow-lg hover:shadow-accent/25 hover:shadow-2xl transform hover:-translate-y-0.5 transition-all duration-300 active:scale-95 font-display"
+                type="button"
+                className="btn-primary group px-7 text-base font-display"
                 onClick={() => navigate(hasResumes ? "/my-resumes" : "/templates")}
               >
                 {hasResumes ? "My Resumes" : "Build My Free Resume"}
                 <ArrowRightIcon className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform duration-200" />
               </button>
               <button
-                className="group inline-flex items-center justify-center border border-ink/15 text-ink py-3.5 px-8 rounded-xl text-base font-semibold hover:border-ink/30 hover:bg-ink/[0.03] transition-all duration-300 active:scale-95 font-display"
+                type="button"
+                className="btn-secondary group px-7 text-base font-display"
                 onClick={() => navigate("/templates")}
               >
                 View Templates
@@ -275,6 +277,14 @@ const LandingPage: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <div className="block md:hidden container mx-auto max-w-4xl px-4">
+        <InContentAd
+          adSlot={AD_CONFIG.slots.mobileTop}
+          size="standard"
+          marginY={20}
+        />
+      </div>
 
       {/* ═══════════ STATS ═══════════ */}
       <section className="py-12">

--- a/resume-builder-ui/src/components/MobileActionBar.tsx
+++ b/resume-builder-ui/src/components/MobileActionBar.tsx
@@ -55,14 +55,16 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
   };
 
   return (
-    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 shadow-lg">
+    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/95 backdrop-blur border-t border-gray-200 shadow-sm">
       {/* Auto-save status bar (subtle, above buttons) - only for authenticated users */}
       {isAuthenticated && (isSaving || lastSaved || saveError) && (
         <div className="px-4 py-1 bg-gray-50 border-b border-gray-100">
           <div className="flex items-center justify-center gap-2 text-xs">
             {isSaving && (
               <>
-                <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-accent"></div>
+                <div className="h-2 w-8 overflow-hidden rounded-full bg-slate-200">
+                  <div className="h-full w-1/2 animate-pulse rounded-full bg-accent" />
+                </div>
                 <span className="text-gray-600">Saving...</span>
               </>
             )}
@@ -88,7 +90,7 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
         <button
           onClick={onNavigationClick}
           disabled={isGenerating || isGeneratingPreview}
-          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 rounded-xl transition-all disabled:opacity-50 hover:bg-gray-100 active:bg-gray-200 active:scale-[0.98] border border-gray-200"
+          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 rounded-lg transition-all disabled:opacity-50 hover:bg-gray-100 active:bg-gray-200 active:scale-[0.98] border border-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           aria-label="Open navigation menu"
           style={{ WebkitTapHighlightColor: "transparent" }}
         >
@@ -101,7 +103,7 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
           <button
             onClick={onPreviewClick}
             disabled={isPreviewLoading || isGenerating}
-            className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-accent text-ink rounded-xl shadow-lg transition-all hover:shadow-xl active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed relative"
+            className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-accent text-ink rounded-lg shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             aria-label="Preview resume PDF"
             style={{ WebkitTapHighlightColor: "transparent" }}
           >
@@ -111,7 +113,9 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
             )}
             {isPreviewLoading ? (
               <>
-                <div className="animate-spin rounded-full h-6 w-6 border-2 border-white border-t-transparent mb-1.5"></div>
+                <span className="mb-1.5 h-2 w-10 overflow-hidden rounded-full bg-ink/15">
+                  <span className="block h-full w-1/2 animate-pulse rounded-full bg-ink/60" />
+                </span>
                 <span className="text-xs font-semibold">Loading...</span>
               </>
             ) : (
@@ -127,13 +131,15 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
         <button
           onClick={onDownloadClick}
           disabled={isGenerating || isGeneratingPreview}
-          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-gradient-to-r from-emerald-600 to-green-600 text-white rounded-xl shadow-lg transition-all hover:shadow-xl active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-emerald-600 text-white rounded-lg shadow-sm transition-all hover:bg-emerald-700 hover:shadow-md active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
           aria-label="Download resume as PDF"
           style={{ WebkitTapHighlightColor: "transparent" }}
         >
           {isGenerating ? (
             <>
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white mb-1.5"></div>
+              <span className="mb-1.5 h-2 w-10 overflow-hidden rounded-full bg-white/30">
+                <span className="block h-full w-1/2 animate-pulse rounded-full bg-white" />
+              </span>
               <span className="text-xs font-semibold">Creating...</span>
             </>
           ) : (

--- a/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
+++ b/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
@@ -77,7 +77,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
 
       {/* Drawer */}
       <div
-        className="fixed top-0 left-0 bottom-0 w-[280px] max-w-[80vw] bg-white z-[9999] lg:hidden shadow-2xl
+        className="fixed top-0 left-0 bottom-0 w-[280px] max-w-[80vw] bg-white z-[9999] lg:hidden shadow-lg
           animate-slide-in-left flex flex-col"
         role="dialog"
         aria-modal="true"
@@ -91,7 +91,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           </h2>
           <button
             onClick={onClose}
-            className="p-2 text-white/80 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-white/80 hover:text-white hover:bg-white/10 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-accent"
             aria-label="Close navigation"
           >
             <MdClose className="text-2xl" />
@@ -106,7 +106,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
             className={`w-full text-left px-4 py-3 rounded-lg transition-all min-h-[48px] flex items-center gap-3
               ${
                 activeSectionIndex === -1
-                  ? "bg-accent/[0.06] border-l-4 border-accent text-ink font-semibold"
+                  ? "bg-accent/[0.06] ring-1 ring-accent/20 text-ink font-semibold"
                   : "hover:bg-gray-100 active:bg-gray-200 text-gray-700"
               }`}
             style={{ WebkitTapHighlightColor: "transparent" }}
@@ -125,7 +125,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
               className={`w-full text-left px-4 py-3 rounded-lg transition-all min-h-[48px] flex items-center gap-3 mt-1
                 ${
                   activeSectionIndex === index
-                    ? "bg-accent/[0.06] border-l-4 border-accent text-ink font-semibold"
+                    ? "bg-accent/[0.06] ring-1 ring-accent/20 text-ink font-semibold"
                     : "hover:bg-gray-100 active:bg-gray-200 text-gray-700"
                 }`}
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -143,7 +143,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           {/* Add Section Button */}
           <button
             onClick={() => handleAction(onAddSection)}
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent text-ink rounded-lg font-medium shadow-md hover:shadow-lg active:scale-95 transition-all min-h-[48px]"
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent text-ink rounded-lg font-medium shadow-sm hover:shadow-md active:scale-[0.98] transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             style={{ WebkitTapHighlightColor: "transparent" }}
           >
             <MdAdd className="text-xl" />
@@ -154,7 +154,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           <div className="relative">
             <button
               onClick={() => setShowAdvancedMenu(!showAdvancedMenu)}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 active:bg-gray-100 transition-all min-h-[48px]"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 active:bg-gray-100 transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               <MdMoreVert className="text-xl" />
@@ -163,16 +163,18 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
 
             {/* Advanced Menu Dropdown */}
             {showAdvancedMenu && (
-              <div className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden">
+              <div className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden">
                 {/* Save My Work */}
                 <button
                   onClick={() => handleAction(onExportYAML)}
                   disabled={loadingSave}
-                  className="w-full text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
                   style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   {loadingSave ? (
-                    <div className="animate-spin rounded-full h-5 w-5 border-2 border-accent border-t-transparent"></div>
+                    <span className="h-2 w-8 overflow-hidden rounded-full bg-accent/20">
+                      <span className="block h-full w-1/2 animate-pulse rounded-full bg-accent" />
+                    </span>
                   ) : (
                     <MdFileDownload className="text-accent text-xl" />
                   )}
@@ -188,11 +190,13 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 <button
                   onClick={() => handleAction(onImportYAML)}
                   disabled={loadingLoad}
-                  className="w-full text-left px-4 py-3 hover:bg-green-50 active:bg-green-100 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-green-50 active:bg-green-100 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
                   style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   {loadingLoad ? (
-                    <div className="animate-spin rounded-full h-5 w-5 border-2 border-green-600 border-t-transparent"></div>
+                    <span className="h-2 w-8 overflow-hidden rounded-full bg-green-100">
+                      <span className="block h-full w-1/2 animate-pulse rounded-full bg-green-600" />
+                    </span>
                   ) : (
                     <MdFileUpload className="text-green-600 text-xl" />
                   )}
@@ -207,7 +211,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 {/* Start Fresh */}
                 <button
                   onClick={() => handleAction(onStartFresh)}
-                  className="w-full text-left px-4 py-3 hover:bg-orange-50 active:bg-orange-100 transition-colors flex items-center gap-3 border-b border-gray-100"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-orange-50 active:bg-orange-100 transition-colors flex items-center gap-3 border-b border-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
                   style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   <MdRefresh className="text-orange-600 text-xl" />
@@ -220,7 +224,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 {/* Help */}
                 <button
                   onClick={() => handleAction(onHelp)}
-                  className="w-full text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
                   style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   <MdHelpOutline className="text-accent text-xl" />

--- a/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
+++ b/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
@@ -107,6 +107,14 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
       const lastElement = currentFocusableElements[currentFocusableElements.length - 1];
       const activeElement = document.activeElement;
 
+      // Drawer container itself is focused (tabIndex={-1}, e.g. after a tap on a
+      // non-interactive area) — wrap explicitly so Shift+Tab can't escape the trap
+      if (activeElement === drawerRef.current) {
+        event.preventDefault();
+        (event.shiftKey ? lastElement : firstElement).focus();
+        return;
+      }
+
       if (!drawerRef.current?.contains(activeElement)) {
         event.preventDefault();
         firstElement.focus();

--- a/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
+++ b/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
@@ -207,7 +207,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                   ? "bg-accent/[0.06] ring-1 ring-accent/20 text-ink font-semibold"
                   : "hover:bg-gray-100 active:bg-gray-200 text-gray-700"
               }`}
-            style={{ WebkitTapHighlightColor: "transparent" }}
           >
             <span className="w-6 h-6 rounded-full bg-accent/10 text-accent flex items-center justify-center text-xs font-bold">
               i
@@ -241,7 +240,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           <button
             onClick={() => handleAction(onAddSection)}
             className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent text-ink rounded-lg font-medium shadow-sm hover:shadow-md active:scale-[0.98] transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-            style={{ WebkitTapHighlightColor: "transparent" }}
           >
             <MdAdd className="text-xl" />
             <span>Add Section</span>
@@ -252,7 +250,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
             <button
               onClick={() => setShowAdvancedMenu(!showAdvancedMenu)}
               className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 active:bg-gray-100 transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-              style={{ WebkitTapHighlightColor: "transparent" }}
             >
               <MdMoreVert className="text-xl" />
               <span>More Options</span>
@@ -266,7 +263,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                   onClick={() => handleAction(onExportYAML)}
                   disabled={loadingSave}
                   className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
-                  style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   {loadingSave ? (
                     <span className="h-2 w-8 overflow-hidden rounded-full bg-accent/20">
@@ -288,7 +284,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                   onClick={() => handleAction(onImportYAML)}
                   disabled={loadingLoad}
                   className="w-full min-h-11 text-left px-4 py-3 hover:bg-green-50 active:bg-green-100 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
-                  style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   {loadingLoad ? (
                     <span className="h-2 w-8 overflow-hidden rounded-full bg-green-100">
@@ -309,7 +304,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 <button
                   onClick={() => handleAction(onStartFresh)}
                   className="w-full min-h-11 text-left px-4 py-3 hover:bg-orange-50 active:bg-orange-100 transition-colors flex items-center gap-3 border-b border-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
-                  style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   <MdRefresh className="text-orange-600 text-xl" />
                   <div className="flex-1">
@@ -322,7 +316,6 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 <button
                   onClick={() => handleAction(onHelp)}
                   className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
-                  style={{ WebkitTapHighlightColor: "transparent" }}
                 >
                   <MdHelpOutline className="text-accent text-xl" />
                   <div className="flex-1">

--- a/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
+++ b/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   MdClose,
   MdDragIndicator,
@@ -32,6 +32,23 @@ interface MobileNavigationDrawerProps {
   loadingLoad?: boolean;
 }
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+const getFocusableElements = (container: HTMLElement | null) => {
+  if (!container) return [];
+
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => !element.hasAttribute("disabled") && !element.hidden
+  );
+};
+
 /**
  * Mobile navigation drawer - slides in from left
  * Shows all resume sections for quick navigation
@@ -52,6 +69,69 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
   loadingLoad = false,
 }) => {
   const [showAdvancedMenu, setShowAdvancedMenu] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const focusableElements = getFocusableElements(drawerRef.current);
+    (focusableElements[0] ?? drawerRef.current)?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const currentFocusableElements = getFocusableElements(drawerRef.current);
+
+      if (currentFocusableElements.length === 0) {
+        event.preventDefault();
+        drawerRef.current?.focus();
+        return;
+      }
+
+      const firstElement = currentFocusableElements[0];
+      const lastElement = currentFocusableElements[currentFocusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (!drawerRef.current?.contains(activeElement)) {
+        event.preventDefault();
+        firstElement.focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -77,11 +157,13 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
 
       {/* Drawer */}
       <div
+        ref={drawerRef}
         className="fixed top-0 left-0 bottom-0 w-[280px] max-w-[80vw] bg-white z-[9999] lg:hidden shadow-lg
           animate-slide-in-left flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-label="Section navigation"
+        tabIndex={-1}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 bg-accent">

--- a/resume-builder-ui/src/components/ResumeCard.tsx
+++ b/resume-builder-ui/src/components/ResumeCard.tsx
@@ -101,7 +101,7 @@ export function ResumeCard({
     try {
       await onRename(resume.id, trimmedTitle);
       setIsEditing(false);
-    } catch (error) {
+    } catch {
       // Revert on error
       setEditedTitle(resume.title);
       setIsEditing(false);
@@ -112,7 +112,7 @@ export function ResumeCard({
 
   return (
     <div
-      className="bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-200 group"
+      className="bg-white rounded-lg border border-slate-200 shadow-sm hover:shadow-md transition-shadow duration-200 group"
     >
       {/* Thumbnail */}
       <div
@@ -126,7 +126,7 @@ export function ResumeCard({
             e.currentTarget.click();
           }
         }}
-        className={`relative bg-gray-100 h-48 overflow-hidden rounded-t-lg ${
+        className={`relative bg-slate-100 h-48 overflow-hidden rounded-t-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
           isPreviewLoading ? 'cursor-wait' : 'cursor-pointer'
         }`}
         onClick={() => !isPreviewLoading && onPreview(resume.id)}
@@ -146,7 +146,9 @@ export function ResumeCard({
         {/* Preview Loading Overlay */}
         {isPreviewLoading && (
           <div data-testid="preview-loading-overlay" className="absolute inset-0 bg-black/50 flex flex-col items-center justify-center gap-2">
-            <div data-testid="preview-loading-spinner" className="animate-spin rounded-full h-8 w-8 border-2 border-white border-t-transparent"></div>
+            <div data-testid="preview-loading-spinner" className="h-2 w-20 overflow-hidden rounded-full bg-white/30">
+              <div className="h-full w-1/2 animate-pulse rounded-full bg-white" />
+            </div>
             <span className="text-white font-medium text-sm">Opening preview...</span>
           </div>
         )}
@@ -180,11 +182,11 @@ export function ResumeCard({
             autoFocus
             disabled={isSaving}
             maxLength={200}
-            className="font-bold text-xl text-gray-900 w-full bg-white border-2 border-accent rounded px-2 py-1 focus:outline-none disabled:opacity-50 mb-2"
+            className="font-bold text-xl text-gray-900 w-full bg-white border border-slate-300 rounded-lg px-2 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50 mb-2"
           />
         ) : (
           <h3
-            className="font-bold text-xl text-gray-900 truncate mb-2 cursor-text hover:bg-gray-50 rounded px-2 py-1 -mx-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="font-bold text-xl text-gray-900 truncate mb-2 cursor-text hover:bg-gray-50 rounded-lg px-2 py-2 -mx-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             role="button"
             tabIndex={0}
             aria-label={`Rename ${resume.title}`}
@@ -206,7 +208,7 @@ export function ResumeCard({
 
         {/* Metadata row */}
         <div className="flex items-center gap-2 mb-3">
-          <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+          <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-md">
             {getTemplateName(resume.template_id)}
           </span>
           <span className="text-xs text-gray-500">
@@ -222,7 +224,7 @@ export function ResumeCard({
               onEdit(resume.id);
             }}
             disabled={isEditButtonLoading}
-            className={`flex-1 bg-accent text-ink py-2 px-4 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 ${
+            className={`flex-1 min-h-11 bg-accent text-ink py-2 px-4 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
               isEditButtonLoading
                 ? 'opacity-75 cursor-not-allowed'
                 : 'hover:bg-accent/90 active:scale-[0.98]'
@@ -230,7 +232,9 @@ export function ResumeCard({
           >
             {isEditButtonLoading ? (
               <>
-                <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent"></div>
+                <span data-testid="edit-loading-indicator" className="h-2 w-10 overflow-hidden rounded-full bg-ink/15">
+                  <span className="block h-full w-1/2 animate-pulse rounded-full bg-ink/60" />
+                </span>
                 <span>Opening...</span>
               </>
             ) : (
@@ -243,7 +247,7 @@ export function ResumeCard({
               e.stopPropagation();
               onDownload(resume.id);
             }}
-            className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             title="Download PDF"
             aria-label="Download PDF"
           >
@@ -252,7 +256,6 @@ export function ResumeCard({
 
           <KebabMenu
             resumeId={resume.id}
-            resumeTitle={resume.title}
             onRename={() => setIsEditing(true)}
             onDuplicate={onDuplicate}
             onDelete={onDelete}

--- a/resume-builder-ui/src/components/SectionNavigator.tsx
+++ b/resume-builder-ui/src/components/SectionNavigator.tsx
@@ -341,13 +341,13 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             onClick={() => onSectionClick(-1)}
             className={`w-full flex items-center transition-all rounded-lg group ${
               isCollapsed
-                ? "flex-col gap-1.5 py-2.5 px-1.5 hover:bg-accent/[0.06]/80"
+                ? "flex-col gap-1.5 py-2.5 px-1.5 hover:bg-accent/[0.06]"
                 : "flex-row gap-3 px-3 py-2.5 hover:bg-gray-100/80"
             } ${
               activeSectionIndex === -1
                 ? isCollapsed
                   ? "bg-accent/[0.06] text-ink/80"
-                  : "bg-accent/[0.06]/80 ring-1 ring-accent/20 text-ink font-medium"
+                  : "bg-accent/[0.06] ring-1 ring-accent/20 text-ink font-medium"
                 : "text-gray-700 hover:text-gray-900"
             }`}
           >
@@ -380,13 +380,13 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               onClick={() => onSectionClick(index)}
               className={`w-full flex items-center transition-all rounded-lg group ${
                 isCollapsed
-                  ? "flex-col gap-1.5 py-2.5 px-1.5 hover:bg-accent/[0.06]/80 mt-1"
+                  ? "flex-col gap-1.5 py-2.5 px-1.5 hover:bg-accent/[0.06] mt-1"
                   : "flex-row gap-3 px-3 py-2.5 hover:bg-gray-100/80 mt-0.5"
               } ${
                 activeSectionIndex === index
                   ? isCollapsed
                     ? "bg-accent/[0.06] text-ink/80"
-                    : "bg-accent/[0.06]/80 ring-1 ring-accent/20 text-ink font-medium"
+                    : "bg-accent/[0.06] ring-1 ring-accent/20 text-ink font-medium"
                   : "text-gray-700 hover:text-gray-900"
               }`}
             >
@@ -634,8 +634,8 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               disabled={loadingSave}
               className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
-                  ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]/80"
-                  : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06]/80 text-gray-700 hover:text-ink/80"
+                  ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]"
+                  : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06] text-gray-700 hover:text-ink/80"
               }`}
             >
               <MdFileDownload
@@ -723,8 +723,8 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               onClick={onHelp}
               className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
-                  ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]/80"
-                  : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06]/80 text-gray-700 hover:text-ink/80"
+                  ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]"
+                  : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06] text-gray-700 hover:text-ink/80"
               }`}
             >
               <MdHelpOutline

--- a/resume-builder-ui/src/components/SectionNavigator.tsx
+++ b/resume-builder-ui/src/components/SectionNavigator.tsx
@@ -106,6 +106,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
   const [headerHeight, setHeaderHeight] = useState(0);
   const [bottomOffset, setBottomOffset] = useState(0);
   const sidebarRef = useRef<HTMLElement>(null);
+  const onCollapseChangeRef = useRef(onCollapseChange);
 
   // Calculate header height on mount and resize
   useEffect(() => {
@@ -172,10 +173,14 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
     };
   }, []);
 
-  // Notify parent of initial state
   useEffect(() => {
-    onCollapseChange?.(isCollapsed);
-  }, [isCollapsed, onCollapseChange]);
+    onCollapseChangeRef.current = onCollapseChange;
+  }, [onCollapseChange]);
+
+  // Notify parent when collapsed state changes
+  useEffect(() => {
+    onCollapseChangeRef.current?.(isCollapsed);
+  }, [isCollapsed]);
 
   // Persist preference to localStorage
   useEffect(() => {

--- a/resume-builder-ui/src/components/SectionNavigator.tsx
+++ b/resume-builder-ui/src/components/SectionNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   MdAdd,
   MdFileDownload,
@@ -175,12 +175,16 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
   // Notify parent of initial state
   useEffect(() => {
     onCollapseChange?.(isCollapsed);
-  }, []);
+  }, [isCollapsed, onCollapseChange]);
 
   // Persist preference to localStorage
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, String(isCollapsed));
   }, [isCollapsed]);
+
+  const handleToggle = useCallback(() => {
+    setIsCollapsed((current) => !current);
+  }, []);
 
   // Keyboard shortcut: Ctrl+\ to toggle sidebar
   useEffect(() => {
@@ -193,13 +197,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isCollapsed]);
-
-  const handleToggle = () => {
-    const newState = !isCollapsed;
-    setIsCollapsed(newState);
-    onCollapseChange?.(newState);
-  };
+  }, [handleToggle]);
 
   // Handle Start Fresh - confirmation dialog is handled by parent (Editor.tsx)
   const handleStartFresh = () => {
@@ -296,7 +294,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
   return (
     <nav
       ref={sidebarRef}
-      className={`hidden lg:flex flex-col fixed right-0 bg-white/95 backdrop-blur-sm border-l border-gray-200/80 shadow-xl overflow-hidden z-[45] transition-all duration-300 ease-in-out ${
+      className={`hidden lg:flex flex-col fixed right-0 bg-white/95 backdrop-blur-sm border-l border-gray-200/80 shadow-sm overflow-hidden z-[45] transition-all duration-300 ease-in-out ${
         isCollapsed ? "w-[72px]" : "w-[280px]"
       }`}
       style={{
@@ -314,7 +312,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
         )}
         <button
           onClick={handleToggle}
-          className={`p-2 hover:bg-white rounded-lg transition-all text-gray-500 hover:text-gray-800 hover:shadow-sm ${
+          className={`inline-flex min-h-11 min-w-11 items-center justify-center p-2 hover:bg-white rounded-lg transition-all text-gray-500 hover:text-gray-800 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
             isCollapsed ? "mx-auto" : ""
           }`}
           aria-label={isCollapsed ? "Expand sidebar (Ctrl+\\)" : "Collapse sidebar (Ctrl+\\)"}
@@ -344,7 +342,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               activeSectionIndex === -1
                 ? isCollapsed
                   ? "bg-accent/[0.06] text-ink/80"
-                  : "bg-accent/[0.06]/80 border-l-[3px] border-accent text-ink font-medium"
+                  : "bg-accent/[0.06]/80 ring-1 ring-accent/20 text-ink font-medium"
                 : "text-gray-700 hover:text-gray-900"
             }`}
           >
@@ -383,7 +381,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
                 activeSectionIndex === index
                   ? isCollapsed
                     ? "bg-accent/[0.06] text-ink/80"
-                    : "bg-accent/[0.06]/80 border-l-[3px] border-accent text-ink font-medium"
+                    : "bg-accent/[0.06]/80 ring-1 ring-accent/20 text-ink font-medium"
                   : "text-gray-700 hover:text-gray-900"
               }`}
             >
@@ -541,7 +539,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
         </div>
 
       {/* Actions Section */}
-      <div className="border-t border-gray-200/60 bg-gradient-to-t from-gray-50/80 to-white">
+      <div className="border-t border-gray-200/60 bg-white">
         <div className={`${isCollapsed ? "py-3 px-2" : "p-4"}`}>
           {!isCollapsed && (
             <h3 className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">
@@ -555,7 +553,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               id="tour-preview-button"
               onClick={onPreviewResume}
               disabled={isPreviewLoading}
-              className={`w-full flex items-center justify-center bg-accent text-ink font-semibold rounded-lg shadow-md hover:shadow-lg hover:bg-accent/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] relative ${
+              className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-semibold rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2.5 px-1 mb-2"
                   : "flex-row gap-2 px-4 py-2.5 mb-2.5"
@@ -589,7 +587,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             id="tour-download-button"
             onClick={onDownloadResume}
             disabled={isGenerating}
-            className={`w-full flex items-center justify-center bg-gradient-to-r from-emerald-600 to-green-600 text-white font-semibold rounded-lg shadow-md hover:shadow-lg hover:from-emerald-500 hover:to-green-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] ${
+            className={`w-full min-h-11 flex items-center justify-center bg-emerald-600 text-white font-semibold rounded-lg shadow-sm hover:bg-emerald-700 hover:shadow-md transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 ${
               isCollapsed
                 ? "flex-col gap-1 py-2.5 px-1"
                 : "flex-row gap-2 px-4 py-2.5 mb-2.5"
@@ -610,7 +608,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
           {/* Secondary Action: Add Section */}
           <button
             onClick={onAddSection}
-            className={`w-full flex items-center justify-center bg-accent text-ink font-medium rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all active:scale-[0.98] ${
+            className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-medium rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
               isCollapsed
                 ? "flex-col gap-1 py-2 px-1 mt-2"
                 : "flex-row gap-2 px-4 py-2 mb-3"
@@ -629,7 +627,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               id="tour-backup-button"
               onClick={onExportYAML}
               disabled={loadingSave}
-              className={`w-full flex items-center transition-all rounded-md disabled:opacity-50 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]/80"
                   : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06]/80 text-gray-700 hover:text-ink/80"
@@ -666,10 +664,10 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             <button
               onClick={onImportYAML}
               disabled={loadingLoad}
-              className={`w-full flex items-center transition-all rounded-md disabled:opacity-50 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-green-50/80"
-                  : "flex-row gap-3 px-3 py-2 hover:bg-green-50/80 text-gray-700 hover:text-green-700"
+                  : "flex-row gap-3 px-3 py-2 hover:bg-green-50/80 text-green-800 hover:text-green-700"
               }`}
             >
               <MdFileUpload
@@ -695,10 +693,10 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             {/* Start Fresh - KEEP LABEL AS-IS (not renamed) */}
             <button
               onClick={handleStartFresh}
-              className={`w-full flex items-center transition-all rounded-md ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-orange-50/80"
-                  : "flex-row gap-3 px-3 py-2 hover:bg-orange-50/80 text-gray-700 hover:text-orange-700"
+                  : "flex-row gap-3 px-3 py-2 hover:bg-orange-50/80 text-orange-800 hover:text-orange-700"
               }`}
             >
               <MdRefresh
@@ -718,7 +716,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             {/* Help */}
             <button
               onClick={onHelp}
-              className={`w-full flex items-center transition-all rounded-md ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]/80"
                   : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06]/80 text-gray-700 hover:text-ink/80"
@@ -743,10 +741,10 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
           <div className={`border-t border-gray-200/60 ${isCollapsed ? "pt-2 px-2" : "pt-3 px-4"}`}>
             <Link
               to="/contact"
-              className={`w-full flex items-center transition-all rounded-md ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-teal-50/80"
-                  : "flex-row gap-3 px-3 py-2 hover:bg-teal-50/80 text-gray-700 hover:text-teal-700"
+                  : "flex-row gap-3 px-3 py-2 hover:bg-teal-50/80 text-teal-800 hover:text-teal-700"
               }`}
             >
               <MdSupport

--- a/resume-builder-ui/src/components/ads/AdContainer.tsx
+++ b/resume-builder-ui/src/components/ads/AdContainer.tsx
@@ -195,7 +195,7 @@ export const AdContainer = ({
     return (
       <div
         ref={containerRef}
-        className={`ad-container ${className}`}
+        className={`ad-container ad-surface ${className}`}
         style={{
           minHeight: `${minHeight}px`,
           ...(minWidth && { minWidth: `${minWidth}px` }),
@@ -269,7 +269,7 @@ export const AdContainer = ({
   return (
     <div
       ref={containerRef}
-      className={`ad-container ${className}`}
+      className={`ad-container ad-surface ${className}`}
       style={containerStyle}
       data-testid={testId}
       role="complementary"

--- a/resume-builder-ui/src/components/ads/SideRailLayout.tsx
+++ b/resume-builder-ui/src/components/ads/SideRailLayout.tsx
@@ -1,11 +1,14 @@
 import { ReactNode } from "react";
 import { AD_CONFIG, isExplicitAdsEnabled } from "../../config/ads";
 import { AdContainer } from "./AdContainer";
+import { InContentAd } from "./InContentAd";
 
 interface SideRailLayoutProps {
   children: ReactNode;
   /** Disable side rails (e.g. on editor pages) */
   enabled?: boolean;
+  /** Hide the global mobile-top ad (e.g. landing page renders its own below the hero) */
+  showMobileTop?: boolean;
 }
 
 /**
@@ -20,6 +23,7 @@ interface SideRailLayoutProps {
 export const SideRailLayout = ({
   children,
   enabled = true,
+  showMobileTop = true,
 }: SideRailLayoutProps) => {
   const explicitAdsEnabled = isExplicitAdsEnabled();
   const showRails = enabled && (explicitAdsEnabled || AD_CONFIG.debug);
@@ -45,6 +49,15 @@ export const SideRailLayout = ({
 
       {/* Page content */}
       <div className="flex-1 min-w-0">
+        {showMobileTop && (
+          <div className="block md:hidden">
+            <InContentAd
+              adSlot={AD_CONFIG.slots.mobileTop}
+              size="large" // "large" (400px) reserves enough for the ~375px mobile fill — prevents CLS
+              marginY={16}
+            />
+          </div>
+        )}
         {children}
       </div>
 

--- a/resume-builder-ui/src/components/ads/SideRailLayout.tsx
+++ b/resume-builder-ui/src/components/ads/SideRailLayout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from "react";
 import { AD_CONFIG, isExplicitAdsEnabled } from "../../config/ads";
 import { AdContainer } from "./AdContainer";
-import { InContentAd } from "./InContentAd";
 
 interface SideRailLayoutProps {
   children: ReactNode;
@@ -46,14 +45,6 @@ export const SideRailLayout = ({
 
       {/* Page content */}
       <div className="flex-1 min-w-0">
-        {/* Mobile-top ad — visible below md, compensates for hidden side rails */}
-        <div className="block md:hidden">
-          <InContentAd
-            adSlot={AD_CONFIG.slots.mobileTop}
-            size="standard"
-            marginY={16}
-          />
-        </div>
         {children}
       </div>
 

--- a/resume-builder-ui/src/components/blog/ATSFormattingRules.tsx
+++ b/resume-builder-ui/src/components/blog/ATSFormattingRules.tsx
@@ -101,7 +101,7 @@ export default function ATSFormattingRules() {
           skills field, so a keyword search for that exact skill never returns
           your name.
         </p>
-        <div className="bg-chalk-dark border-l-4 border-red-500 p-6 my-6">
+        <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6 my-6">
           <h3 className="font-bold text-ink mb-2">The invisible rejection</h3>
           <p className="text-stone-warm">
             This is the failure mode that costs qualified people interviews. Your
@@ -366,8 +366,8 @@ export default function ATSFormattingRules() {
           Frequently Asked Questions
         </h2>
         <div className="space-y-4 my-6">
-          {FAQS.map((faq, i) => (
-            <div key={i} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-5">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-5">
               <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
               <p className="text-stone-warm">{faq.answer}</p>
             </div>

--- a/resume-builder-ui/src/components/blog/HumanizeAIResume.tsx
+++ b/resume-builder-ui/src/components/blog/HumanizeAIResume.tsx
@@ -123,7 +123,7 @@ export default function HumanizeAIResume() {
         </p>
 
         <div className="space-y-4">
-          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+          <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6">
             <h3 className="font-bold text-ink mb-2">Generic, round-number metrics with no context</h3>
             <p className="text-stone-warm">
               "Increased efficiency by 30%." Thirty percent of what, measured how,
@@ -131,14 +131,14 @@ export default function HumanizeAIResume() {
               real data to anchor them.
             </p>
           </div>
-          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+          <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6">
             <h3 className="font-bold text-ink mb-2">Uniform sentence rhythm</h3>
             <p className="text-stone-warm">
               Every bullet runs 12–15 words and follows the same shape. Real
               accomplishments come in different sizes, so real bullets should too.
             </p>
           </div>
-          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+          <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6">
             <h3 className="font-bold text-ink mb-2">Corporate filler</h3>
             <p className="text-stone-warm">
               "Spearheaded," "leveraged synergies," "spearheaded cross-functional
@@ -146,7 +146,7 @@ export default function HumanizeAIResume() {
               but describe nothing.
             </p>
           </div>
-          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+          <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6">
             <h3 className="font-bold text-ink mb-2">Hallucinated specifics</h3>
             <p className="text-stone-warm">
               AI will confidently invent a tool, a certification, or a metric you
@@ -154,7 +154,7 @@ export default function HumanizeAIResume() {
               collapse in an interview.
             </p>
           </div>
-          <div className="bg-chalk-dark border-l-4 border-red-500 p-6">
+          <div className="rounded-lg border border-red-200/70 bg-red-50/80 p-6">
             <h3 className="font-bold text-ink mb-2">Em-dash overuse and identical bullet openers</h3>
             <p className="text-stone-warm">
               A cascade of em dashes, and every bullet starting with the same verb
@@ -274,8 +274,8 @@ export default function HumanizeAIResume() {
           Frequently Asked Questions
         </h2>
         <div className="space-y-4 my-6">
-          {FAQS.map((faq, i) => (
-            <div key={i} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-4">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-4">
               <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
               <p className="text-stone-warm text-sm">{faq.answer}</p>
             </div>

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -280,7 +280,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
           </div>
           <button
             onClick={modals.closeAIWarning}
-            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             aria-label="Close review banner"
           >
             <X className="w-4 h-4" />

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -268,7 +268,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
     >
       {/* Imported Resume Review Banner */}
       {modals.showAIWarning && (
-        <div className="mb-4 p-4 rounded-lg border-2 bg-accent/[0.06] border-accent/20 flex items-start gap-3">
+        <div className="mb-4 p-4 rounded-lg border border-slate-200 bg-accent/[0.06] flex items-start gap-3">
           <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5 text-accent" />
           <div className="flex-1">
             <h3 className="font-semibold text-sm text-ink">
@@ -280,7 +280,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
           </div>
           <button
             onClick={modals.closeAIWarning}
-            className="text-gray-400 hover:text-gray-600"
+            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             aria-label="Close review banner"
           >
             <X className="w-4 h-4" />
@@ -353,12 +353,12 @@ export const EditorContent: React.FC<EditorContentProps> = ({
 
         <DragOverlay modifiers={[restrictToVerticalAxis]} dropAnimation={{
           duration: 250,
-          easing: 'cubic-bezier(0.18, 0.67, 0.6, 1.22)',
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
         }}>
           {dragDrop.activeId ? (
             dragDrop.activeLevel === 'section' && dragDrop.draggedSection ? (
               // Section drag preview - lifted appearance with scale and rotation
-              <div className={`bg-white backdrop-blur-sm rounded-xl shadow-2xl border-2 border-accent/70 px-6 py-4 max-w-md cursor-grabbing ${liftedPreviewClasses}`}>
+              <div className={`bg-white rounded-lg shadow-lg border border-slate-200 px-6 py-4 max-w-md cursor-grabbing ${liftedPreviewClasses}`}>
                 <div className="flex items-center gap-3">
                   <div className="w-10 h-10 rounded-lg bg-accent/10 flex items-center justify-center">
                     <div className="flex flex-col gap-0.5">
@@ -436,7 +436,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
               </div>
             ) : dragDrop.activeLevel === 'subitem' ? (
               // Fallback subitem preview - lifted appearance
-              <div className={`bg-white backdrop-blur-sm rounded-md shadow-xl border-2 border-accent/70 px-3 py-2 max-w-xs cursor-grabbing ${liftedPreviewClasses}`}>
+              <div className={`bg-white rounded-md shadow-lg border border-slate-200 px-3 py-2 max-w-xs cursor-grabbing ${liftedPreviewClasses}`}>
                 <div className="flex items-center gap-2">
                   <div className="w-6 h-6 rounded bg-accent/10 flex items-center justify-center">
                     <div className="w-1.5 h-1.5 rounded-full bg-accent" />

--- a/resume-builder-ui/src/components/editor/EditorHeader.tsx
+++ b/resume-builder-ui/src/components/editor/EditorHeader.tsx
@@ -199,7 +199,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
       <div className="fixed top-4 right-6 z-[65] hidden lg:flex items-center gap-3">
         {/* Save Status for authenticated users */}
         {isAuthenticated && saveStatus && (
-          <div className="bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 shadow-md border border-gray-200/60">
+          <div className="bg-white/95 backdrop-blur-sm rounded-lg px-3 py-2 shadow-sm border border-gray-200/60">
             <SaveStatusIndicator status={saveStatus} lastSaved={lastSaved} />
           </div>
         )}
@@ -208,14 +208,14 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
       {/* Mobile Job Notification Banner */}
       {showMobileBanner && (
         <div className="fixed top-0 left-0 right-0 z-[70] lg:hidden animate-[slideDown_0.3s_ease-out]">
-          <div className="bg-ink text-white px-4 py-3 flex items-center justify-between shadow-lg">
+          <div className="bg-ink text-white px-4 py-3 flex items-center justify-between shadow-sm">
             <Link
               to="/jobs"
               onClick={() => {
                 handleBadgeClick();
                 dismissMobileBanner();
               }}
-              className="flex items-center gap-2 flex-1 min-w-0"
+              className="flex min-h-11 items-center gap-2 flex-1 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
               <JobSparkleIcon className="w-4 h-4 flex-shrink-0 text-accent" />
               <span className="text-sm font-medium truncate">
@@ -225,7 +225,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
             </Link>
             <button
               onClick={dismissMobileBanner}
-              className="ml-2 p-1 hover:bg-white/10 rounded transition-colors flex-shrink-0"
+              className="ml-2 inline-flex min-h-9 min-w-9 items-center justify-center p-1 hover:bg-white/10 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
               aria-label="Dismiss"
             >
               <X className="w-4 h-4" />
@@ -238,7 +238,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
       {showIdleTooltip &&
         ReactDOM.createPortal(
           <div
-            className="fixed top-20 right-6 z-[70] bg-accent text-ink text-sm px-4 py-3 rounded-lg shadow-xl animate-bounce"
+            className="fixed top-20 right-6 z-[70] bg-accent text-ink text-sm px-4 py-3 rounded-lg shadow-md"
             role="alert"
             aria-live="polite"
           >
@@ -247,7 +247,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
               <span>Don't forget to save your progress permanently</span>
               <button
                 onClick={onDismissIdleTooltip}
-                className="ml-2 hover:opacity-75 text-white"
+                className="ml-2 inline-flex min-h-8 min-w-8 items-center justify-center rounded-md text-ink hover:bg-ink/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/50"
                 aria-label="Dismiss reminder"
               >
                 ✕

--- a/resume-builder-ui/src/components/editor/EditorHeader.tsx
+++ b/resume-builder-ui/src/components/editor/EditorHeader.tsx
@@ -225,7 +225,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
             </Link>
             <button
               onClick={dismissMobileBanner}
-              className="ml-2 inline-flex min-h-9 min-w-9 items-center justify-center p-1 hover:bg-white/10 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="ml-2 inline-flex min-h-11 min-w-11 items-center justify-center p-1 hover:bg-white/10 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
               aria-label="Dismiss"
             >
               <X className="w-4 h-4" />
@@ -247,7 +247,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
               <span>Don't forget to save your progress permanently</span>
               <button
                 onClick={onDismissIdleTooltip}
-                className="ml-2 inline-flex min-h-8 min-w-8 items-center justify-center rounded-md text-ink hover:bg-ink/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/50"
+                className="ml-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-ink hover:bg-ink/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/50"
                 aria-label="Dismiss reminder"
               >
                 ✕

--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -456,7 +456,7 @@ export default function ResumeKeywordScanner() {
 
       {/* Scanner Tool */}
       <RevealSection variant="fade-up">
-        <div ref={scannerSectionRef} className="mb-16">
+        <div ref={scannerSectionRef} className="mb-16 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
           {/* Privacy trust signal */}
           <div className="flex items-center justify-center gap-2 mb-6 text-xs text-mist">
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
@@ -476,7 +476,7 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="resume-text"
-                className="w-full h-56 md:h-64 rounded-xl border border-black/[0.08] bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste your resume text here..."
                 value={resumeText}
                 onChange={(e) => setResumeText(e.target.value)}
@@ -499,7 +499,7 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="job-description"
-                className="w-full h-56 md:h-64 rounded-xl border border-black/[0.08] bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste the job description here..."
                 value={jobDescription}
                 onChange={(e) => setJobDescription(e.target.value)}
@@ -517,13 +517,16 @@ export default function ResumeKeywordScanner() {
           <div className="flex flex-col items-center gap-3">
             <div className="flex justify-center gap-4">
               <button
+                type="button"
                 onClick={handleScan}
                 disabled={!canScan || isMatching}
-                className="btn-primary px-8 py-3.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center gap-2"
+                className="btn-primary px-8 disabled:opacity-40 disabled:cursor-not-allowed disabled:transform-none inline-flex items-center gap-2"
               >
                 {isMatching ? (
                   <>
-                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    <span className="h-2 w-10 overflow-hidden rounded-full bg-ink/15">
+                      <span className="block h-full w-1/2 animate-pulse rounded-full bg-ink/60" />
+                    </span>
                     Analyzing...
                   </>
                 ) : (
@@ -531,7 +534,7 @@ export default function ResumeKeywordScanner() {
                 )}
               </button>
               {(resumeText || jobDescription) && (
-                <button onClick={handleClear} className="btn-secondary px-6 py-3.5">
+                <button type="button" onClick={handleClear} className="btn-secondary px-6">
                   Clear
                 </button>
               )}
@@ -548,13 +551,14 @@ export default function ResumeKeywordScanner() {
       {/* Error state */}
       {error && !isMatching && (
         <RevealSection variant="fade-up">
-          <div className="mb-8 bg-red-50 rounded-2xl p-6 border border-red-200 text-center">
+          <div className="mb-8 bg-red-50 rounded-lg p-6 border border-red-200 text-center">
             <p className="text-red-600 text-sm font-medium mb-2">Something went wrong</p>
             <p className="text-red-500 text-xs mb-4">{error}</p>
             <button
+              type="button"
               onClick={handleScan}
               disabled={!canScan}
-              className="btn-secondary px-6 py-2.5 text-sm"
+              className="btn-secondary px-6 text-sm"
             >
               Retry
             </button>
@@ -576,7 +580,7 @@ export default function ResumeKeywordScanner() {
         <RevealSection variant="fade-up">
           <div className="mb-16">
             {/* Score Overview */}
-            <div className="bg-white rounded-2xl p-6 sm:p-8 shadow-premium border border-black/[0.06] mb-8">
+            <div className="bg-white rounded-lg p-6 sm:p-8 shadow-sm border border-slate-200 mb-8">
               <div className="grid md:grid-cols-3 gap-6 md:gap-8 items-center">
                 <div className="md:col-span-1">
                   <ScoreRing result={result} />
@@ -620,7 +624,7 @@ export default function ResumeKeywordScanner() {
             </div>
 
             {/* Three-Tab Keyword Section */}
-            <div className="bg-white rounded-2xl p-4 sm:p-6 shadow-sm border border-black/[0.06]">
+            <div className="bg-white rounded-lg p-4 sm:p-6 shadow-sm border border-slate-200">
               <div className="flex gap-2 mb-6 overflow-x-auto pb-1 -mb-1 scrollbar-none">
                 {([
                   { key: 'missing' as const, label: 'Missing', count: result.missingCount, activeClass: 'bg-red-50 text-red-600 border border-red-200' },
@@ -628,9 +632,10 @@ export default function ResumeKeywordScanner() {
                   { key: 'matched' as const, label: 'Matched', count: result.matchedCount, activeClass: 'bg-accent/10 text-accent border border-accent/20' },
                 ] as const).map(tab => (
                   <button
+                    type="button"
                     key={tab.key}
                     onClick={() => setActiveTab(tab.key)}
-                    className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+                    className={`min-h-11 px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
                       activeTab === tab.key
                         ? tab.activeClass
                         : 'text-stone-warm hover:bg-chalk-dark border border-transparent'
@@ -736,7 +741,7 @@ export default function ResumeKeywordScanner() {
             ].map((tip) => (
               <div
                 key={tip.title}
-                className="bg-white rounded-2xl p-6 shadow-sm border border-black/[0.06] border-l-4 border-l-accent"
+                className="bg-white rounded-lg p-6 shadow-sm border border-slate-200"
               >
                 <h3 className="font-display text-lg font-bold text-ink mb-2">
                   {tip.title}

--- a/resume-builder-ui/src/contexts/EditorContext.tsx
+++ b/resume-builder-ui/src/contexts/EditorContext.tsx
@@ -32,6 +32,8 @@ export const useEditorContext = () => {
   return context;
 };
 
+export const useOptionalEditorContext = () => useContext(EditorContext);
+
 interface EditorProviderProps {
   children: ReactNode;
   // Auto-save state can be injected from useAutoSave hook

--- a/resume-builder-ui/src/pages/MyResumes.tsx
+++ b/resume-builder-ui/src/pages/MyResumes.tsx
@@ -298,9 +298,11 @@ export default function MyResumes() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+        <div className="text-center rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+          <div className="mx-auto mb-4 h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+            <div className="h-full w-1/2 animate-pulse rounded-full bg-accent" />
+          </div>
           <p className="text-gray-600">
             {authLoading ? 'Initializing authentication...' : 'Loading your resumes...'}
           </p>
@@ -321,16 +323,17 @@ export default function MyResumes() {
 
   if (isError) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center max-w-md">
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+        <div className="text-center max-w-md rounded-lg border border-red-100 bg-white p-8 shadow-sm">
           <svg className="w-16 h-16 text-red-500 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <h2 className="text-2xl font-bold text-gray-900 mb-2">Error Loading Resumes</h2>
           <p className="text-gray-600 mb-4">{error?.message || 'Failed to load resumes'}</p>
           <button
+            type="button"
             onClick={() => refetch()}
-            className="bg-accent text-ink px-6 py-2 rounded-lg hover:bg-accent/90 transition-colors"
+            className="btn-primary px-6"
           >
             Try Again
           </button>
@@ -340,10 +343,24 @@ export default function MyResumes() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="container mx-auto px-4 py-8 max-w-[1200px]">
+    <div className="min-h-screen bg-slate-50">
+      <div className="container mx-auto px-4 py-8 md:py-10 max-w-[1200px]">
+        <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.12em] text-slate-500">
+              Dashboard
+            </p>
+            <h1 className="mt-1 text-2xl md:text-3xl font-extrabold text-ink font-display">
+              My Resumes
+            </h1>
+          </div>
+          <p className="text-sm font-medium text-slate-600">
+            {resumes.length} of 5 resumes used
+          </p>
+        </div>
+
         {/* Resume Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6">
           {/* Ghost Card - Always first */}
           <GhostCard
             isAtLimit={resumes.length >= 5}
@@ -418,7 +435,9 @@ export default function MyResumes() {
       {downloadingId && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-sm mx-4">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
+            <div className="mx-auto mb-4 h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+              <div className="h-full w-1/2 animate-pulse rounded-full bg-accent" />
+            </div>
             <p className="text-center text-gray-700">
               Generating PDF...
             </p>

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -239,18 +239,26 @@ details .faq-content > div {
 }
 
 /* ── Hero "builds itself" sequence ──
-   Hidden start states live ONLY in keyframe `from` + fill-mode both/forwards,
-   so `animation: none` (reduced motion) leaves everything in its final visible
-   state. Animates clip-path/opacity/transform only — zero CLS. Delay comes
-   from the per-element --d custom property. */
+   Hidden start states live ONLY in keyframe `from` + fill-mode both/forwards
+   (or a base opacity: 0), so `animation: none` (reduced motion) leaves
+   everything in its final visible state. Animates clip-path/opacity/transform
+   only — zero CLS. Delay comes from the per-element --d custom property.
+   The whole sequence is paused until useScrollReveal adds .revealed to the
+   .hero-seq container (matters on mobile, where the card sits below the CTAs). */
 @keyframes hero-rise {
   from { opacity: 0; transform: translateY(16px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+@keyframes hero-card-in {
+  from { opacity: 0; transform: perspective(1000px) rotateX(14deg) translateY(36px) scale(0.94); }
+  60%  { opacity: 1; }
+  to   { opacity: 1; transform: perspective(1000px) rotateX(0deg) translateY(0) scale(1); }
+}
 @keyframes hero-pop {
-  0%   { opacity: 0; transform: scale(0.5); }
-  70%  { opacity: 1; transform: scale(1.08); }
-  100% { opacity: 1; transform: scale(1); }
+  0%   { opacity: 0; transform: scale(0.4) rotate(-8deg); }
+  60%  { opacity: 1; transform: scale(1.12) rotate(2deg); }
+  80%  { transform: scale(0.97) rotate(-1deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0deg); }
 }
 @keyframes hero-stamp {
   0%   { opacity: 0; transform: scale(1.6) rotate(-8deg); }
@@ -262,12 +270,72 @@ details .faq-content > div {
   20%, 60%     { opacity: 0; }
   100%         { opacity: 0; }
 }
+@keyframes hero-progress {
+  0%   { transform: scaleX(0); opacity: 1; }
+  85%  { transform: scaleX(1); opacity: 1; }
+  100% { transform: scaleX(1); opacity: 0; }
+}
+@keyframes hero-scan {
+  from { transform: translateY(0); opacity: 0; }
+  15%  { opacity: 1; }
+  80%  { opacity: 1; }
+  to   { transform: translateY(440px); opacity: 0; }
+}
+@keyframes hero-bob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-6px); }
+}
+@keyframes hero-glow {
+  0%, 100% { opacity: 0.6; transform: translate(-50%, -50%) scale(0.92); }
+  50%      { opacity: 1; transform: translate(-50%, -50%) scale(1.06); }
+}
 
+@keyframes hero-underline {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+@keyframes hero-title-scan {
+  /* sweep for ~28% of the cycle, then rest — both endpoints render pure ink,
+     so the loop restart is invisible */
+  0%   { background-position: 100% 0; }
+  28%  { background-position: 0% 0; }
+  100% { background-position: 0% 0; }
+}
+
+/* Accent sheen sweeps across "Free Resume Builder" (left → right), looping
+   with a long pause. The text is always painted (gradient is ink except the
+   moving band), so LCP is safe; at rest (and under reduced motion / no
+   background-clip support) it reads as plain ink. */
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .hero-title-scan {
+    background-image: linear-gradient(100deg, #0c0c0c 42%, #00d47e 50%, #0c0c0c 58%);
+    background-size: 300% 100%;
+    background-position: 100% 0;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: hero-title-scan 6s ease-in-out 0.5s infinite;
+  }
+}
+
+/* Accent highlighter behind "Get You Hired" in the H1 — draws in on load
+   (above the fold, not gated; text itself never animates so LCP is unaffected) */
+.hero-underline {
+  transform-origin: left;
+  animation: hero-underline 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.9s both;
+}
+
+/* Ambient loops (not part of the gated sequence) */
 .hero-mockup {
   animation: float 4s ease-in-out infinite;
 }
-.hero-rise {
-  animation: hero-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+.hero-glow {
+  animation: hero-glow 7s ease-in-out infinite;
+}
+
+/* Sequence steps */
+.hero-card-in {
+  animation: hero-card-in 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
   animation-delay: var(--d, 0s);
 }
 .hero-type {
@@ -279,14 +347,42 @@ details .faq-content > div {
   animation-delay: var(--d, 0s);
 }
 .hero-pop {
-  animation: hero-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: hero-pop 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
   animation-delay: var(--d, 0s);
 }
 .hero-stamp {
   animation:
     hero-stamp 0.45s cubic-bezier(0.16, 1, 0.3, 1) both,
-    pulse-accent 1.4s ease-out 2;
-  animation-delay: var(--d, 0s), calc(var(--d, 0s) + 0.65s);
+    pulse-accent 1.4s ease-out 2,
+    hero-bob 5.5s ease-in-out infinite;
+  animation-delay: var(--d, 0s), calc(var(--d, 0s) + 0.7s), calc(var(--d, 0s) + 1.6s);
+}
+.hero-chip {
+  animation:
+    hero-rise 0.5s cubic-bezier(0.16, 1, 0.3, 1) both,
+    hero-bob 6.5s ease-in-out infinite;
+  animation-delay: var(--d, 0s), calc(var(--d, 0s) + 1.2s);
+}
+.hero-progress {
+  opacity: 0; /* base-hidden so reduced-motion (animation: none) never shows a stuck bar */
+  transform-origin: left;
+  animation: hero-progress 3.4s linear both;
+  animation-delay: var(--d, 0s);
+}
+.hero-scan {
+  opacity: 0;
+  animation: hero-scan 0.8s ease-in-out both;
+  animation-delay: var(--d, 0s);
+}
+.hero-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 9999px;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0);
+  animation: dcm-particle-burst 0.7s ease-out both;
+  animation-delay: var(--d, 0s);
 }
 .hero-type-caret {
   position: relative;
@@ -302,6 +398,16 @@ details .faq-content > div {
   opacity: 0; /* hidden by default so reduced-motion (animation: none) never shows a stuck caret */
   animation: hero-caret-blink 1.6s step-end forwards;
   animation-delay: var(--d, 0s);
+}
+
+/* Gate: sequence waits for scroll-into-view (useScrollReveal adds .revealed) */
+.hero-seq :is(.hero-card-in, .hero-type, .hero-draw, .hero-pop, .hero-stamp, .hero-chip, .hero-progress, .hero-scan, .hero-particle),
+.hero-seq .hero-type-caret::after {
+  animation-play-state: paused;
+}
+.hero-seq.revealed :is(.hero-card-in, .hero-type, .hero-draw, .hero-pop, .hero-stamp, .hero-chip, .hero-progress, .hero-scan, .hero-particle),
+.hero-seq.revealed .hero-type-caret::after {
+  animation-play-state: running;
 }
 
 /* ── Download Celebration Modal ── */
@@ -414,11 +520,17 @@ details .faq-content > div {
   /* Landing page animations: disable (hero-* classes settle in their final
      visible state; the caret ::after defaults to opacity 0) */
   .hero-mockup,
-  .hero-rise,
+  .hero-glow,
+  .hero-underline,
+  .hero-card-in,
   .hero-type,
   .hero-draw,
   .hero-pop,
   .hero-stamp,
+  .hero-chip,
+  .hero-progress,
+  .hero-scan,
+  .hero-particle,
   .hero-type-caret::after,
   .demo-typing {
     animation: none !important;

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -238,6 +238,72 @@ details .faq-content > div {
   50%      { box-shadow: 0 0 0 8px rgba(0,212,126,0); }
 }
 
+/* ── Hero "builds itself" sequence ──
+   Hidden start states live ONLY in keyframe `from` + fill-mode both/forwards,
+   so `animation: none` (reduced motion) leaves everything in its final visible
+   state. Animates clip-path/opacity/transform only — zero CLS. Delay comes
+   from the per-element --d custom property. */
+@keyframes hero-rise {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes hero-pop {
+  0%   { opacity: 0; transform: scale(0.5); }
+  70%  { opacity: 1; transform: scale(1.08); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes hero-stamp {
+  0%   { opacity: 0; transform: scale(1.6) rotate(-8deg); }
+  70%  { opacity: 1; transform: scale(0.95) rotate(0deg); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes hero-caret-blink {
+  0%, 40%, 80% { opacity: 1; }
+  20%, 60%     { opacity: 0; }
+  100%         { opacity: 0; }
+}
+
+.hero-mockup {
+  animation: float 4s ease-in-out infinite;
+}
+.hero-rise {
+  animation: hero-rise 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--d, 0s);
+}
+.hero-type {
+  animation: typewriter 0.8s steps(14, end) both;
+  animation-delay: var(--d, 0s);
+}
+.hero-draw {
+  animation: typewriter 0.45s ease-out both;
+  animation-delay: var(--d, 0s);
+}
+.hero-pop {
+  animation: hero-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--d, 0s);
+}
+.hero-stamp {
+  animation:
+    hero-stamp 0.45s cubic-bezier(0.16, 1, 0.3, 1) both,
+    pulse-accent 1.4s ease-out 2;
+  animation-delay: var(--d, 0s), calc(var(--d, 0s) + 0.65s);
+}
+.hero-type-caret {
+  position: relative;
+}
+.hero-type-caret::after {
+  content: '';
+  position: absolute;
+  top: 0.1em;
+  bottom: 0.1em;
+  right: -4px;
+  width: 2px;
+  background: #00d47e;
+  opacity: 0; /* hidden by default so reduced-motion (animation: none) never shows a stuck caret */
+  animation: hero-caret-blink 1.6s step-end forwards;
+  animation-delay: var(--d, 0s);
+}
+
 /* ── Download Celebration Modal ── */
 @keyframes dcm-scale-in {
   0% { transform: scale(0); opacity: 0; }
@@ -345,8 +411,15 @@ details .faq-content > div {
     display: none !important;
   }
 
-  /* Landing page animations: disable */
+  /* Landing page animations: disable (hero-* classes settle in their final
+     visible state; the caret ::after defaults to opacity 0) */
   .hero-mockup,
+  .hero-rise,
+  .hero-type,
+  .hero-draw,
+  .hero-pop,
+  .hero-stamp,
+  .hero-type-caret::after,
   .demo-typing {
     animation: none !important;
   }

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -55,28 +55,25 @@
 
 /* 2026 Modern Button System */
 .btn-primary {
-  @apply relative inline-flex items-center justify-center bg-accent text-ink font-bold rounded-xl shadow-lg hover:shadow-2xl transform hover:-translate-y-0.5 transition-all duration-300 active:scale-95 overflow-hidden;
+  @apply relative inline-flex min-h-11 items-center justify-center bg-accent text-ink font-bold rounded-lg shadow-sm hover:shadow-md transition-all duration-200 active:scale-[0.98] overflow-hidden;
 }
 
 .btn-primary::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.15), transparent);
-  transform: translateX(-100%);
-  transition: transform 0.7s ease-out;
-}
-
-.btn-primary:hover::before {
-  transform: translateX(100%);
+  content: none;
 }
 
 .btn-secondary {
-  @apply relative inline-flex items-center justify-center bg-white border border-gray-200 text-ink font-semibold rounded-xl shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-300 active:scale-95;
+  @apply relative inline-flex min-h-11 items-center justify-center bg-white border border-gray-200 text-ink font-semibold rounded-lg shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 active:scale-[0.98];
 }
 
 .btn-ghost {
-  @apply relative text-gray-700 hover:text-ink transition-all duration-300 font-medium px-3 py-2 rounded-lg hover:bg-black/5;
+  @apply relative inline-flex min-h-11 items-center justify-center text-gray-700 hover:text-ink transition-all duration-200 font-medium px-3 py-2 rounded-lg hover:bg-black/5;
+}
+
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible,
+.btn-ghost:focus-visible {
+  @apply outline-none ring-2 ring-accent ring-offset-2 ring-offset-white;
 }
 
 .btn-ghost::before {
@@ -273,7 +270,7 @@ details .faq-content > div {
 }
 
 .animate-dcm-scale-in {
-  animation: dcm-scale-in 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: dcm-scale-in 0.42s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 .animate-dcm-checkmark-draw {
   animation: dcm-checkmark-draw 0.6s ease-in-out 0.3s forwards;
@@ -494,7 +491,7 @@ footer {
 .Toastify__toast--success .custom-toast {
   background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(52, 211, 153, 0.05)) !important;
   border: 1px solid rgba(16, 185, 129, 0.3) !important;
-  border-left: 4px solid #10b981 !important;
+  box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.08) !important;
 }
 
 .Toastify__toast--success .custom-toast::before {
@@ -506,7 +503,7 @@ footer {
 .Toastify__toast--error .custom-toast {
   background: linear-gradient(135deg, rgba(239, 68, 68, 0.1), rgba(248, 113, 113, 0.05)) !important;
   border: 1px solid rgba(239, 68, 68, 0.3) !important;
-  border-left: 4px solid #ef4444 !important;
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.08) !important;
 }
 
 .Toastify__toast--error .custom-toast::before {
@@ -518,7 +515,7 @@ footer {
 .Toastify__toast--info .custom-toast {
   background: linear-gradient(135deg, rgba(0, 212, 126, 0.1), rgba(0, 212, 126, 0.05)) !important;
   border: 1px solid rgba(0, 212, 126, 0.3) !important;
-  border-left: 4px solid #00d47e !important;
+  box-shadow: inset 0 0 0 1px rgba(0, 212, 126, 0.08) !important;
 }
 
 .Toastify__toast--info .custom-toast::before {
@@ -530,7 +527,7 @@ footer {
 .Toastify__toast--warning .custom-toast {
   background: linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(251, 191, 36, 0.05)) !important;
   border: 1px solid rgba(245, 158, 11, 0.3) !important;
-  border-left: 4px solid #f59e0b !important;
+  box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.08) !important;
 }
 
 .Toastify__toast--warning .custom-toast::before {
@@ -742,6 +739,40 @@ footer {
 .ad-container {
   contain: layout style;
   max-width: 100%;
+}
+
+.ad-surface {
+  position: relative;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.88), rgba(255, 255, 255, 0.96)),
+    repeating-linear-gradient(135deg, rgba(15, 23, 42, 0.035) 0 1px, transparent 1px 12px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.ad-surface::before {
+  content: "Advertisement";
+  position: absolute;
+  top: 0.5rem;
+  left: 0.75rem;
+  z-index: 1;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.72);
+  pointer-events: none;
+}
+
+.ad-surface:empty::after {
+  content: "";
+  position: absolute;
+  inset: 2.25rem 0.75rem 0.75rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.44);
+  pointer-events: none;
 }
 
 ins.adsbygoogle {


### PR DESCRIPTION
## Summary
- tighten shared button, focus, footer, header, card, drawer, and editor action surfaces for cleaner utility-first UX
- restyle ad containers as reserved labeled surfaces, preserve slot IDs, and move the mobile-top slot below the landing hero
- add ad slot regression coverage and update loading indicators away from border spinners

## Verification
- npm test -- --run
- npm run build
- npx eslint touched UI/test files
- Browser mobile smoke on /: no horizontal overflow, no app-owned visible tap targets below 44px

Note: npm run lint still fails repo-wide on unrelated existing files outside this changeset.