### PR TITLE
🎨 Palette: Enhance keyboard accessibility for confirmation dialogs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-07-09 - ResponsiveConfirmDialog Keyboard Accessibility
+
+**Learning:** Custom dialog action buttons styled with Tailwind lose default browser focus outlines. Modals also require explicit focus management (like focusing on mount) and an Escape key listener to close for screen reader compatibility and full keyboard navigation.
+**Action:** Always add `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to styled modal buttons, explicitly manage focus with `useRef` and `useEffect` on mount, and bind a `keydown` listener for the Escape key on custom dialogs.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -46,6 +46,25 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
     : "bg-accent hover:bg-accent/90 text-white";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isLoading) {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, isLoading, onClose]);
 
   return (
     <>
@@ -69,11 +88,14 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
       >
         {/* Dialog Content */}
         <div
+          ref={dialogRef}
+          tabIndex={-1}
           className="bg-white rounded-t-2xl lg:rounded-2xl shadow-2xl
             w-full lg:max-w-md
             max-h-[85vh] lg:max-h-[90vh]
             flex flex-col
-            transform transition-transform duration-300"
+            transform transition-transform duration-300
+            focus:outline-none"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
@@ -97,7 +119,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +145,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -135,6 +157,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What: Added focus management (auto-focusing the dialog container on open), an 'Escape' key event listener to close the dialog, and explicit focus rings (`focus-visible:ring-2`) to all interactive buttons (Close, Cancel, Confirm) in `ResponsiveConfirmDialog`.
🎯 Why: To ensure keyboard and screen-reader users can fully navigate and interact with the confirmation dialog, solving the problem of lost focus rings on styled Tailwind buttons and missing Escape key support.
📸 Before/After: Before, buttons had no visible focus outlines and the Escape key did not close the dialog. After, all interactive elements display a clear focus ring, the dialog correctly receives initial focus, and it can be dismissed via keyboard.
♿ Accessibility: Added explicit focus outlines to restore keyboard navigability and implemented standard modal interaction patterns (initial focus capture and escape-to-close) for improved screen reader and assistive device support.

---
*PR created automatically by Jules for task [13768297032486373074](https://jules.google.com/task/13768297032486373074) started by @aafre*