### PR TITLE
fix(seo): align /about foundingDate with Organization schema (2024-01)

### DIFF
--- a/resume-builder-ui/src/components/AboutUs.tsx
+++ b/resume-builder-ui/src/components/AboutUs.tsx
@@ -20,7 +20,7 @@ export default function AboutUs() {
               "@type": "Organization",
               name: "EasyFreeResume",
               description: "Free professional resume builder platform",
-              foundingDate: "2019",
+              foundingDate: "2024-01",
               mission:
                 "Democratize career opportunities by providing free professional resume tools",
             },


### PR DESCRIPTION
## What

Fix a self-inconsistent `foundingDate` in the `/about` page schema.

- `resume-builder-ui/src/components/AboutUs.tsx` (AboutPage → `mainEntity` Organization) declared `foundingDate: "2019"`.
- `resume-builder-ui/index.html` (site-wide Organization schema) declares `foundingDate: "2024-01"`.

Owner confirmed **2024-01** is correct. This aligns `AboutUs.tsx` to match.

## Why

Off-site authority / entity-recognition is the current SEO priority (the binding constraint on core-update recovery). A founding date that disagrees with itself across the site's own structured data is a weak/contradictory entity signal — the exact thing that workstream is trying to strengthen. This also lines up with the new Wikidata item's `inception (P571)`, so Wikidata + `index.html` + `AboutUs.tsx` all agree.

## Change

```diff
-              foundingDate: "2019",
+              foundingDate: "2024-01",
```

## Risk / testing

- Schema-only value change. No title / H1 / canonical / URL / visible-copy change.
- String → string edit; nothing to typecheck or test.
- `/about` GSC (28d before): 0 clicks / 64 impr / pos 1.4 (branded-navigational). Entity-consistency upside, no ranking exposure.

Logged in `seo-tracking/changelog.md` (2026-07-15).