### PR TITLE
perf(seo): fix /ats-resume-templates desktop LCP (4.7s → prerendered paint)

### DIFF
--- a/resume-builder-ui/src/components/seo/TemplatesHub.tsx
+++ b/resume-builder-ui/src/components/seo/TemplatesHub.tsx
@@ -40,7 +40,10 @@ export default function TemplatesHub() {
       {/* In-content Ad - Below hero */}
       <InContentAd adSlot={AD_CONFIG.slots.templatesIncontent} marginY={32} />
 
-      <RevealSection variant="fade-up">
+      {/* Not reveal-wrapped: on desktop the intro <p> below is the LCP element.
+          RevealSection starts children at opacity:0 until hydration adds
+          .revealed (IntersectionObserver), which stalled desktop LCP at ~4.7s.
+          Rendering it plainly lets it paint from the prerendered HTML. */}
         <div className="mb-16 cv-auto cv-h-500">
           <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight text-ink mb-8 text-center">
             What makes a resume ATS-friendly
@@ -76,7 +79,6 @@ export default function TemplatesHub() {
             </ul>
           </div>
         </div>
-      </RevealSection>
 
       {config.features && <FeatureGrid features={config.features} />}
 


### PR DESCRIPTION
## Problem
Post-release (v3.28.0) prod CWV audit found **`/ats-resume-templates` desktop LCP = 4.7–4.85s** (reproduced twice via Chrome DevTools trace), failing the <2.5s "good" threshold. TTFB is ~30ms — the entire delay is **render delay**. Mobile is fine (~931ms).

## Root cause (confirmed by code trace)
On a wide desktop viewport the largest element is the intro paragraph in the "What makes a resume ATS-friendly" block (`TemplatesHub.tsx`). That block was wrapped in `<RevealSection variant="fade-up">`:

- `styles.css:104` → `[data-reveal] { opacity: 0 }` — reveal children start **invisible**.
- The visible state (`.revealed`, `styles.css:116`) is only applied **after hydration**, via `useEffect` + IntersectionObserver in `useScrollReveal.ts`.
- So the LCP paragraph is present in the prerendered HTML but paints `opacity:0` until JS runs → LCP registers at ~4.7s.

The page is on `PRERENDER_TO_ALL_ROUTES` (`app.py:1566`), so the HTML is served pre-rendered — but the reveal wrapper defeated the benefit for the LCP element. `prefers-reduced-motion` users were unaffected (`styles.css:540` forces `opacity:1`), so this only hit motion-enabled (majority) users.

## Fix
Unwrap **only the first below-hero block** from `RevealSection` so its text paints straight from the prerendered HTML. Below-fold sections keep their scroll-reveal animations. The `cv-auto cv-h-500` height reservation is retained, so no CLS is introduced (opacity/transform don't affect layout).

One-file, structural change — no copy, title, H1, or schema edits.

## Verification
- `npx tsc -b` clean
- `npx vitest run` → 1474 passed, 23 skipped
- **Empirical LCP re-measure should be done on DEV** (Chrome DevTools trace at desktop ≥1280px + mobile) before merge — expected: desktop LCP < 2.5s, mobile unchanged, CLS ≤0.02.

## SEO governance
`/ats-resume-templates` is Tier-2 (not in the active Tier-1 GSC watch window). This is a **perf-only** change — no ranking-signal surface touched. Log in `seo-tracking/changelog.md` on merge with before/after LCP numbers.

## Notes
- Pre-existing `impeccable` design findings on this file (side-tab accent borders) are the project's own design-system pattern (CLAUDE.md specifies `border-2 border-accent/*` on template/ATS cards) and are out of scope for this perf fix.
- Do not merge without approval + DEV LCP re-check.