### PR TITLE
🎨 Palette: Add confirmation dialog when deleting sections

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-07 - Responsive Confirm Dialog for Destructive Actions
+**Learning:** Users can accidentally lose significant amounts of data if major structural changes, like deleting entire sections, lack friction. Standard `window.confirm` isn't very accessible or mobile-friendly.
+**Action:** Always use the `ResponsiveConfirmDialog` component for destructive actions (such as 'Delete section') to provide a consistent, accessible, and mobile-friendly confirmation prompt that prevents accidental data loss.

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -20,45 +23,57 @@ const SectionControls: React.FC<{
   };
 
   return (
-    <div className="absolute top-4 right-4 flex gap-2">
-      <button
-        type="button"
-        aria-label="Move section up"
-        title="Move section up"
-        onClick={() => moveSection(sectionIndex, sectionIndex - 1)}
-        disabled={sectionIndex === 0}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
-          sectionIndex === 0
-            ? "bg-gray-300 cursor-not-allowed text-gray-500"
-            : "bg-accent hover:bg-accent text-ink"
-        }`}
-      >
-        <MdArrowUpward className="text-lg" />
-      </button>
-      <button
-        type="button"
-        aria-label="Move section down"
-        title="Move section down"
-        onClick={() => moveSection(sectionIndex, sectionIndex + 1)}
-        disabled={sectionIndex === sections.length - 1}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
-          sectionIndex === sections.length - 1
-            ? "bg-gray-300 cursor-not-allowed text-gray-500"
-            : "bg-accent hover:bg-accent text-ink"
-        }`}
-      >
-        <MdArrowDownward className="text-lg" />
-      </button>
-      <button
-        type="button"
-        aria-label="Delete section"
-        title="Delete section"
-        onClick={deleteSection}
-        className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
-      >
-        <MdDeleteOutline className="text-lg" />
-      </button>
-    </div>
+    <>
+      <div className="absolute top-4 right-4 flex gap-2">
+        <button
+          type="button"
+          aria-label="Move section up"
+          title="Move section up"
+          onClick={() => moveSection(sectionIndex, sectionIndex - 1)}
+          disabled={sectionIndex === 0}
+          className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+            sectionIndex === 0
+              ? "bg-gray-300 cursor-not-allowed text-gray-500"
+              : "bg-accent hover:bg-accent text-ink"
+          }`}
+        >
+          <MdArrowUpward className="text-lg" />
+        </button>
+        <button
+          type="button"
+          aria-label="Move section down"
+          title="Move section down"
+          onClick={() => moveSection(sectionIndex, sectionIndex + 1)}
+          disabled={sectionIndex === sections.length - 1}
+          className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+            sectionIndex === sections.length - 1
+              ? "bg-gray-300 cursor-not-allowed text-gray-500"
+              : "bg-accent hover:bg-accent text-ink"
+          }`}
+        >
+          <MdArrowDownward className="text-lg" />
+        </button>
+        <button
+          type="button"
+          aria-label="Delete section"
+          title="Delete section"
+          onClick={() => setIsConfirmOpen(true)}
+          className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
+        >
+          <MdDeleteOutline className="text-lg" />
+        </button>
+      </div>
+
+      <ResponsiveConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={deleteSection}
+        title="Delete Section"
+        message="Are you sure you want to delete this section? All content inside will be lost."
+        confirmText="Delete"
+        isDestructive={true}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
💡 What: Replaced instant section delete with `ResponsiveConfirmDialog` in `SectionControls.tsx`.
🎯 Why: Prevents accidental data loss when a user misclicks the delete icon in the section controls. Major structural changes should have friction.
📸 Before/After: Clicking delete instantly removed the section. Now, it opens an accessible, mobile-friendly confirmation bottom sheet.
♿ Accessibility: Uses the built-in a11y features of `ResponsiveConfirmDialog` (`role="dialog"`, `aria-modal="true"`, focus trapping).

---
*PR created automatically by Jules for task [5525184964148293207](https://jules.google.com/task/5525184964148293207) started by @aafre*