### PR TITLE
🎨 Palette: Added Confirmation Dialog for Section Deletion

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-23 - Added Confirmation Dialog for Section Deletion
+**Learning:** The SectionControls component allowed users to delete an entire resume section with a single click. This was a destructive action that could easily lead to accidental data loss.
+**Action:** Used the existing `ResponsiveConfirmDialog` component to intercept the deletion, requiring the user to explicitly confirm before the section is permanently removed. This prevents accidental data loss and provides a consistent, accessible confirmation prompt.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+1. **Analyze UI for UX/accessibility opportunities**: I reviewed several components for missing accessibility states, tooltips, loading indicators, confirmation dialogs, etc.
+2. **Select the best enhancement**: The `SectionControls.tsx` component allows users to delete an entire resume section with a single click. This is a destructive action that can lead to data loss. Adding a confirmation dialog before deleting a section provides a significant UX improvement by preventing accidental data loss. It fits perfectly into the UX focus guidelines.
+3. **Implement the enhancement**: Modify `SectionControls.tsx` to use the existing `ResponsiveConfirmDialog` component.
+4. **Verify changes**: Ensure the component works correctly with tests/linting.
+5. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+6. **Submit PR**: Title "🎨 Palette: [UX improvement]".

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,7 +27,6 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
-    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,6 +27,7 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
+    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -13,14 +16,16 @@ const SectionControls: React.FC<{
     setSections(newSections);
   };
 
-  const deleteSection = () => {
+  const handleDeleteConfirm = () => {
     const newSections = [...sections];
     newSections.splice(sectionIndex, 1);
     setSections(newSections);
+    setIsDeleteDialogOpen(false);
   };
 
   return (
-    <div className="absolute top-4 right-4 flex gap-2">
+    <>
+      <div className="absolute top-4 right-4 flex gap-2">
       <button
         type="button"
         aria-label="Move section up"
@@ -53,12 +58,24 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsDeleteDialogOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
     </div>
+
+    <ResponsiveConfirmDialog
+      isOpen={isDeleteDialogOpen}
+      onClose={() => setIsDeleteDialogOpen(false)}
+      onConfirm={handleDeleteConfirm}
+      title="Delete Section?"
+      message="Are you sure you want to delete this section? This action cannot be undone."
+      confirmText="Delete"
+      cancelText="Cancel"
+      isDestructive={true}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
💡 What: Added a confirmation dialog using `ResponsiveConfirmDialog` before allowing users to delete a resume section from the `SectionControls` component.
🎯 Why: Deleting a section is a destructive action that previously happened instantly on click. Adding a confirmation prevents accidental data loss and aligns with our UX guidelines for destructive actions.
📸 Before/After: The deletion now triggers an accessible modal prompting for confirmation instead of immediately removing the data.
♿ Accessibility: Uses the existing, accessible `ResponsiveConfirmDialog` (which handles focus trapping and aria-roles) to ensure keyboard and screen reader users have a clear, safe interaction flow.

---
*PR created automatically by Jules for task [16661345527821906975](https://jules.google.com/task/16661345527821906975) started by @aafre*