### PR TITLE
🎨 Palette: Improve 'Add Description Point' interaction UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-07-05 - Consistent repeatable items UX
+**Learning:** Quiet by default is necessary when presenting the ability to add new repeating sub-items within an entity block. Loud custom button styles distract the user's focus away from filling in the important forms.
+**Action:** Instead of loud buttons for adding repeating items in list entities, employ the standard `<GhostButton>` UI component.

--- a/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
+++ b/resume-builder-ui/src/__tests__/ExperienceSection.test.tsx
@@ -194,7 +194,7 @@ describe("ExperienceSection", { timeout: 5000 }, () => {
     render(<ExperienceSection {...props} />, { wrapper: DndWrapper });
 
     // For the first experience, click the Add Description Point button.
-    const addDescButton = screen.getAllByText("+ Add Description Point")[0];
+    const addDescButton = screen.getAllByText("Add Description Point")[0];
     fireEvent.click(addDescButton);
 
     expect(onUpdateMock).toHaveBeenCalledTimes(1);

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { RichTextInput } from './RichTextInput';
 import { MarkdownHint } from './MarkdownLinkPreview';
+import { GhostButton } from './shared/GhostButton';
 import IconManager from './IconManager';
 import ItemDndContext from './ItemDndContext';
 import SortableItem from './SortableItem';
@@ -192,12 +193,9 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
               </ItemDndContext>
             )}
           </div>
-          <button
-            onClick={handleDescAdd}
-            className="mt-3 bg-accent text-ink px-4 py-2 rounded-lg font-medium shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300 flex items-center gap-2"
-          >
-            + Add Description Point
-          </button>
+          <GhostButton onClick={handleDescAdd} className="mt-3">
+            Add Description Point
+          </GhostButton>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 💡 What
Replaced the custom styled "Add Description Point" button within the Experience items list with the generic `<GhostButton>` component. Updated test files accordingly.

### 🎯 Why
Loud button styling inside of repeating entity block lists distracts the user's attention from filling in their information. The `<GhostButton>` follows the established "Quiet by Default" UX behavior for repeatable items across other standard sections.

### 📸 Before/After
Replaced loud accent buttons with subtle dashed generic buttons.

### ♿ Accessibility
Improved focus indicators via the `<GhostButton>` component.

---
*PR created automatically by Jules for task [1977412085955501927](https://jules.google.com/task/1977412085955501927) started by @aafre*