### PR TITLE
🎨 Palette: Add delete confirmation to SectionControls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-18 - ResponsiveConfirmDialog for SectionControls
+**Learning:** Destructive actions like deleting a section were missing a confirmation dialog, leading to potential accidental data loss without a way to recover.
+**Action:** Used `ResponsiveConfirmDialog` in `SectionControls` to add a confirmation prompt before deleting sections, ensuring a safer and more consistent user experience.

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,7 +27,6 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
-    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,6 +27,7 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
+    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
@@ -13,13 +14,17 @@ const SectionControls: React.FC<{
     setSections(newSections);
   };
 
+  const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
+
   const deleteSection = () => {
     const newSections = [...sections];
     newSections.splice(sectionIndex, 1);
     setSections(newSections);
+    setIsConfirmDeleteOpen(false);
   };
 
   return (
+    <>
     <div className="absolute top-4 right-4 flex gap-2">
       <button
         type="button"
@@ -53,12 +58,23 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsConfirmDeleteOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
     </div>
+    <ResponsiveConfirmDialog
+      isOpen={isConfirmDeleteOpen}
+      onClose={() => setIsConfirmDeleteOpen(false)}
+      onConfirm={deleteSection}
+      title="Delete Section?"
+      message="Are you sure you want to delete this section? This action cannot be undone."
+      confirmText="Delete"
+      cancelText="Cancel"
+      isDestructive={true}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
### 💡 What
Added a confirmation dialog when deleting sections from the resume editor by updating the `SectionControls` component to use the standard `ResponsiveConfirmDialog`.

### 🎯 Why
Deleting a section is a destructive action that removes a significant amount of user data (e.g., an entire work experience block or all education entries). Previously, clicking the "Delete" trashcan icon removed the section immediately without warning, leading to potential accidental data loss without an easy way to recover.

### 📸 Before/After
*(Verified via Playwright script internally)*
- **Before:** Clicking the trashcan icon instantly deletes the section.
- **After:** Clicking the trashcan icon opens a standard modal asking "Are you sure you want to delete this section?", requiring an explicit "Delete" or "Cancel" confirmation.

### ♿ Accessibility
- Uses the existing `ResponsiveConfirmDialog` which properly sets `role="dialog"`, `aria-modal="true"`, and manages focus to ensure keyboard accessibility and screen reader support when confirming destructive actions.

---
*PR created automatically by Jules for task [17488725865791417193](https://jules.google.com/task/17488725865791417193) started by @aafre*