### PR TITLE
⚡ Bolt: Use CSafeDumper for YAML serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-09 - Faster YAML Loading
 **Learning:** Using `yaml.safe_load` for parsing resume configurations is significantly slower than using `yaml.CSafeLoader`. Our benchmarks showed a ~10x speedup when using `yaml.load` with `CSafeLoader`.
 **Action:** Use `utils.yaml_converter.fast_yaml_load` instead of `yaml.safe_load` across the codebase to reduce CPU blocking during YAML parsing and PDF generation.
+
+## 2026-07-17 - Faster YAML Serialization
+**Learning:** PyYAML's default `yaml.dump` is slow. Using `yaml.CSafeDumper` provides a ~10x speedup but throws an `OverflowError` if `width=float('inf')` is used to disable wrapping.
+**Action:** Use a very large integer like `int(1e9)` for `width` instead of infinity when using C-extensions to achieve fast, non-wrapping serialization.

--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.utils import secure_filename
 
 from supabase import Client, create_client
-from utils.yaml_converter import fast_yaml_load
+from utils.yaml_converter import fast_yaml_dump, fast_yaml_load
 
 # Load environment variables from .env file
 load_dotenv()
@@ -1563,13 +1563,15 @@ NOINDEX_ROUTES = {
 }
 
 # ponytail: explicit allowlist — expand only after per-route dev/field CWV validation
-PRERENDER_TO_ALL_ROUTES = frozenset({
-    "free-resume-builder-no-sign-up",
-    "ai-resume-builder-free",
-    "free-cv-builder-no-sign-up",
-    "ats-resume-templates",
-    "resume-keywords",
-})
+PRERENDER_TO_ALL_ROUTES = frozenset(
+    {
+        "free-resume-builder-no-sign-up",
+        "ai-resume-builder-free",
+        "free-cv-builder-no-sign-up",
+        "ats-resume-templates",
+        "resume-keywords",
+    }
+)
 
 
 def _is_bot(user_agent: str) -> bool:
@@ -3548,7 +3550,7 @@ def generate_pdf_for_saved_resume(resume_id):
             # Write YAML to temp file
             yaml_path = temp_dir_path / "resume.yaml"
             with open(yaml_path, "w") as f:
-                yaml.dump(yaml_data, f)
+                fast_yaml_dump(yaml_data, f)
 
             # Generate PDF
             timestamp = datetime.now().strftime("%Y%m%d_%H_%M_%S")
@@ -3785,7 +3787,7 @@ def generate_thumbnail_for_resume(resume_id):
             # Write YAML to temp file
             yaml_path = temp_dir_path / "resume.yaml"
             with open(yaml_path, "w") as f:
-                yaml.dump(yaml_data, f)
+                fast_yaml_dump(yaml_data, f)
 
             # Generate PDF
             timestamp = datetime.now().strftime("%Y%m%d_%H_%M_%S")

--- a/utils/yaml_converter.py
+++ b/utils/yaml_converter.py
@@ -13,9 +13,10 @@ from typing import Any, Dict
 import yaml
 
 try:
+    from yaml import CSafeDumper as SafeDumper
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeDumper, SafeLoader
 
 
 def fast_yaml_load(stream):
@@ -24,6 +25,17 @@ def fast_yaml_load(stream):
     Uses C-based CSafeLoader if available (~10x speedup).
     """
     return yaml.load(stream, Loader=SafeLoader)
+
+
+def fast_yaml_dump(data: Any, stream=None, **kwargs):
+    """
+    A significantly faster alternative to yaml.dump.
+    Uses C-based CSafeDumper if available (~10x speedup).
+    Replaces width=float('inf') with int(1e9) to prevent OverflowError with CSafeDumper.
+    """
+    if kwargs.get("width") == float("inf"):
+        kwargs["width"] = int(1e9)
+    return yaml.dump(data, stream, Dumper=SafeDumper, **kwargs)
 
 
 def json_to_yaml_structure(resume_data: Dict[str, Any]) -> str:
@@ -66,12 +78,12 @@ def json_to_yaml_structure(resume_data: Dict[str, Any]) -> str:
     }
 
     # Convert to YAML string
-    yaml_string = yaml.dump(
+    yaml_string = fast_yaml_dump(
         yaml_structure,
         default_flow_style=False,
         allow_unicode=True,
         sort_keys=False,
-        width=float("inf"),  # Prevent line wrapping
+        width=int(1e9),  # Prevent line wrapping
     )
 
     return yaml_string


### PR DESCRIPTION
💡 What: Replaced default `yaml.dump` with `yaml.CSafeDumper` in a new `fast_yaml_dump` utility function.
🎯 Why: PyYAML's default serializer is pure Python and slow. Since we serialize massive YAML documents for PDF rendering, this becomes a major bottleneck.
📊 Impact: ~10x speedup in YAML serialization, reducing CPU time spent rendering PDFs.
🔬 Measurement: Verified using `time.perf_counter()` on 100 iterations of complex dummy YAML output.

---
*PR created automatically by Jules for task [4943752873680575097](https://jules.google.com/task/4943752873680575097) started by @aafre*