### PR TITLE
🎨 Palette: Enhance accessibility for ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-17 - Accessibility enhancements for custom Modals
+**Learning:** Custom dialogs built with React need explicit focus management (auto-focusing on mount) and keyboard event listeners (Escape key to close) to be accessible. Standard Tailwind `shadow-md` buttons often lose default browser outlines and require explicit `focus-visible:ring` classes.
+**Action:** Always place hooks before early returns (like `if (!isOpen) return null;`), add `tabIndex={-1}` to programmatic focus targets, and ensure custom action buttons have explicit `focus:outline-none focus-visible:ring-2` utilities.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,26 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Handle Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isOpen && e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Auto-focus container when opened
+  useEffect(() => {
+    if (isOpen && containerRef.current) {
+      containerRef.current.focus();
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -61,11 +81,14 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
         className="fixed z-[9999]
           bottom-0 left-0 right-0
           lg:inset-0 lg:flex lg:items-center lg:justify-center
-          animate-slide-up lg:animate-fade-in"
+          animate-slide-up lg:animate-fade-in
+          outline-none"
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
         aria-describedby="dialog-description"
+        tabIndex={-1}
+        ref={containerRef}
       >
         {/* Dialog Content */}
         <div
@@ -97,7 +120,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,6 +146,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
@@ -134,6 +158,9 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 ${
+                  isDestructive ? "focus-visible:ring-red-500" : "focus-visible:ring-accent"
+                } focus-visible:ring-offset-2
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}


### PR DESCRIPTION
### 💡 What
Enhanced the `ResponsiveConfirmDialog` component to improve keyboard accessibility and focus management.

### 🎯 Why
Custom dialogs need explicit focus management to be fully accessible to keyboard and screen reader users. Previously, the dialog did not trap or auto-focus, and the action buttons lacked distinct focus indicators when navigated via keyboard.

### 📸 Before/After
*(Visuals provided via Playwright verification video)*
**Before:** Modal did not respond to the Escape key, and tabbing through buttons did not show a clear focus ring.
**After:** Modal auto-focuses on open, closes with the Escape key, and all interactive buttons (Cancel, Confirm, Close) display clear, context-aware `focus-visible` rings (red for destructive actions, blue/accent for standard).

### ♿ Accessibility
- Added `tabIndex={-1}` and auto-focus on mount for the dialog container.
- Added Escape key listener to close the dialog.
- Added explicitly defined `focus-visible:ring-2` states for all action buttons.

---
*PR created automatically by Jules for task [8003295297138772809](https://jules.google.com/task/8003295297138772809) started by @aafre*