### PR TITLE
fix(scanner): make Resume Keyword Scanner output correct and trustworthy

### DIFF
--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -93,9 +93,11 @@ function ScoreRing({ result }: { result: EnhancedScanResult }) {
 const NLP_WORDS = ['PARSING', 'TOKENIZING', 'EMBEDDING', 'CALIBRATING'] as const;
 const NODE_THRESHOLDS = [0, 17, 33, 50, 67, 83] as const;
 
-function ModelStatusIndicator({
+// Exported for tests only — not part of the page's public API.
+export function ModelStatusIndicator({
   status,
   progress,
+  statusText,
 }: {
   status: string;
   progress: number;

--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -139,37 +139,44 @@ function ModelStatusIndicator({
   // loading
   if (status === 'loading') {
     return (
-      <div className="min-h-[32px] flex items-center gap-3">
-        <span
-          className="w-2 h-2 rounded-full bg-accent"
-          style={{ animation: 'ks-breathe 2s ease-in-out infinite' }}
-        />
-        <span
-          key={wordIndex}
-          className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase"
-          style={{ animation: 'fadeIn 0.3s ease-out' }}
-        >
-          {NLP_WORDS[wordIndex]}...
-        </span>
-        <span className="flex items-center gap-0.5">
-          {NODE_THRESHOLDS.map((_, i) => (
-            <span
-              key={i}
-              className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
-                i < litCount ? 'bg-accent' : 'bg-mist/30'
-              }`}
-              style={
-                i === litCount - 1 && litCount > 0
-                  ? { animation: 'pulse-accent 1.5s ease-in-out infinite' }
-                  : undefined
-              }
-            />
-          ))}
-        </span>
-        {progress > 0 && (
-          <span className="font-mono text-[10px] text-mist tabular-nums">
-            {progress}%
+      <div className="flex flex-col items-center gap-1">
+        <div className="min-h-[32px] flex items-center gap-3">
+          <span
+            className="w-2 h-2 rounded-full bg-accent"
+            style={{ animation: 'ks-breathe 2s ease-in-out infinite' }}
+          />
+          <span
+            key={wordIndex}
+            className="font-mono text-xs tracking-[0.15em] text-accent-text uppercase"
+            style={{ animation: 'fadeIn 0.3s ease-out' }}
+          >
+            {NLP_WORDS[wordIndex]}...
           </span>
+          <span className="flex items-center gap-0.5">
+            {NODE_THRESHOLDS.map((_, i) => (
+              <span
+                key={i}
+                className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+                  i < litCount ? 'bg-accent' : 'bg-mist/30'
+                }`}
+                style={
+                  i === litCount - 1 && litCount > 0
+                    ? { animation: 'pulse-accent 1.5s ease-in-out infinite' }
+                    : undefined
+                }
+              />
+            ))}
+          </span>
+          {progress > 0 && (
+            <span className="font-mono text-[10px] text-mist tabular-nums">
+              {progress}%
+            </span>
+          )}
+        </div>
+        {/* Phase 3: explicit one-time/size copy so a slow first load reads as
+            expected progress, not a hang. */}
+        {statusText && (
+          <span className="font-mono text-[10px] text-mist tracking-wide">{statusText}</span>
         )}
       </div>
     );

--- a/resume-builder-ui/src/components/tools/__tests__/ResumeKeywordScanner.test.tsx
+++ b/resume-builder-ui/src/components/tools/__tests__/ResumeKeywordScanner.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelStatusIndicator } from '../ResumeKeywordScanner';
+
+// Regression test for the statusText crash: the prop was declared in the
+// props type but missing from the destructuring pattern, so the loading
+// branch's bare `statusText` reference threw a ReferenceError at runtime
+// and unmounted the whole page. tsc -b catches this (TS2304), but the
+// baseline `npx tsc --noEmit` checks zero files (solution-style root
+// tsconfig), and no suite rendered this component — so it escaped.
+describe('ModelStatusIndicator', () => {
+  it('renders statusText during loading without crashing', () => {
+    const statusText = 'Downloading AI model (one-time, ~23 MB)…';
+    render(<ModelStatusIndicator status="loading" progress={42} statusText={statusText} />);
+
+    expect(screen.getByText(statusText)).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+  });
+});

--- a/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
+++ b/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractKeywords, scanResume } from '../keywordMatcher';
+import { extractKeywords, scanResume, prepareLexicalResume, countKeywordOccurrencesLexical } from '../keywordMatcher';
 
 // ---------------------------------------------------------------------------
 // 1. extractKeywords — Basic Extraction
@@ -1039,6 +1039,35 @@ describe('scanResume', () => {
       const result = scanResume(resume, jd);
       const fintech = result.missing.find((m) => m.keyword === 'fintech');
       expect(fintech?.category).toBe('hard-skill');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 18. Lexical Pass — Stem-Adjacent Verbatim Phrases (regression coverage)
+  // ---------------------------------------------------------------------------
+  // Reproduces three browser-verified misses in the lexical pre-pass
+  // (prepareLexicalResume + countKeywordOccurrencesLexical), the pass the
+  // semantic worker runs before falling back to embedding cosine.
+  describe('lexical pass — stem-adjacent verbatim phrases', () => {
+    it('"monitor vital" matches resume "monitoring vital signs"', () => {
+      const resume = prepareLexicalResume(
+        'Daily responsibilities include administering medications, monitoring vital signs, IV insertion and maintenance.'
+      );
+      expect(countKeywordOccurrencesLexical('monitor vital', resume)).toBeGreaterThan(0);
+    });
+
+    it('"administer medications" matches resume "administering medications"', () => {
+      const resume = prepareLexicalResume(
+        'Daily responsibilities include administering medications, monitoring vital signs, IV insertion and maintenance.'
+      );
+      expect(countKeywordOccurrencesLexical('administer medications', resume)).toBeGreaterThan(0);
+    });
+
+    it('"restful apis" matches resume "RESTful APIs" (case-only difference, literal substring)', () => {
+      const resume = prepareLexicalResume(
+        'Designed and maintained RESTful APIs and microservices on AWS cloud infrastructure.'
+      );
+      expect(countKeywordOccurrencesLexical('restful apis', resume)).toBeGreaterThan(0);
     });
   });
 

--- a/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
+++ b/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
@@ -1069,6 +1069,23 @@ describe('scanResume', () => {
       );
       expect(countKeywordOccurrencesLexical('restful apis', resume)).toBeGreaterThan(0);
     });
+
+    it('gerund-named known skill "mentoring" matches resume "mentored"', () => {
+      // "mentoring" is in KNOWN_SKILLS, so the skip-set protects it from
+      // stemming AND the known-skill gate skips the stem fallback — while
+      // the resume's "mentored" stems to "mentor". Must still match.
+      const resume = prepareLexicalResume(
+        'Led code reviews and mentored junior engineers.'
+      );
+      expect(countKeywordOccurrencesLexical('mentoring', resume)).toBeGreaterThan(0);
+    });
+
+    it('known skill "docker" does NOT match unrelated dock words (no over-stemming)', () => {
+      const resume = prepareLexicalResume(
+        'Docked cargo ships at the loading dock daily.'
+      );
+      expect(countKeywordOccurrencesLexical('docker', resume)).toBe(0);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
+++ b/resume-builder-ui/src/utils/__tests__/keywordMatcher.test.ts
@@ -1086,6 +1086,27 @@ describe('scanResume', () => {
       );
       expect(countKeywordOccurrencesLexical('docker', resume)).toBe(0);
     });
+
+    it('unchanged single word "install" matches inflected resume "installing"', () => {
+      const resume = prepareLexicalResume(
+        'Responsible for installing and configuring network equipment.'
+      );
+      expect(countKeywordOccurrencesLexical('install', resume)).toBeGreaterThan(0);
+    });
+
+    it('single word "data" does NOT match unrelated longer word "database"', () => {
+      const resume = prepareLexicalResume(
+        'Administered the customer database and its schema.'
+      );
+      expect(countKeywordOccurrencesLexical('data', resume)).toBe(0);
+    });
+
+    it('multi-word stem match does NOT bleed across words ("data analysis" ≠ "database analysis")', () => {
+      const resume = prepareLexicalResume(
+        'Led the database analysis and reporting effort.'
+      );
+      expect(countKeywordOccurrencesLexical('data analysis', resume)).toBe(0);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/resume-builder-ui/src/utils/keywordData/index.ts
+++ b/resume-builder-ui/src/utils/keywordData/index.ts
@@ -1,4 +1,4 @@
-export { stem, stemPhrase, registerSkipTerms } from './stemmer';
+export { stem, stemPhrase, rawStem, registerSkipTerms } from './stemmer';
 export { SYNONYMS, MULTI_WORD_SYNONYM_KEYS, normalizeSynonym, applyMultiWordSynonyms, applyAllSynonyms } from './synonyms';
 export {
   type KeywordCategory,

--- a/resume-builder-ui/src/utils/keywordData/stemmer.ts
+++ b/resume-builder-ui/src/utils/keywordData/stemmer.ts
@@ -84,6 +84,18 @@ export function stem(word: string): string {
   // Never stem known skills / tech terms
   if (skipSet?.has(lower)) return lower;
 
+  return rawStem(lower);
+}
+
+/**
+ * Stem a word IGNORING the skip set. Needed when the skill name itself is
+ * an inflected English word ("mentoring", "consulting"): the skip set
+ * rightly protects it during text stemming, but matching it against resume
+ * text stemmed the normal way ("mentored" → "mentor") requires its true stem.
+ */
+export function rawStem(word: string): string {
+  const lower = word.toLowerCase();
+
   // Don't stem very short words
   if (lower.length <= 4) return lower;
 

--- a/resume-builder-ui/src/utils/keywordMatcher.ts
+++ b/resume-builder-ui/src/utils/keywordMatcher.ts
@@ -43,7 +43,9 @@ export interface ScanResult {
 }
 
 // Common English stop words to filter out
-const STOP_WORDS = new Set([
+// Exported so other matchers (e.g. the semantic worker) can reuse the same
+// vetted list instead of maintaining a second, smaller copy.
+export const STOP_WORDS = new Set([
   'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
   'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
   'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
@@ -60,7 +62,7 @@ const STOP_WORDS = new Set([
 
 // Generic job posting filler words
 // (4c) Removed 'development', 'tools', 'support' — meaningful when repeated in requirements
-const JOB_FILLER = new Set([
+export const JOB_FILLER = new Set([
   'experience', 'required', 'preferred', 'ability', 'skills', 'including',
   'work', 'working', 'position', 'role', 'company', 'team', 'opportunity',
   'responsibilities', 'requirements', 'qualifications', 'candidate',
@@ -126,7 +128,7 @@ const PLACEMENT_RULES: Array<{ pattern: RegExp; placement: string }> = [
   { pattern: /(agile|scrum|kanban|waterfall|lean|six\s+sigma|sdlc)/i, placement: 'Skills section — Methodologies' },
 ];
 
-function getSuggestedPlacement(keyword: string): string {
+export function getSuggestedPlacement(keyword: string): string {
   for (const rule of PLACEMENT_RULES) {
     if (rule.pattern.test(keyword)) {
       return rule.placement;
@@ -138,7 +140,7 @@ function getSuggestedPlacement(keyword: string): string {
 /**
  * Normalize text for comparison — lowercase, collapse whitespace
  */
-function normalize(text: string): string {
+export function normalize(text: string): string {
   return text.toLowerCase().replace(/['']/g, "'").replace(/\s+/g, ' ').trim();
 }
 
@@ -147,7 +149,7 @@ function normalize(text: string): string {
  * If a section header is found, return text from that header onward.
  * Otherwise return the full text (best effort).
  */
-function extractRequirementsSection(text: string): string {
+export function extractRequirementsSection(text: string): string {
   const match = REQUIREMENTS_HEADER.exec(text);
   let section = text;
   if (match && match.index !== undefined) {
@@ -354,18 +356,58 @@ function stemText(text: string): string {
   return text.replace(/[a-z]+/gi, (word) => stem(word));
 }
 
+/** Pre-processed resume text ready for lexical keyword lookup */
+export interface LexicalResume {
+  normalized: string;
+  stemmed: string;
+}
+
+/**
+ * Prepare resume text once for lexical keyword matching: normalize, apply
+ * synonym canonicalization, and pre-stem for fallback matching. Reused by
+ * both `scanResume` and the semantic-matcher worker's lexical pre-pass so
+ * verbatim/synonym/stem keyword matching stays in one place.
+ */
+export function prepareLexicalResume(resumeText: string): LexicalResume {
+  // (4a) Normalize resume through full synonym pipeline (multi-word + single-word)
+  let normalized = normalize(resumeText);
+  normalized = applyAllSynonyms(normalized);
+  // (4f) Pre-stem resume text once for fallback stem matching
+  const stemmed = stemText(normalized);
+  return { normalized, stemmed };
+}
+
+/**
+ * Count occurrences of a keyword phrase in a prepared resume using the
+ * exact → synonym-normalized → stem-fallback cascade. Returns 0 if not found.
+ */
+export function countKeywordOccurrencesLexical(keyword: string, resume: LexicalResume): number {
+  // Try exact match first
+  let count = countOccurrences(keyword, resume.normalized);
+
+  // Also try with the synonym-normalized form if different
+  if (count === 0) {
+    const normalizedKeyword = normalizeSynonym(keyword);
+    if (normalizedKeyword !== keyword) {
+      count = countOccurrences(normalizedKeyword, resume.normalized);
+    }
+  }
+
+  // (4f) Stem fallback: only if exact match found nothing AND keyword is NOT a known skill
+  // (known skills like "React", "Docker" should match exactly, not via stems)
+  if (count === 0 && !isKnownSkill(keyword)) {
+    count = countStemOccurrences(keyword, resume.stemmed);
+  }
+
+  return count;
+}
+
 /**
  * Scan resume text against extracted job description keywords
  */
 export function scanResume(resumeText: string, jobDescription: string): ScanResult {
   const keywords = extractKeywords(jobDescription);
-
-  // (4a) Normalize resume through full synonym pipeline (multi-word + single-word)
-  let normalizedResume = normalize(resumeText);
-  normalizedResume = applyAllSynonyms(normalizedResume);
-
-  // (4f) Pre-stem resume text once for fallback stem matching
-  const stemmedResume = stemText(normalizedResume);
+  const resumeLex = prepareLexicalResume(resumeText);
 
   const matched: KeywordResult[] = [];
   const missing: KeywordResult[] = [];
@@ -375,19 +417,7 @@ export function scanResume(resumeText: string, jobDescription: string): ScanResu
     const normalizedKeyword = normalizeSynonym(keyword);
     const category = getSkillCategory(keyword) || getSkillCategory(normalizedKeyword) || 'hard-skill';
 
-    // Try exact match first
-    let count = countOccurrences(keyword, normalizedResume);
-
-    // Also try with the synonym-normalized form if different
-    if (count === 0 && normalizedKeyword !== keyword) {
-      count = countOccurrences(normalizedKeyword, normalizedResume);
-    }
-
-    // (4f) Stem fallback: only if exact match found nothing AND keyword is NOT a known skill
-    // (known skills like "React", "Docker" should match exactly, not via stems)
-    if (count === 0 && !isKnownSkill(keyword)) {
-      count = countStemOccurrences(keyword, stemmedResume);
-    }
+    const count = countKeywordOccurrencesLexical(keyword, resumeLex);
 
     if (count > 0) {
       matched.push({ keyword, found: true, count, category });

--- a/resume-builder-ui/src/utils/keywordMatcher.ts
+++ b/resume-builder-ui/src/utils/keywordMatcher.ts
@@ -100,6 +100,7 @@ export const JOB_FILLER = new Set([
   'deadline', 'deadlines', 'workload', 'sector', 'public',
   'prioritise', 'prioritize', 'liaising', 'liaise',
   'ongoing', 'forthcoming', 'particular', 'using', 'used',
+  'hands-on', 'similar',
 ]);
 
 // Connector words — bigrams containing these are almost always noise

--- a/resume-builder-ui/src/utils/keywordMatcher.ts
+++ b/resume-builder-ui/src/utils/keywordMatcher.ts
@@ -339,11 +339,32 @@ function countOccurrences(keyword: string, text: string): number {
  */
 function countStemOccurrences(keyword: string, stemmedText: string): number {
   const stemmedKeyword = stemPhrase(keyword);
-  if (stemmedKeyword === keyword) return 0; // No stemming change, skip
-  const escaped = stemmedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = stemmedKeyword.includes(' ')
-    ? new RegExp(escaped, 'gi')
-    : new RegExp(`(?<=^|\\W)${escaped}(?=\\W|$)`, 'gi');
+
+  if (!stemmedKeyword.includes(' ')) {
+    // Single word: keep the original exact-boundary behavior. Bailing out
+    // when stemming didn't change the keyword is safe here — a single short
+    // word (e.g. "data") must NOT loosely match an unrelated longer word
+    // (e.g. "database") that happens to start with the same letters.
+    if (stemmedKeyword === keyword) return 0; // No stemming change, skip
+    const escaped = stemmedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`(?<=^|\\W)${escaped}(?=\\W|$)`, 'gi');
+    const matches = stemmedText.match(pattern);
+    return matches ? matches.length : 0;
+  }
+
+  // Multi-word: always search, even when the keyword phrase's own stem
+  // equals itself — the point of this fallback is to catch RESUME words
+  // that need stemming (e.g. "monitoring" -> "monitor"), which still
+  // applies when the keyword is already in base form.
+  //
+  // Match each stemmed word with a trailing \w*: the suffix-stripping
+  // stemmer is single-pass, so a keyword already in dictionary form (e.g.
+  // "administer") can over-stem relative to an inflected resume word
+  // stemmed in one pass (e.g. "administering" -> "administer"). Treating
+  // each stemmed word as a prefix (not a whole-word match) absorbs that
+  // asymmetry without changing stem() itself.
+  const words = stemmedKeyword.split(' ').map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const pattern = new RegExp(`(?<=^|\\W)${words.join('\\w*\\s+')}\\w*(?=\\W|$)`, 'gi');
   const matches = stemmedText.match(pattern);
   return matches ? matches.length : 0;
 }
@@ -385,9 +406,16 @@ export function countKeywordOccurrencesLexical(keyword: string, resume: LexicalR
   // Try exact match first
   let count = countOccurrences(keyword, resume.normalized);
 
-  // Also try with the synonym-normalized form if different
+  // Also try with the synonym-normalized form if different. Use the same
+  // applyAllSynonyms() pipeline the resume text was built with (not the
+  // single-key normalizeSynonym lookup) — a multi-word keyword like
+  // "restful apis" isn't itself a registered synonym key, but its first
+  // WORD is ("restful" -> "rest apis"), and resume.normalized already went
+  // through that same per-word expansion. Re-deriving the keyword the same
+  // way keeps both sides symmetric instead of comparing a raw keyword
+  // against a synonym-rewritten resume.
   if (count === 0) {
-    const normalizedKeyword = normalizeSynonym(keyword);
+    const normalizedKeyword = applyAllSynonyms(keyword);
     if (normalizedKeyword !== keyword) {
       count = countOccurrences(normalizedKeyword, resume.normalized);
     }

--- a/resume-builder-ui/src/utils/keywordMatcher.ts
+++ b/resume-builder-ui/src/utils/keywordMatcher.ts
@@ -12,6 +12,7 @@ import {
   registerSkipTerms,
   stem,
   stemPhrase,
+  rawStem,
   normalizeSynonym,
   applyMultiWordSynonyms,
   applyAllSynonyms,
@@ -425,6 +426,20 @@ export function countKeywordOccurrencesLexical(keyword: string, resume: LexicalR
   // (known skills like "React", "Docker" should match exactly, not via stems)
   if (count === 0 && !isKnownSkill(keyword)) {
     count = countStemOccurrences(keyword, resume.stemmed);
+  }
+
+  // Gerund-named known skills ("mentoring", "consulting") are protected by
+  // the stemmer's skip set AND excluded by the known-skill gate above, so
+  // an inflected resume form ("mentored" → stemmed "mentor") never matches.
+  // For those, search the stemmed resume for the skill's raw (skip-bypassing)
+  // stem with an exact word boundary.
+  // ponytail: -ing single words only; "docker"→"dock" would over-match dock
+  // words, and multi-word skill phrases haven't shown this miss in practice.
+  if (count === 0 && isKnownSkill(keyword) && !keyword.includes(' ') && keyword.endsWith('ing')) {
+    const raw = rawStem(keyword);
+    if (raw !== keyword.toLowerCase()) {
+      count = countOccurrences(raw, resume.stemmed);
+    }
   }
 
   return count;

--- a/resume-builder-ui/src/utils/keywordMatcher.ts
+++ b/resume-builder-ui/src/utils/keywordMatcher.ts
@@ -343,11 +343,12 @@ function countStemOccurrences(keyword: string, stemmedText: string): number {
   const stemmedKeyword = stemPhrase(keyword);
 
   if (!stemmedKeyword.includes(' ')) {
-    // Single word: keep the original exact-boundary behavior. Bailing out
-    // when stemming didn't change the keyword is safe here — a single short
-    // word (e.g. "data") must NOT loosely match an unrelated longer word
-    // (e.g. "database") that happens to start with the same letters.
-    if (stemmedKeyword === keyword) return 0; // No stemming change, skip
+    // Single word, exact word-boundary match against the pre-stemmed resume.
+    // Search even when the keyword's own stem is unchanged (e.g. "install",
+    // "monitor", "test"): the resume side is stemmed too, so an inflected
+    // resume form ("installing" -> "install") must still match. The word
+    // boundaries below prevent a short word (e.g. "data") from matching an
+    // unrelated longer one (e.g. "database").
     const escaped = stemmedKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`(?<=^|\\W)${escaped}(?=\\W|$)`, 'gi');
     const matches = stemmedText.match(pattern);
@@ -359,14 +360,15 @@ function countStemOccurrences(keyword: string, stemmedText: string): number {
   // that need stemming (e.g. "monitoring" -> "monitor"), which still
   // applies when the keyword is already in base form.
   //
-  // Match each stemmed word with a trailing \w*: the suffix-stripping
-  // stemmer is single-pass, so a keyword already in dictionary form (e.g.
-  // "administer") can over-stem relative to an inflected resume word
-  // stemmed in one pass (e.g. "administering" -> "administer"). Treating
-  // each stemmed word as a prefix (not a whole-word match) absorbs that
-  // asymmetry without changing stem() itself.
+  // Match each stemmed word with a bounded trailing \w{0,3}: the
+  // suffix-stripping stemmer is single-pass, so a keyword already in
+  // dictionary form (e.g. "administer") can over-stem relative to an
+  // inflected resume word stemmed in one pass (e.g. "administering" ->
+  // "administer"). Allowing up to 3 trailing chars absorbs that suffix
+  // asymmetry (er/ing/ed/s/es) without letting an unbounded \w* match a
+  // wholly different longer word (e.g. "data" -> "database").
   const words = stemmedKeyword.split(' ').map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const pattern = new RegExp(`(?<=^|\\W)${words.join('\\w*\\s+')}\\w*(?=\\W|$)`, 'gi');
+  const pattern = new RegExp(`(?<=^|\\W)${words.join('\\w{0,3}\\s+')}\\w{0,3}(?=\\W|$)`, 'gi');
   const matches = stemmedText.match(pattern);
   return matches ? matches.length : 0;
 }

--- a/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
+++ b/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
@@ -213,7 +213,10 @@ describe('semanticMatcher.worker', () => {
     for (const kw of result.matched) {
       expect(kw.found).toBe(true);
       expect(['exact', 'semantic']).toContain(kw.matchType);
-      expect(kw.similarity).toBeGreaterThanOrEqual(0.65);
+      // Recalibrated (Phase 1): matched threshold is 0.55, not the old 0.65 —
+      // and lexical hits (all three keywords here appear verbatim in the
+      // resume) are floored at the threshold regardless of raw cosine.
+      expect(kw.similarity).toBeGreaterThanOrEqual(0.55);
     }
   });
 
@@ -365,7 +368,10 @@ describe('semanticMatcher.worker', () => {
     const result = (results[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
 
     if (result.totalKeywords > 0) {
-      const expectedPct = Math.round((result.matchedCount / result.totalKeywords) * 100);
+      // Phase 1: partial matches count for half credit, not zero.
+      const expectedPct = Math.round(
+        ((result.matchedCount + 0.5 * result.partialCount) / result.totalKeywords) * 100
+      );
       expect(result.matchPercentage).toBe(expectedPct);
     }
   });
@@ -413,5 +419,92 @@ describe('semanticMatcher.worker', () => {
     expect(mockPipeline).toHaveBeenCalled();
     // Should have both progress/ready AND result messages
     expect(getMessages('match:result')).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------
+  // Phase 1 fix acceptance tests
+  //
+  // These use fully-controlled embeddings instead of the hash-based
+  // fakeEmbedding() above: any text NOT explicitly mapped collapses to the
+  // same vector as the GENERIC_PHRASES, so it gets pruned by
+  // filterGenericTerms() and never reaches the final keyword list. This
+  // keeps each test deterministic and focused on exactly one candidate,
+  // without needing to hand-enumerate every n-gram the extractor produces.
+  // ---------------------------------------------------------------------
+  describe('Phase 1 fixes', () => {
+    const GENERIC = [0, 1, 0, 0];
+
+    function mockControlledEmbeddings(embedMap: Record<string, number[]>) {
+      const mockExtractor = vi.fn(async (texts: string[]) => ({
+        tolist: () => texts.map((t) => embedMap[t.toLowerCase().trim()] ?? GENERIC),
+      }));
+      mockPipeline.mockResolvedValue(mockExtractor);
+    }
+
+    async function freshWorker() {
+      vi.resetModules();
+      await import('../semanticMatcher.worker');
+      workerHandler = (self as unknown as { onmessage: typeof workerHandler }).onmessage;
+      postedMessages.length = 0;
+    }
+
+    it('(a) force-promotes a verbatim keyword to matched even with worst-case (negative) cosine similarity', async () => {
+      mockControlledEmbeddings({
+        'monitor vital signs': [1, 0, 0, 0],
+        'experienced icu nurse who will monitor vital signs for every patient.': [-1, 0, 0, 0],
+      });
+      await freshWorker();
+
+      const jd = 'Qualifications: monitor vital signs for every patient.';
+      const resume = 'Experienced ICU nurse who will monitor vital signs for every patient.';
+
+      await sendMessage({ type: 'match', resumeText: resume, jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      // Every other candidate n-gram collapses to the GENERIC vector and is
+      // filtered out, so only the verbatim phrase should remain.
+      expect(result.totalKeywords).toBe(1);
+      const kw = result.matched.find((k) => k.keyword === 'monitor vital signs');
+      expect(kw).toBeDefined();
+      expect(kw!.found).toBe(true);
+      expect(kw!.matchType).toBe('exact');
+    });
+
+    it('(b) matches a JD keyword via stem fallback ("management" JD keyword vs "managed" in resume)', async () => {
+      mockControlledEmbeddings({
+        management: [1, 0, 0, 0],
+      });
+      await freshWorker();
+
+      const jd = 'Requirements: team management is essential.';
+      const resume = 'Successfully managed cross-functional engineering teams across three product lines.';
+
+      await sendMessage({ type: 'match', resumeText: resume, jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      const kw = result.matched.find((k) => k.keyword === 'management');
+      expect(kw).toBeDefined();
+      expect(kw!.matchType).toBe('exact');
+    });
+
+    it('(d) score formula gives partial-bucket keywords exactly half credit', async () => {
+      mockControlledEmbeddings({
+        quantum: [1, 0],
+        'this is unrelated content only.': [0.5, Math.sqrt(0.75)], // cosine(quantum, chunk) = 0.5 → 'partial'
+      });
+      await freshWorker();
+
+      const jd = 'Requirements: strong knowledge of quantum required for this position.';
+      const resume = 'This is unrelated content only.';
+
+      await sendMessage({ type: 'match', resumeText: resume, jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      expect(result.totalKeywords).toBe(1);
+      expect(result.matchedCount).toBe(0);
+      expect(result.partialCount).toBe(1);
+      // (0 matched + 0.5 * 1 partial) / 1 total = 50%
+      expect(result.matchPercentage).toBe(50);
+    });
   });
 });

--- a/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
+++ b/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
@@ -575,5 +575,18 @@ describe('semanticMatcher.worker', () => {
       expect(allKeywords).not.toContain('hands-on with aws');
       expect(allKeywords).not.toContain('jest or similar');
     });
+
+    it('(g) JD boilerplate unigrams "hands-on" and "similar" are not keywords', async () => {
+      const jd = 'Must be hands-on with AWS. Hands-on attitude required. ' +
+        'Jest or similar testing framework. Cypress or similar tools. ' +
+        'Similar hands-on roles considered.';
+
+      await sendMessage({ type: 'match', resumeText: 'Nurse with general clinical experience.', jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      const allKeywords = [...result.matched, ...result.partial, ...result.missing].map((k) => k.keyword);
+      expect(allKeywords).not.toContain('hands-on');
+      expect(allKeywords).not.toContain('similar');
+    });
   });
 });

--- a/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
+++ b/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
@@ -557,5 +557,23 @@ describe('semanticMatcher.worker', () => {
       expect(keywordLabels).not.toContain('aws cloud');
       expect(keywordLabels).not.toContain('cloud infrastructure');
     });
+
+    it('(f) trigram extraction rejects glue-word middle terms ("X or Y", "X with Y")', async () => {
+      // The trigram loop only checked the FIRST and LAST word against
+      // STOP_WORDS/JOB_FILLER, never the middle word — so any trigram whose
+      // middle word is a bare connector ("or", "with") survived as junk even
+      // though the bigram loop already rejects connectors in either position.
+      const jd = 'Requirements: experience with Jenkins or GitHub for CI/CD. ' +
+        'Must be hands-on with AWS cloud infrastructure. ' +
+        'Jest or similar testing framework experience required.';
+
+      await sendMessage({ type: 'match', resumeText: 'Nurse with general clinical experience.', jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      const allKeywords = [...result.matched, ...result.partial, ...result.missing].map((k) => k.keyword);
+      expect(allKeywords).not.toContain('jenkins or github');
+      expect(allKeywords).not.toContain('hands-on with aws');
+      expect(allKeywords).not.toContain('jest or similar');
+    });
   });
 });

--- a/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
+++ b/resume-builder-ui/src/workers/__tests__/semanticMatcher.worker.test.ts
@@ -507,4 +507,55 @@ describe('semanticMatcher.worker', () => {
       expect(result.matchPercentage).toBe(50);
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Phase 2 fix acceptance tests (extraction quality)
+  // ---------------------------------------------------------------------
+  describe('Phase 2 fixes', () => {
+    it('(c) comma is a clause boundary — no cross-clause bigram in candidate extraction', async () => {
+      // Without the Phase 2 fix, "administer medications, monitor vital signs"
+      // would yield the nonsensical cross-clause bigram "medications monitor".
+      const jd = 'Requirements: administer medications, monitor vital signs regularly. ' +
+        'Chart medications, monitor changes daily.';
+
+      await sendMessage({ type: 'match', resumeText: 'Nurse with general clinical experience.', jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      const allKeywords = [...result.matched, ...result.partial, ...result.missing].map((k) => k.keyword);
+      expect(allKeywords).not.toContain('medications monitor');
+    });
+
+    it('(e) dedupes overlapping n-grams lexically when embedding clustering (0.85) misses them', async () => {
+      vi.resetModules();
+      const embedMap: Record<string, number[]> = {
+        'aws cloud infrastructure': [1, 0, 0, 0],
+        'aws cloud': [0, 0, 1, 0],
+        'cloud infrastructure': [0, 0, 0, 1],
+      };
+      const GENERIC = [0, 1, 0, 0];
+      const mockExtractor = vi.fn(async (texts: string[]) => ({
+        tolist: () => texts.map((t) => embedMap[t.toLowerCase().trim()] ?? GENERIC),
+      }));
+      mockPipeline.mockResolvedValue(mockExtractor);
+
+      await import('../semanticMatcher.worker');
+      workerHandler = (self as unknown as { onmessage: typeof workerHandler }).onmessage;
+      postedMessages.length = 0;
+
+      const jd = 'Requirements: aws cloud infrastructure is critical. ' +
+        'Strong aws cloud infrastructure experience needed. ' +
+        'Manage aws cloud infrastructure daily operations.';
+
+      await sendMessage({ type: 'match', resumeText: 'Unrelated resume content.', jobDescription: jd });
+      const result = (getMessages('match:result')[0] as { type: 'match:result'; result: EnhancedScanResult }).result;
+
+      const keywordLabels = [...result.matched, ...result.partial, ...result.missing].map((k) => k.keyword);
+      // The three orthogonal embeddings above are deliberately < 0.85 cosine
+      // apart, so only the lexical substring dedup (not embedding clustering)
+      // can collapse them — only the longest surviving phrase should remain.
+      expect(keywordLabels).toContain('aws cloud infrastructure');
+      expect(keywordLabels).not.toContain('aws cloud');
+      expect(keywordLabels).not.toContain('cloud infrastructure');
+    });
+  });
 });

--- a/resume-builder-ui/src/workers/semanticMatcher.worker.ts
+++ b/resume-builder-ui/src/workers/semanticMatcher.worker.ts
@@ -12,9 +12,24 @@ import type {
   EnhancedKeywordResult,
   EnhancedScanResult,
 } from '../types/semanticMatcher';
+import {
+  getSuggestedPlacement,
+  prepareLexicalResume,
+  countKeywordOccurrencesLexical,
+} from '../utils/keywordMatcher';
 
 // Use remote models from HuggingFace Hub, allow local caching via Cache API
 env.allowLocalModels = false;
+
+// Recalibrated thresholds (Phase 1 fix): the embedding pass alone is only the
+// tie-breaker for keywords the lexical pass (below) can't already confirm —
+// see runMatch(). 0.65 was calibrated too high; real semantic matches cluster
+// at 0.65-0.77, so genuine hits were routinely scored as "partial" (worth 0).
+const MATCHED_THRESHOLD = 0.55;
+const PARTIAL_THRESHOLD = 0.45;
+// Cosine value above which a matched keyword is labeled 'exact' vs 'semantic'
+// (embedding path only — lexical hits are always 'exact', see runMatch()).
+const EXACT_COSINE_THRESHOLD = 0.85;
 
 let extractor: FeatureExtractionPipeline | null = null;
 let modelLoadPromise: Promise<void> | null = null;
@@ -246,27 +261,8 @@ function chunkResume(text: string): string[] {
   return chunks;
 }
 
-// --- Placement suggestion (copied from keywordMatcher.ts) ---
-
-const PLACEMENT_RULES: Array<{ pattern: RegExp; placement: string }> = [
-  { pattern: /\b(python|java|javascript|typescript|c\+\+|ruby|go|rust|php|swift|kotlin|scala|r|matlab|sql|html|css|sass|less)\b/i, placement: 'Skills section — Technical Skills' },
-  { pattern: /\b(react|angular|vue|node|express|django|flask|spring|rails|next\.?js|nuxt|svelte|laravel|asp\.net)\b/i, placement: 'Skills section — Frameworks' },
-  { pattern: /\b(aws|azure|gcp|docker|kubernetes|terraform|jenkins|ci\/cd|git|linux|nginx|apache)\b/i, placement: 'Skills section — Tools & Infrastructure' },
-  { pattern: /\b(excel|powerpoint|word|salesforce|hubspot|jira|confluence|slack|figma|sketch|photoshop|tableau|power\s?bi)\b/i, placement: 'Skills section — Software' },
-  { pattern: /(certified|certification|license|cpa|pmp|scrum|cissp|aws\s+certified)/i, placement: 'Certifications section' },
-  { pattern: /(agile|scrum|kanban|waterfall|lean|six\s+sigma|sdlc)/i, placement: 'Skills section — Methodologies' },
-];
-
-function getSuggestedPlacement(keyword: string): string {
-  for (const rule of PLACEMENT_RULES) {
-    if (rule.pattern.test(keyword)) {
-      return rule.placement;
-    }
-  }
-  return 'Skills section or Experience bullet points';
-}
-
 // --- Main matching pipeline ---
+// (getSuggestedPlacement is imported from keywordMatcher.ts — no more duplicate copy)
 
 async function runMatch(resumeText: string, jobDescription: string): Promise<EnhancedScanResult> {
   // 1. Extract candidate phrases from JD
@@ -330,7 +326,16 @@ async function runMatch(resumeText: string, jobDescription: string): Promise<Enh
   const chunks = chunkResume(resumeText);
   const chunkEmbeddings = await embed(chunks);
 
-  // 6. For each keyword, find max similarity across chunks
+  // Phase 1: prepare resume once for the lexical exact/synonym/stem pass —
+  // reuses the same cascade keywordMatcher.ts's scanResume() already uses.
+  const lexicalResume = prepareLexicalResume(resumeText);
+
+  // 6. For each keyword: lexical pass FIRST. A keyword present in the resume
+  // (verbatim, synonym-normalized, or stemmed) is force-promoted to "matched"
+  // regardless of embedding cosine — a short JD phrase vs. a long resume
+  // sentence dilutes cosine even for a literal match (the root cause of the
+  // "verbatim skill shown as missing" bug). Only keywords the lexical pass
+  // can't confirm fall through to the embedding-cosine classification.
   const matched: EnhancedKeywordResult[] = [];
   const partial: EnhancedKeywordResult[] = [];
   const missing: EnhancedKeywordResult[] = [];
@@ -347,19 +352,40 @@ async function runMatch(resumeText: string, jobDescription: string): Promise<Enh
       }
     }
 
+    // Prefer a chunk that literally contains the phrase for display context;
+    // fall back to the highest-cosine chunk.
+    const literalChunkIdx = chunks.findIndex(c => c.toLowerCase().includes(kw.label.toLowerCase()));
+    const bestMatchContext = chunks[literalChunkIdx >= 0 ? literalChunkIdx : bestChunkIdx]?.slice(0, 150);
+
+    const lexicalCount = countKeywordOccurrencesLexical(kw.label, lexicalResume);
+    if (lexicalCount > 0) {
+      // ponytail: floor the displayed similarity at the matched threshold so a
+      // diluted cosine never shows a confusing low % next to a "matched" badge.
+      // Upgrade path: surface lexical vs. semantic confidence as separate fields
+      // if the UI ever needs to distinguish them.
+      matched.push({
+        keyword: kw.label,
+        found: true,
+        similarity: Math.round(Math.max(maxSim, MATCHED_THRESHOLD) * 100) / 100,
+        matchType: 'exact',
+        bestMatchContext,
+      });
+      continue;
+    }
+
     const result: EnhancedKeywordResult = {
       keyword: kw.label,
-      found: maxSim >= 0.65,
+      found: maxSim >= MATCHED_THRESHOLD,
       similarity: Math.round(maxSim * 100) / 100,
-      matchType: maxSim >= 0.65
-        ? (maxSim >= 0.85 ? 'exact' : 'semantic')
-        : (maxSim >= 0.45 ? 'partial' : 'none'),
-      bestMatchContext: chunks[bestChunkIdx]?.slice(0, 150),
+      matchType: maxSim >= MATCHED_THRESHOLD
+        ? (maxSim >= EXACT_COSINE_THRESHOLD ? 'exact' : 'semantic')
+        : (maxSim >= PARTIAL_THRESHOLD ? 'partial' : 'none'),
+      bestMatchContext,
     };
 
-    if (maxSim >= 0.65) {
+    if (maxSim >= MATCHED_THRESHOLD) {
       matched.push(result);
-    } else if (maxSim >= 0.45) {
+    } else if (maxSim >= PARTIAL_THRESHOLD) {
       partial.push(result);
     } else {
       result.suggestedPlacement = getSuggestedPlacement(kw.label);
@@ -372,8 +398,13 @@ async function runMatch(resumeText: string, jobDescription: string): Promise<Enh
   partial.sort((a, b) => b.similarity - a.similarity);
   missing.sort((a, b) => b.similarity - a.similarity);
 
+  // Phase 1: partial matches count for half credit — a resume that's 80%
+  // covered by verbatim/semantic matches plus a few partials should not be
+  // scored the same as one with only 20% direct matches.
   const total = keywords.length;
-  const matchPercentage = total > 0 ? Math.round((matched.length / total) * 100) : 0;
+  const matchPercentage = total > 0
+    ? Math.round(((matched.length + 0.5 * partial.length) / total) * 100)
+    : 0;
 
   return {
     matchPercentage,

--- a/resume-builder-ui/src/workers/semanticMatcher.worker.ts
+++ b/resume-builder-ui/src/workers/semanticMatcher.worker.ts
@@ -13,6 +13,9 @@ import type {
   EnhancedScanResult,
 } from '../types/semanticMatcher';
 import {
+  STOP_WORDS,
+  JOB_FILLER,
+  extractRequirementsSection,
   getSuggestedPlacement,
   prepareLexicalResume,
   countKeywordOccurrencesLexical,
@@ -90,7 +93,10 @@ async function embed(texts: string[]): Promise<number[][]> {
 
 /** Extract candidate keyword phrases from job description text */
 function extractCandidates(text: string): Map<string, number> {
-  const lower = text.toLowerCase();
+  // Phase 2: focus on the requirements/qualifications section when the JD has
+  // one — skips company-blurb and benefits noise (reuses keywordMatcher.ts).
+  const focused = extractRequirementsSection(text);
+  const lower = focused.toLowerCase();
   const candidates = new Map<string, number>();
 
   // 1) Special tech terms (C++, C#, .NET, etc.) — extract before normalizing
@@ -107,33 +113,13 @@ function extractCandidates(text: string): Map<string, number> {
     candidates.set(term, (candidates.get(term) || 0) + 1);
   }
 
-  // 3) Split into sentences, then extract n-grams
-  const sentences = lower.split(/[.!?;:\n]+/).filter(s => s.trim().length > 5);
-  const stopWords = new Set([
-    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-    'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
-    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
-    'could', 'should', 'may', 'might', 'shall', 'can', 'need', 'must',
-    'that', 'which', 'who', 'whom', 'this', 'these', 'those', 'it', 'its',
-    'we', 'our', 'you', 'your', 'they', 'their', 'he', 'she', 'him', 'her',
-    'not', 'no', 'nor', 'as', 'if', 'then', 'than', 'too', 'very', 'just',
-    'about', 'all', 'also', 'am', 'any', 'because', 'both', 'each',
-    'more', 'most', 'other', 'so', 'some', 'such', 'up', 'what', 'when',
-    'where', 'while', 'how', 'out', 'into', 'my', 'me', 'i',
-  ]);
-
-  const fillerWords = new Set([
-    'experience', 'required', 'preferred', 'ability', 'skills', 'including',
-    'work', 'working', 'position', 'role', 'company', 'team', 'opportunity',
-    'responsibilities', 'requirements', 'qualifications', 'candidate',
-    'apply', 'job', 'description', 'employment', 'equal', 'employer',
-    'benefits', 'salary', 'competitive', 'minimum', 'years', 'degree',
-    'bachelor', 'master', 'education', 'looking', 'seeking', 'ideal',
-    'someone', 'strong', 'excellent', 'good', 'great', 'solid',
-    'knowledge', 'understanding', 'familiarity', 'plus', 'bonus',
-    'demonstrated', 'proven', 'ensuring', 'responsible', 'proficient',
-    'relevant', 'related',
-  ]);
+  // 3) Split into sentences, then extract n-grams.
+  // Phase 2: comma/parens now count as clause boundaries too, so
+  // "administer medications, monitor vital signs" no longer yields the
+  // cross-clause bigram "medications monitor".
+  const sentences = lower.split(/[.!?;:,()\n]+/).filter(s => s.trim().length > 5);
+  // Phase 2: reuse keywordMatcher's larger, battle-tested stop/filler lists
+  // instead of maintaining a second, smaller copy here.
 
   for (const sentence of sentences) {
     const words = sentence
@@ -144,7 +130,7 @@ function extractCandidates(text: string): Map<string, number> {
     // Unigrams
     for (const word of words) {
       const clean = word.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
-      if (clean.length <= 2 || stopWords.has(clean) || fillerWords.has(clean)) continue;
+      if (clean.length <= 2 || STOP_WORDS.has(clean) || JOB_FILLER.has(clean)) continue;
       candidates.set(clean, (candidates.get(clean) || 0) + 1);
     }
 
@@ -153,8 +139,8 @@ function extractCandidates(text: string): Map<string, number> {
       const a = words[i].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
       const b = words[i + 1].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
       if (a.length < 2 || b.length < 2) continue;
-      if (stopWords.has(a) || stopWords.has(b)) continue;
-      if (fillerWords.has(a) || fillerWords.has(b)) continue;
+      if (STOP_WORDS.has(a) || STOP_WORDS.has(b)) continue;
+      if (JOB_FILLER.has(a) || JOB_FILLER.has(b)) continue;
       const bigram = `${a} ${b}`;
       candidates.set(bigram, (candidates.get(bigram) || 0) + 1);
     }
@@ -165,8 +151,8 @@ function extractCandidates(text: string): Map<string, number> {
       const b = words[i + 1].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
       const c = words[i + 2].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
       if (a.length < 2 || b.length < 2 || c.length < 2) continue;
-      if (stopWords.has(a) || stopWords.has(c)) continue;
-      if (fillerWords.has(a) || fillerWords.has(c)) continue;
+      if (STOP_WORDS.has(a) || STOP_WORDS.has(c)) continue;
+      if (JOB_FILLER.has(a) || JOB_FILLER.has(c)) continue;
       const trigram = `${a} ${b} ${c}`;
       candidates.set(trigram, (candidates.get(trigram) || 0) + 1);
     }
@@ -261,6 +247,38 @@ function chunkResume(text: string): string[] {
   return chunks;
 }
 
+// --- Lexical n-gram dedup (Phase 2) ---
+
+/**
+ * Drop shorter multi-word candidates that are a substring of a longer
+ * surviving candidate (e.g. "aws cloud" and "cloud infrastructure" both
+ * swallowed by "aws cloud infrastructure"). The 0.85 embedding cluster
+ * (clusterEmbeddings above) misses these because adding/removing a word
+ * can shift cosine similarity below the cluster threshold even though the
+ * phrases describe the same concept. Single words are left untouched here
+ * — they're already handled by the subsumption step above.
+ */
+function dedupSubstringOverlaps<T extends { label: string }>(items: T[]): T[] {
+  const multiWord = [...items]
+    .filter(i => i.label.includes(' '))
+    .sort((a, b) => b.label.length - a.label.length); // longest first
+
+  const dropped = new Set<string>();
+  for (let i = 0; i < multiWord.length; i++) {
+    const shorter = multiWord[i];
+    if (dropped.has(shorter.label)) continue;
+    for (let j = 0; j < i; j++) {
+      const longer = multiWord[j];
+      if (!dropped.has(longer.label) && longer.label.includes(shorter.label)) {
+        dropped.add(shorter.label);
+        break;
+      }
+    }
+  }
+
+  return items.filter(i => !dropped.has(i.label));
+}
+
 // --- Main matching pipeline ---
 // (getSuggestedPlacement is imported from keywordMatcher.ts — no more duplicate copy)
 
@@ -315,6 +333,10 @@ async function runMatch(resumeText: string, jobDescription: string): Promise<Enh
     if (k.label.includes(' ')) return true;
     return !multiWord.some(mw => mw.freq >= k.freq && mw.label.includes(k.label));
   });
+
+  // Phase 2: lexical substring dedup for overlapping multi-word n-grams
+  // that the 0.85 embedding cluster didn't catch (see dedupSubstringOverlaps).
+  keywords = dedupSubstringOverlaps(keywords);
 
   keywords = keywords.slice(0, 40);
 

--- a/resume-builder-ui/src/workers/semanticMatcher.worker.ts
+++ b/resume-builder-ui/src/workers/semanticMatcher.worker.ts
@@ -149,7 +149,11 @@ function extractCandidates(text: string): Map<string, number> {
       candidates.set(bigram, (candidates.get(bigram) || 0) + 1);
     }
 
-    // Trigrams — first and last words must not be stop/filler
+    // Trigrams — first and last words must not be stop/filler. The middle
+    // word must not be a bare connector (STOP_WORDS) either — the bigram
+    // loop above already rejects "with"/"or"/"and" etc. in either position,
+    // but this loop only checked the ends, letting glue-word junk like
+    // "jenkins or github" and "hands-on with aws" survive as a trigram.
     for (let i = 0; i < words.length - 2; i++) {
       const a = words[i].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
       const b = words[i + 1].replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
@@ -157,6 +161,7 @@ function extractCandidates(text: string): Map<string, number> {
       if (a.length < 2 || b.length < 2 || c.length < 2) continue;
       if (STOP_WORDS.has(a) || STOP_WORDS.has(c)) continue;
       if (JOB_FILLER.has(a) || JOB_FILLER.has(c)) continue;
+      if (STOP_WORDS.has(b)) continue;
       const trigram = `${a} ${b} ${c}`;
       candidates.set(trigram, (candidates.get(trigram) || 0) + 1);
     }

--- a/resume-builder-ui/src/workers/semanticMatcher.worker.ts
+++ b/resume-builder-ui/src/workers/semanticMatcher.worker.ts
@@ -62,14 +62,18 @@ async function ensureModel(): Promise<void> {
   }
 
   modelLoadPromise = (async () => {
-    post({ type: 'init:progress', progress: 0, status: 'Downloading AI model...' });
+    // Phase 3: explicit "one-time, ~23 MB" copy so a slow first load reads as
+    // expected progress, not a hang (subsequent visits hit the Cache API and
+    // this state is skipped almost instantly).
+    const DOWNLOAD_STATUS = 'Downloading AI model (one-time, ~23 MB)…';
+    post({ type: 'init:progress', progress: 0, status: DOWNLOAD_STATUS });
 
     // @ts-expect-error — pipeline() overload union too complex for TS
     extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {
       dtype: 'q8',
       progress_callback: (data: { status: string; progress?: number }) => {
         if (data.status === 'progress' && data.progress != null) {
-          post({ type: 'init:progress', progress: Math.round(data.progress), status: 'Downloading AI model...' });
+          post({ type: 'init:progress', progress: Math.round(data.progress), status: DOWNLOAD_STATUS });
         }
       },
     }) as FeatureExtractionPipeline;

--- a/resume-builder-ui/src/workers/semanticMatcher.worker.ts
+++ b/resume-builder-ui/src/workers/semanticMatcher.worker.ts
@@ -276,9 +276,21 @@ function dedupSubstringOverlaps<T extends { label: string }>(items: T[]): T[] {
   for (let i = 0; i < multiWord.length; i++) {
     const shorter = multiWord[i];
     if (dropped.has(shorter.label)) continue;
+    const shorterWords = shorter.label.split(' ');
     for (let j = 0; j < i; j++) {
       const longer = multiWord[j];
-      if (!dropped.has(longer.label) && longer.label.includes(shorter.label)) {
+      if (dropped.has(longer.label)) continue;
+      // Contiguous WORD-level subphrase, not raw substring: "platform
+      // engineering" must not swallow the unrelated "form engineering".
+      const longerWords = longer.label.split(' ');
+      let isSubphrase = false;
+      for (let k = 0; k <= longerWords.length - shorterWords.length; k++) {
+        if (shorterWords.every((w, idx) => longerWords[k + idx] === w)) {
+          isSubphrase = true;
+          break;
+        }
+      }
+      if (isSubphrase) {
         dropped.add(shorter.label);
         break;
       }


### PR DESCRIPTION
## Summary

The `/resume-keyword-scanner` tool looked polished but produced **wrong, misleading output**: a resume listing skills verbatim was told they were "missing", paraphrases scored 0%, and every real-world resume rendered "Low Match — Significant Gaps Found". This PR fixes the matching algorithm so the output is correct and actionable, without touching the page's SEO layer (title/schema/FAQ/copy) or the privacy model (all matching stays 100% in-browser).

**Do not merge without owner sign-off.** Intended to fold into the big-release integration branch for DEV testing.

## Root causes (verified in code, not hypothesized)

1. **No lexical/exact-match fallback.** Scoring was purely `cosineSim(keyword, chunk)`. A keyword appearing verbatim in a long resume sentence got a diluted cosine and fell below the "matched" bar → shown as *missing*.
2. **Thresholds too high + partials scored zero.** `matched ≥ 0.65` with headline score = `matched/total`; real matches cluster at 0.65–0.77, so genuine hits landed in "partial" and contributed nothing.
3. **Noisy extraction.** Comma was not a clause boundary (cross-clause bigrams like "medications monitor"); glue-word fragments ("jenkins or github") and boilerplate ("hands-on", "similar") survived as keywords.
4. **No first-load progress** during the ~23 MB model download.

## Changes (per commit)

| Commit | Change |
|--------|--------|
| `5487bbe` | Add lexical exact/substring/stem/synonym pass that force-promotes present keywords to `matched` **before** the embedding pass; recalibrate `matched ≥ 0.55`, score = `(matched + 0.5·partial)/total` |
| `f47d5f8` | Extraction quality: comma/paren clause boundaries, substring-overlap dedup, expanded filler |
| `b70573c` | Surface model-download progress copy ("Downloading AI model…") |
| `f577eb7` | Destructure `statusText` in `ModelStatusIndicator` (crash found in browser verify + regression test) |
| `3942d27` | Match stem-adjacent verbatim phrases ("monitor vital" ↔ "monitoring vital signs"; "restful apis" ↔ "RESTful APIs"); symmetric synonym pipeline on both sides |
| `3fba365` | Reject glue-word **middle** terms in trigram extraction (loop only checked first/last word) |
| `1b1f84d` | Stem-match gerund-named known skills ("mentoring" ↔ "mentored") — skip-set + known-skill gate previously blocked the stem fallback for these |
| `396852a` | Filter JD boilerplate unigrams "hands-on" and "similar" |

## Before / after (browser-verified acceptance cases)

| Case | Before | After | Verdict |
|------|--------|-------|---------|
| TC1 near-verbatim SWE | 28% "Low", "software" flagged missing | **78% "Strong"**, all 11 skill probes + "restful apis" matched | ✅ |
| TC2 paraphrase (mgr) | 0% matched | **38%**, partials credited | ✅ above mismatch control |
| TC3 nurse mirror (gate) | 5%, verbatim phrases in Missing | **94% "Strong"**, "monitor vital signs"/"administer medications" matched | ✅ |
| TC4 mismatch control (SWE resume vs nurse JD) | 0% | **0%**, 0 matched | ✅ discriminates |
| TC5 re-scan sensitivity | — | 78 → 70 (remove docker/k8s/jenkins) → 78 (re-add) | ✅ |
| Privacy | — | Scan issues only model-asset + ad GETs; **no user text POSTed** | ✅ not regressed |

The two latest commits (`1b1f84d`, `396852a`) are covered by deterministic unit tests (fail-before/pass-after) and a live code trace; visual browser re-confirmation is deferred to DEV QA (the DevTools browser session wedged locally — the fixes need no model to verify).

## Test evidence

- Full suite: **1467 passing, 23 skipped** (`npx vitest run`).
- Scanner-focused suites (`src/utils/__tests__`, `src/workers/__tests__`): **371 passing**.
- New deterministic tests per fix: stem-adjacent phrases (3), gerund known-skill + `docker`≠`dock` guard (2), glue-word trigram (1), boilerplate unigram (1).
- Type-check: `npx tsc -b --force` clean.

> **Repo pitfall documented:** the root `tsconfig` is solution-style (`"files": []`), so `npx tsc --noEmit` checks **zero files** and is vacuous. Use `npx tsc -b`.

## Known limitations (not blockers — documented for the owner)

- **Extraction drops phrases sitting before a `Requirements:`/`Responsibilities:` header** (e.g. "team leadership", "budget ownership" in an intro sentence). Deferred: two fix proposals on record; relaxing the truncation risks re-admitting company-blurb noise — a product-judgment call.
- **Paraphrase matching is directionally correct but weak** (short-phrase-vs-sentence cosine is inherently soft). Output is no longer *misleading*, but it's *incomplete* on heavy paraphrases — an acceptable failure mode for a free heuristic tool.
- Verdict bands (Strong ≥70 / Moderate ≥40 / Low) left as-is; force-promotion + partial credit already pushes well-tailored resumes past 70 without lowering the bar for weak ones.

## Guardrails honored

- Matching stays 100% in-browser (privacy verified in DevTools Network — no user text leaves the page).
- No new dependencies; model stays lazy-loaded off idle; no new main-thread work.
- SEO layer (title/schema/FAQ/internal links) untouched.
- Existing UX preserved (score ring, three tabs, context cards, mobile layout); only the model-download progress copy was added.