### PR TITLE
🎨 Palette: Improve ResponsiveConfirmDialog keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-11 - Custom Dialog Accessibility (Focus & Keyboard Navigation)
+**Learning:** Custom dialogs built with Tailwind classes lose default browser focus outlines on action buttons (Confirm/Cancel), and they do not automatically support standard 'Escape' key closure or auto-focusing behavior out of the box, breaking keyboard accessibility for screen reader users and power users.
+**Action:** When building or enhancing custom modals, always restore keyboard accessibility by adding explicit `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` (using contextual ring colors) to action buttons. Furthermore, ensure the modal container has a `tabIndex={-1}`, auto-focuses on mount via a `useRef`, and implements a `keydown` listener for the 'Escape' key to ensure proper keyboard management.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,26 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Handle Escape key to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Auto-focus dialog on open
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -58,10 +78,12 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
       {/* Dialog Container - Bottom sheet on mobile, center modal on desktop */}
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className="fixed z-[9999]
           bottom-0 left-0 right-0
           lg:inset-0 lg:flex lg:items-center lg:justify-center
-          animate-slide-up lg:animate-fade-in"
+          animate-slide-up lg:animate-fade-in focus:outline-none"
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
@@ -97,7 +119,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +145,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -135,6 +157,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility features to `ResponsiveConfirmDialog`. Specifically:
1. The dialog container auto-focuses on open.
2. The dialog can be closed with the 'Escape' key.
3. The action buttons (Confirm/Cancel/Close) now have explicit `focus-visible:ring-2` outlines (red for destructive actions, accent for normal actions, gray for close/cancel).

🎯 **Why:** Custom UI dialogs built with Tailwind classes often lose the browser's default focus outlines on buttons (e.g. `bg-red-600` masks it). Furthermore, React modals do not naturally intercept the Escape key or focus themselves without manual refs. This broke accessibility for screen readers and power users relying on keyboard navigation.

📸 **Before/After:**
*(Visual change: When tabbing through a Delete Resume modal, users will now clearly see a ring around the focused action button. Pressing Escape will close it).*

♿ **Accessibility:** This explicitly restores focus visibility and standard modal keyboard paradigms (Escape to close, auto-focus container).

---
*PR created automatically by Jules for task [3672896167426356089](https://jules.google.com/task/3672896167426356089) started by @aafre*