### PR TITLE
feat(seo): add "check resume against ATS free" funnel page for keyword scanner

### DIFF
--- a/resume-builder-ui/src/App.tsx
+++ b/resume-builder-ui/src/App.tsx
@@ -89,6 +89,7 @@ const BlogIndex = lazy(() => import("./components/BlogIndex"));
 const ResumeMistakesToAvoid = lazy(() => import("./components/blog/ResumeMistakesToAvoid"));
 const ATSOptimization = lazy(() => import("./components/blog/ATSOptimization"));
 const ATSFormattingRules = lazy(() => import("./components/blog/ATSFormattingRules"));
+const FreeATSResumeCheck = lazy(() => import("./components/blog/FreeATSResumeCheck"));
 const ResumeNoExperience = lazy(() => import("./components/blog/ResumeNoExperience"));
 const ProfessionalSummaryExamples = lazy(() => import("./components/blog/ProfessionalSummaryExamples"));
 const ResumeKeywordsGuide = lazy(() => import("./components/blog/ResumeKeywordsGuide"));
@@ -568,6 +569,14 @@ function AppContent() {
             element={
               <Suspense fallback={<BlogLoadingSkeleton />}>
                 <ATSFormattingRules />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/blog/free-ats-resume-check"
+            element={
+              <Suspense fallback={<BlogLoadingSkeleton />}>
+                <FreeATSResumeCheck />
               </Suspense>
             }
           />

--- a/resume-builder-ui/src/components/blog/ATSOptimization.tsx
+++ b/resume-builder-ui/src/components/blog/ATSOptimization.tsx
@@ -476,6 +476,8 @@ export default function ATSOptimization() {
           <Link to="/resume-keyword-scanner" className="text-accent hover:underline font-medium">resume keyword scanner</Link>{" "}
           to instantly check whether your resume includes the right terms for
           your target role.
+          {" "}For the complete workflow, follow all four methods in our{" "}
+          <Link to="/blog/free-ats-resume-check" className="text-accent hover:underline font-medium">free ATS resume check guide</Link>.
         </p>
 
         <div className="bg-accent/[0.06] border border-accent/20 rounded-xl p-6 my-6">

--- a/resume-builder-ui/src/components/blog/FreeATSResumeCheck.tsx
+++ b/resume-builder-ui/src/components/blog/FreeATSResumeCheck.tsx
@@ -1,0 +1,298 @@
+import BlogLayout from "../BlogLayout";
+import { Link } from "react-router-dom";
+
+const FAQS = [
+  {
+    question: "How do I check if my resume passes ATS for free?",
+    answer:
+      "Run a keyword scan against the job description (EasyFreeResume's scanner is free and unlimited), then do the plain-text paste test to catch formatting that parsers lose. Together they cover the two real failure modes: missing keywords and unparseable structure.",
+  },
+  {
+    question: "Is there a truly free ATS resume checker?",
+    answer:
+      "Yes. EasyFreeResume's keyword scanner is free with unlimited scans and no account; it runs in your browser, so your resume is never uploaded. Many other \"free\" checkers cap scans or gate full results behind sign-up.",
+  },
+  {
+    question: "What ATS score should my resume get?",
+    answer:
+      "There is no universal ATS score — every checker measures differently. Aim to cover the job description's must-have keywords you genuinely possess and pass a plain-text paste test; that matters more than any single percentage.",
+  },
+  {
+    question: "Do recruiters actually see an ATS score?",
+    answer:
+      "No. Recruiters see parsed fields and search results, not a score. Scores from checkers are heuristics that estimate how well your resume matches a specific job description.",
+  },
+  {
+    question: "Can ATS read PDF resumes?",
+    answer:
+      "Modern systems parse text-based PDFs fine. Problems come from scanned/image PDFs and from layouts like tables, columns, and graphics. If your PDF text is selectable and it survives a plain-text paste, format isn't your problem.",
+  },
+  {
+    question: "How often should I check my resume against ATS?",
+    answer:
+      "For every application. Keyword matching is per job description, so re-scan your resume against each posting and adjust honestly rather than reusing one generic version.",
+  },
+];
+
+export default function FreeATSResumeCheck() {
+  return (
+    <BlogLayout
+      title="How to Check Your Resume Against ATS (4 Free Methods)"
+      description="Four genuinely free ways to test whether your resume survives applicant tracking systems, including an unlimited keyword scanner that runs in your browser."
+      publishDate="2026-07-13"
+      lastUpdated="2026-07-13"
+      readTime="8 min"
+      keywords={[
+        "how to check if resume passes ATS",
+        "check resume ATS score free",
+        "test resume against ATS free",
+        "free ATS resume checker",
+        "ATS keyword scanner",
+        "ATS resume test",
+      ]}
+      ctaType="resume"
+      faqs={FAQS}
+    >
+      <div className="space-y-8">
+        {/* Answer-first intro (<= 50 words) */}
+        <p className="text-xl leading-relaxed text-stone-warm font-medium">
+          Check your resume four ways: scan its keywords against the job description,
+          run a plain-text paste test, match keywords manually, and audit its structure.
+          There is no universal ATS score; each method catches a different failure mode.
+        </p>
+
+        <div className="bg-chalk-dark border border-black/[0.06] rounded-xl p-6 my-8">
+          <h2 className="font-bold text-ink mb-4 text-lg">On this page</h2>
+          <ol className="space-y-2 text-ink/80 list-decimal list-inside">
+            <li>What passing the ATS actually means</li>
+            <li>Method 1: Run a free keyword scan</li>
+            <li>Method 2: Use the plain-text paste test</li>
+            <li>Method 3: Match job-description keywords manually</li>
+            <li>Method 4: Audit your resume structure</li>
+            <li>How paid ATS checkers compare</li>
+          </ol>
+        </div>
+
+        <h2 id="meaning" className="text-3xl font-bold text-ink mt-12 mb-6">
+          What &quot;Passing the ATS&quot; Actually Means
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          An applicant tracking system does not make one universal pass-or-fail
+          decision. It first parses your document into fields such as contact
+          details, work history, education, and skills. Recruiters can then search,
+          filter, or rank those records using terms related to the role. Different
+          employers configure different systems and workflows, so a score from one
+          checker cannot predict every employer&apos;s result.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          In practice, a resume usually loses visibility for one of two reasons. The
+          parser cannot recover important text from the layout, or the resume does
+          not contain the terms a recruiter searches for. The four checks below
+          test those problems separately. For a closer look at what parsers can and
+          cannot read, see our guide to{" "}
+          <Link to="/blog/ats-formatting-rules" className="text-accent hover:underline font-medium">
+            ATS formatting rules
+          </Link>.
+        </p>
+
+        <h2 id="keyword-scan" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Method 1: Run a Free Keyword Scan Against the Job Description
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Start with the job description because keyword relevance is specific to
+          each application. EasyFreeResume&apos;s own{" "}
+          <Link to="/resume-keyword-scanner" className="text-accent hover:underline font-medium">
+            free resume keyword scanner
+          </Link>{" "}
+          compares your resume with the posting. It is free for unlimited scans,
+          requires no account, and runs entirely in your browser, so the text you
+          paste is not uploaded.
+        </p>
+        <ol className="list-decimal pl-6 space-y-3 text-lg leading-relaxed text-stone-warm">
+          <li>
+            Paste the text of your resume into the resume field. Use the version
+            you plan to submit, not a longer master document.
+          </li>
+          <li>
+            Paste the complete job description into the second field. Include the
+            responsibilities and requirements, because both can contain terms used
+            in a recruiter&apos;s search.
+          </li>
+          <li>
+            Run the scan and review the coverage score, matched terms, and missing
+            terms. Treat the score as a comparison aid for this posting, not as a
+            promise that an employer will accept or reject the resume.
+          </li>
+          <li>
+            Add a missing keyword only when it describes experience or knowledge
+            you genuinely have. Put it in a clear bullet or skills entry that gives
+            a recruiter useful context. Never copy requirements you cannot support.
+          </li>
+        </ol>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Re-scan after editing. A useful result is not the highest possible
+          percentage; it is a resume that clearly uses the employer&apos;s language
+          while remaining accurate. A truthful exact term such as a tool name,
+          certification, or method can help both a text search and the person who
+          reads the resume later.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Review missing terms in context before changing anything. A posting may
+          mention a tool as one option among several, repeat the company&apos;s own
+          product name, or include duties that belong to another team. Those words
+          do not automatically belong on your resume. Prioritize requirements that
+          are central to the role and supported by your work, projects, education,
+          or certifications. This keeps the document focused and prevents a scan
+          result from turning into keyword stuffing.
+        </p>
+
+        <h2 id="plain-text-test" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Method 2: Use the Plain-Text Paste Test
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          This 60-second test exposes structural problems that a keyword comparison
+          cannot see. Open your finished resume, select all its content, copy it,
+          and paste it into a plain-text editor such as Notepad or TextEdit in plain
+          text mode. Then read the result from top to bottom.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Check whether your name and contact details appear first, section headings
+          remain attached to the right content, job titles stay with the correct
+          employers and dates, and bullets read in their intended order. Text that
+          vanishes was probably stored in a graphic, header, footer, icon, or text
+          box. Text that interleaves or jumps around often came from tables or
+          columns. Those are signs that a parser may build an incomplete or
+          confusing candidate record.
+        </p>
+        <div className="bg-accent/[0.06] border border-accent/20 rounded-xl p-6 my-8">
+          <h3 className="font-bold text-ink mb-2">What a clean result looks like</h3>
+          <p className="text-ink/80">
+            Every important fact appears as selectable text in a logical sequence:
+            contact details, summary, skills, experience, and education. Minor lost
+            spacing is harmless. Missing facts or scrambled reading order require a
+            layout fix.
+          </p>
+        </div>
+
+        <h2 id="manual-match" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Method 3: Match Job-Description Keywords Manually
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          A manual check is useful when you want to understand why a term matters,
+          or when a posting is short enough to review line by line. Highlight the
+          must-have skills, tools, certifications, methods, and domain terms in the
+          job description. Separate required qualifications from optional ones, and
+          ignore generic language that does not describe the work.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Search your resume for each must-have term. Confirm that the exact wording
+          appears when it is truthful, rather than relying only on a synonym. For
+          example, &quot;project management&quot; and &quot;managed projects&quot; communicate similar
+          ideas to a person, but exact-phrase searching may treat them differently.
+          Exact-phrase matching is a common ATS search behavior, not a rule used by
+          every system.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Place terms where they prove something. A software name can sit in Skills,
+          but a work-history bullet showing how you used it is stronger. Spell out
+          an acronym once when the posting uses both versions, such as &quot;project
+          management office (PMO).&quot; Do not hide repeated keywords, paste the job
+          description into the document, or force awkward repetitions. The final
+          resume still needs to make sense to a recruiter.
+        </p>
+
+        <h2 id="structural-audit" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Method 4: Audit Your Resume Structure
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Finish with a visual and technical audit. This catches risky choices
+          before you submit the file and gives you a short checklist to reuse for
+          later applications.
+        </p>
+        <div className="grid md:grid-cols-2 gap-6 my-8">
+          <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+            <h3 className="font-bold text-green-800 mb-3">Do</h3>
+            <ul className="list-disc pl-5 space-y-2 text-green-800/90">
+              <li>Use a single-column reading order.</li>
+              <li>Use standard headings such as Experience, Education, and Skills.</li>
+              <li>Keep names, dates, and skills as real selectable text.</li>
+              <li>Choose a standard, readable font and consistent date format.</li>
+              <li>Open the final PDF and confirm its text can be selected.</li>
+            </ul>
+          </div>
+          <div className="bg-red-50 border border-red-200 rounded-xl p-6">
+            <h3 className="font-bold text-red-800 mb-3">Don&apos;t</h3>
+            <ul className="list-disc pl-5 space-y-2 text-red-800/90">
+              <li>Split core content across sidebars or multiple columns.</li>
+              <li>Put essential details inside tables, graphics, or icons.</li>
+              <li>Store contact details only in a header or footer.</li>
+              <li>Use creative labels that obscure what a section contains.</li>
+              <li>Submit a scanned or image-only PDF.</li>
+            </ul>
+          </div>
+        </div>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          If rebuilding the layout would take too long, start with one of our{" "}
+          <Link to="/templates/ats-friendly" className="text-accent hover:underline font-medium">
+            ATS-friendly resume templates
+          </Link>. They provide a simple structure, but you should still run the
+          plain-text and keyword checks on your finished content.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Follow the application&apos;s file instructions first. If it requests a DOCX,
+          submit a DOCX. If PDF is accepted, export a text-based PDF rather than
+          scanning or photographing the page. Reopen the exported file instead of
+          assuming it matches the editor: confirm that every page renders, links do
+          not cover text, and characters copy correctly. Run the paste test on that
+          final file, because export settings can introduce problems that were not
+          visible while you were editing.
+        </p>
+
+        <h2 id="paid-checkers" className="text-3xl font-bold text-ink mt-12 mb-6">
+          What About Paid ATS Checkers?
+        </h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Paid tools can bundle keyword comparison with writing suggestions,
+          formatting feedback, or application tracking. Some people value those
+          extra workflows. However, many products described as free cap scans,
+          require an account, or reserve full results for a paid plan. Check the
+          current terms before spending time entering your resume.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          You do not need a paid checker to cover the two basic risks. A browser-based
+          keyword comparison shows whether your truthful qualifications use the
+          posting&apos;s language, while the plain-text test shows whether the structure
+          survives parsing. Manual matching and the structural checklist let you
+          investigate anything those first checks flag. No tool can guarantee an
+          interview or reproduce every employer&apos;s ATS configuration.
+        </p>
+
+        <h2 id="faq" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Frequently Asked Questions
+        </h2>
+        <div className="space-y-4 my-6">
+          {FAQS.map((faq) => (
+            <div key={faq.question} className="bg-chalk-dark border border-black/[0.06] rounded-lg p-5">
+              <h3 className="font-bold text-ink mb-2">{faq.question}</h3>
+              <p className="text-stone-warm">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">Check Both Failure Modes</h2>
+        <p className="text-lg leading-relaxed text-stone-warm">
+          A useful ATS check combines keyword relevance with readable structure.
+          Run the plain-text test once after layout changes, then compare the resume
+          with the job description for every application. Ignore any promise of a
+          universal passing score and focus on accurate evidence a recruiter can find.
+        </p>
+        <p className="text-lg leading-relaxed text-stone-warm mt-4">
+          Start now with our{" "}
+          <Link to="/resume-keyword-scanner" className="text-accent hover:underline font-medium">
+            free, unlimited resume keyword scanner
+          </Link>; it needs no account and keeps your resume in your browser.
+        </p>
+      </div>
+    </BlogLayout>
+  );
+}

--- a/resume-builder-ui/src/data/blogPosts.ts
+++ b/resume-builder-ui/src/data/blogPosts.ts
@@ -198,6 +198,15 @@ export const blogPosts: BlogPost[] = [
     category: "ATS Optimization",
   },
   {
+    slug: "free-ats-resume-check",
+    title: "How to Check Your Resume Against ATS (4 Free Methods)",
+    description:
+      "Four genuinely free ways to test whether your resume survives applicant tracking systems, including an unlimited keyword scanner that runs in your browser.",
+    publishDate: "2026-07-13",
+    readTime: "8 min",
+    category: "ATS Optimization",
+  },
+  {
     slug: "resume-no-experience",
     title: "Resume with No Experience: Real Examples + Free Template",
     description:

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -70,6 +70,7 @@ export const STATIC_URLS: SitemapUrl[] = [
   { loc: '/blog/job-interview-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/ats-resume-optimization', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/ats-formatting-rules', priority: 0.5, changefreq: 'monthly', lastmod: '2026-07-01' },
+  { loc: '/blog/free-ats-resume-check', priority: 0.5, changefreq: 'monthly', lastmod: '2026-07-13' },
   { loc: '/blog/resume-mistakes-to-avoid', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/professional-summary-examples', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
   { loc: '/blog/cover-letter-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },


### PR DESCRIPTION
## What

- Add `/blog/free-ats-resume-check`, a 1,476-word answer-first guide covering four free ATS checks.
- Register the route, blog metadata, sitemap metadata, and prerender path.
- Add one contextual inbound link from the established ATS optimization guide.
- Render all six FAQs visibly and through the matching FAQPage schema.

## Why

This page gives the zero-impression `/resume-keyword-scanner` tool query coverage for searches such as "how to check if my resume passes ATS" and guides readers into the scanner without unsupported claims.

## Files changed

- `resume-builder-ui/src/components/blog/FreeATSResumeCheck.tsx`
- `resume-builder-ui/src/App.tsx`
- `resume-builder-ui/src/data/blogPosts.ts`
- `resume-builder-ui/src/data/sitemapUrls.ts`
- `resume-builder-ui/src/components/blog/ATSOptimization.tsx`

## Verification

```text
$ npx tsc -b
exit 0

$ npx vitest run
Test Files  73 passed | 3 skipped (76)
Tests       1474 passed | 23 skipped (1497)
Duration    29.57s

$ npm run lint
179 errors, 21 warnings (repository baseline; command exits 1)

$ npx eslint src/App.tsx src/components/blog/ATSOptimization.tsx src/components/blog/FreeATSResumeCheck.tsx src/data/blogPosts.ts src/data/sitemapUrls.ts
exit 0

$ npm run build
exit 0
120 sitemap URLs generated (74 static + 20 keyword pages + 26 example pages)

$ PRERENDER_ONLY=/blog/free-ats-resume-check npm run prerender
[prerender] 1 routes to prerender
Rendering: /blog/free-ats-resume-check
Success: 1/1

Generated HTML assertions:
- title: How to Check Your Resume Against ATS (4 Free Methods) | EasyFreeResume
- robots: index, follow
- canonical: https://easyfreeresume.com/blog/free-ats-resume-check
- FAQPage JSON-LD blocks: 1
- visible FAQ questions: 6/6
- sitemap URL present: yes

$ git diff --cached --check
clean
```

Owner-gated merge; Claude reviews first.
