### PR TITLE
⚡ Bolt: Optimize YAML serialization with CSafeDumper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-09 - Faster YAML Loading
 **Learning:** Using `yaml.safe_load` for parsing resume configurations is significantly slower than using `yaml.CSafeLoader`. Our benchmarks showed a ~10x speedup when using `yaml.load` with `CSafeLoader`.
 **Action:** Use `utils.yaml_converter.fast_yaml_load` instead of `yaml.safe_load` across the codebase to reduce CPU blocking during YAML parsing and PDF generation.
+
+## 2026-07-09 - C-based YAML Serialization
+**Learning:** PyYAML's default `yaml.dump` is slow. Using `yaml.CSafeDumper` gives a ~10x speedup for serialization. However, `CSafeDumper` has a bug where it throws an `OverflowError: cannot convert float infinity to integer` if `width=float("inf")` is passed. It must be substituted with a large integer (e.g., `width=1000000`).
+**Action:** Always import and use `CSafeDumper` alongside `CSafeLoader` for YAML processing to maximize performance, but beware of using `float("inf")` for the width parameter when preventing line wraps.

--- a/utils/yaml_converter.py
+++ b/utils/yaml_converter.py
@@ -13,9 +13,10 @@ from typing import Any, Dict
 import yaml
 
 try:
+    from yaml import CSafeDumper as SafeDumper
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeDumper, SafeLoader
 
 
 def fast_yaml_load(stream):
@@ -68,10 +69,11 @@ def json_to_yaml_structure(resume_data: Dict[str, Any]) -> str:
     # Convert to YAML string
     yaml_string = yaml.dump(
         yaml_structure,
+        Dumper=SafeDumper,
         default_flow_style=False,
         allow_unicode=True,
         sort_keys=False,
-        width=float("inf"),  # Prevent line wrapping
+        width=1000000,  # Prevent line wrapping. CSafeDumper fails on float("inf")
     )
 
     return yaml_string


### PR DESCRIPTION
💡 What: Updated `json_to_yaml_structure` to use `CSafeDumper` when serializing YAML data. `width=float("inf")` was also replaced with `width=1000000` to avoid an `OverflowError` bug in PyYAML's C implementation.
🎯 Why: PyYAML's default dumper is pure Python and very slow. Using the C-based Dumper significantly speeds up the conversion of JSONB database data to YAML for PDF generation.
📊 Impact: Reduces YAML serialization time by ~90% (from ~0.97s to ~0.08s per 100 iterations of a large resume).
🔬 Measurement: Verified by benchmarking the `yaml.dump` call with a large nested dictionary. All existing tests pass.

---
*PR created automatically by Jules for task [4150258529652983487](https://jules.google.com/task/4150258529652983487) started by @aafre*