### PR TITLE
⚡ Bolt: Prevent O(n) child re-renders by stabilizing section update callbacks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-09 - Faster YAML Loading
 **Learning:** Using `yaml.safe_load` for parsing resume configurations is significantly slower than using `yaml.CSafeLoader`. Our benchmarks showed a ~10x speedup when using `yaml.load` with `CSafeLoader`.
 **Action:** Use `utils.yaml_converter.fast_yaml_load` instead of `yaml.safe_load` across the codebase to reduce CPU blocking during YAML parsing and PDF generation.
+
+## 2026-07-11 - Stable Callbacks for Memoized Lists
+**Learning:** When passing callbacks to memoized list children (like `ExperienceItem` wrapped in `React.memo`), if the parent callback depends on the entire list's state object (e.g. `section`), the callback is recreated on every keystroke. This defeats memoization and causes O(n) re-renders across all items when only one is edited.
+**Action:** Use a `useRef` to store the latest state (e.g. `sectionRef.current = section`) inside the parent component, allowing the callback dependency array to omit the state object, preserving a stable callback reference for all children.

--- a/resume-builder-ui/src/components/editor/SectionRenderer.tsx
+++ b/resume-builder-ui/src/components/editor/SectionRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import { Section, IconListItem } from '../../types';
 import { EditorContentIconRegistry } from './EditorContent';
 import { isExperienceSection, isEducationSection } from '../../utils/sectionTypeChecker';
@@ -60,12 +60,17 @@ const SectionRenderer: React.FC<SectionRendererProps> = React.memo(({
     handleReorderEntry(index, oldIndex, newIndex);
   }, [handleReorderEntry, index]);
 
+  const sectionRef = useRef(section);
+  useEffect(() => {
+    sectionRef.current = section;
+  }, [section]);
+
   const onUpdate = useCallback((updatedContent: unknown) => {
     // Pass-through wrapper: content type varies by section and is enforced
     // by each child component's own prop types. We just wrap it into the
     // section object and forward to the parent handler.
-    handleUpdateSection(index, { ...section, content: updatedContent } as Section);
-  }, [handleUpdateSection, index, section]);
+    handleUpdateSection(index, { ...sectionRef.current, content: updatedContent } as Section);
+  }, [handleUpdateSection, index]);
 
   const onGenericUpdate = useCallback((updatedSection: Section) => {
     handleUpdateSection(index, updatedSection);


### PR DESCRIPTION
💡 What: Stabilized the `onUpdate` callback in `SectionRenderer.tsx` by using a `useRef` to hold the latest `section` state, removing the direct dependency on `section`. 
🎯 Why: The previous `onUpdate` callback depended on the `section` object, which changed whenever any field in a child item (like an Experience description) was typed into. This recreated the callback, which recreated the child component callbacks, forcing all `ExperienceItem`s to re-render simultaneously and defeating `React.memo`. 
📊 Impact: Reduces list item re-renders during editing from O(N) to O(1). Only the actively edited item will re-render, while siblings will successfully skip rendering. 
🔬 Measurement: Can be verified by placing a `console.log` in `ExperienceItem` and typing into a field. Before, every keystroke logged N times. Now, it only logs once.

---
*PR created automatically by Jules for task [15713885491937851773](https://jules.google.com/task/15713885491937851773) started by @aafre*