### PR TITLE
🎨 Palette: Add section deletion confirmation and improve keyboard focus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-22 - Interactive Control Accessibility and Destructive Dialogs
+**Learning:** Custom Tailwind buttons (such as those in SectionControls) often lose browser default focus outlines, making keyboard navigation difficult. Furthermore, destructive actions in deeply nested components (like inline section deletion) often lack the global confirmations used at the page level.
+**Action:** Always explicitly include focus-visible utilities (e.g., focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2) on interactive elements. Consistently use ResponsiveConfirmDialog for all destructive actions, even inline ones, to prevent accidental data loss.

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -27,10 +30,10 @@ const SectionControls: React.FC<{
         title="Move section up"
         onClick={() => moveSection(sectionIndex, sectionIndex - 1)}
         disabled={sectionIndex === 0}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+        className={`p-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white transition-colors ${
           sectionIndex === 0
             ? "bg-gray-300 cursor-not-allowed text-gray-500"
-            : "bg-accent hover:bg-accent text-ink"
+            : "bg-accent hover:bg-accent/90 text-ink"
         }`}
       >
         <MdArrowUpward className="text-lg" />
@@ -41,10 +44,10 @@ const SectionControls: React.FC<{
         title="Move section down"
         onClick={() => moveSection(sectionIndex, sectionIndex + 1)}
         disabled={sectionIndex === sections.length - 1}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+        className={`p-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white transition-colors ${
           sectionIndex === sections.length - 1
             ? "bg-gray-300 cursor-not-allowed text-gray-500"
-            : "bg-accent hover:bg-accent text-ink"
+            : "bg-accent hover:bg-accent/90 text-ink"
         }`}
       >
         <MdArrowDownward className="text-lg" />
@@ -53,11 +56,22 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
-        className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
+        onClick={() => setIsConfirmOpen(true)}
+        className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white transition-colors"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
+
+      <ResponsiveConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={deleteSection}
+        title="Delete Section?"
+        message="Are you sure you want to delete this section? This action cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        isDestructive={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
💡 What: Wrapped the inline 'Delete section' button in `SectionControls.tsx` with a `ResponsiveConfirmDialog` and added `focus-visible` utilities to the interactive control buttons.
🎯 Why: Prevents accidental data loss when removing sections, ensuring consistency with page-level destructive actions. Additionally improves keyboard accessibility by providing clear visual focus indicators on custom styled buttons.
📸 Before/After: Visual changes include an explicit confirmation modal for deletion and high-contrast focus rings when tabbing through section controls.
♿ Accessibility: Ensures that keyboard users have clear indication of focused state via `focus-visible:ring-2 focus-visible:ring-offset-2`.

---
*PR created automatically by Jules for task [17616346542374786322](https://jules.google.com/task/17616346542374786322) started by @aafre*