### PR TITLE
🎨 Palette: Add keyboard accessibility to ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2026-07-19 - Keyboard Accessibility for Modals
+**Learning:** Custom React modals often lack proper focus management and keyboard interaction support (like Escape key to close). Adding `tabIndex={-1}` on the wrapper with auto-focus on mount, plus dedicated `useEffect` hooks for keyboard event listeners, ensures standard a11y compliance.
+**Action:** Always include focus management (`tabIndex`, auto-focusing `useRef`, Escape listeners) and explicitly define `focus-visible` outline utility classes on all interactive elements within custom UI overlays.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { MdWarning, MdClose } from "react-icons/md";
 
 interface ResponsiveConfirmDialogProps {
@@ -33,6 +33,27 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
   isDestructive = false,
   isLoading = false,
 }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Focus management - auto-focus dialog when it opens
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
+
+  // Handle Escape key to close dialog
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen && !isLoading) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isLoading, onClose]);
+
   if (!isOpen) return null;
 
   const handleConfirm = () => {
@@ -58,10 +79,12 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
       {/* Dialog Container - Bottom sheet on mobile, center modal on desktop */}
       <div
+        ref={modalRef}
+        tabIndex={-1}
         className="fixed z-[9999]
           bottom-0 left-0 right-0
           lg:inset-0 lg:flex lg:items-center lg:justify-center
-          animate-slide-up lg:animate-fade-in"
+          animate-slide-up lg:animate-fade-in focus:outline-none"
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
@@ -97,7 +120,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +146,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -134,7 +157,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]
+                min-h-[48px] lg:min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-600' : 'focus-visible:ring-accent'}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What: Added robust focus management and keyboard accessibility to `ResponsiveConfirmDialog`.
🎯 Why: Custom modals often trap users without standard keyboard interactions. This change auto-focuses the dialog, traps focus appropriately (or at least manages the wrapper), and allows users to dismiss it with the Escape key.
♿ Accessibility:
- Added `tabIndex={-1}` and auto-focus logic to the modal container.
- Added a `keydown` event listener for the `Escape` key to close the dialog.
- Added explicit `focus-visible` outline styles (Tailwind rings) to all interactive elements (Close, Cancel, Confirm buttons) to ensure clear visual indicators for keyboard navigation.

---
*PR created automatically by Jules for task [5534525558885397237](https://jules.google.com/task/5534525558885397237) started by @aafre*