### PR TITLE
🎨 Palette: Improve accessibility of ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2026-07-15 - Modal Dialog Accessibility
+**Learning:** Custom modal dialogs (like ResponsiveConfirmDialog) need explicit focus management. Adding `tabIndex={-1}` and auto-focusing on mount ensures screen readers announce the dialog. Additionally, handling the Escape key to close the dialog and ensuring visible focus states (`focus-visible:ring-2`) on custom buttons are critical for keyboard navigation.
+**Action:** Always include focus trapping/auto-focus, Escape key event listeners, and visible focus rings when building custom modal or dialog components.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,24 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -66,6 +84,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
         aria-modal="true"
         aria-labelledby="dialog-title"
         aria-describedby="dialog-description"
+      tabIndex={-1}
+      ref={dialogRef}
       >
         {/* Dialog Content */}
         <div
@@ -97,7 +117,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400 rounded transition-colors p-1 -mr-1"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -121,7 +141,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               onClick={onClose}
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
-                hover:bg-gray-50 active:bg-gray-100
+                hover:bg-gray-50 active:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -133,6 +153,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               disabled={isLoading}
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'}
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}


### PR DESCRIPTION
💡 What: Added focus management (auto-focusing the dialog on open), Escape key handling to close the dialog, and visible focus states (`focus-visible`) to all interactive buttons in the ResponsiveConfirmDialog component.
🎯 Why: Custom modals often break keyboard navigation and screen reader support if they don't explicitly manage focus or handle the Escape key. The custom styled buttons also lacked visible focus indicators when navigated via keyboard.
📸 Before/After: Before, opening the dialog did not trap focus, pressing Escape did nothing, and tabbing to buttons showed no clear outline. After, the dialog is focused on open, Escape closes it, and clear focus rings appear on buttons during keyboard navigation.
♿ Accessibility: Greatly improved keyboard and screen reader accessibility by ensuring the dialog is properly focused and announced, allowing cancellation via standard keyboard shortcuts, and restoring visible focus outlines for all interactive elements.

---
*PR created automatically by Jules for task [14774202405323689444](https://jules.google.com/task/14774202405323689444) started by @aafre*