### PR TITLE
fix(seo): add inbound internal links to reddit page

### DIFF
--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -565,16 +565,6 @@ export default function BestFreeResumeBuilders2026() {
           There&rsquo;s no single &ldquo;best&rdquo; resume builder &mdash; it depends on what you need:
         </p>
 
-        <p className="text-lg leading-relaxed text-stone-warm">
-          Community feedback can help narrow the choice, too: see{" "}
-          <Link
-            to="/best-free-resume-builder-reddit"
-            className="text-accent hover:underline"
-          >
-            which free resume builder Reddit users recommend
-          </Link>.
-        </p>
-
         <div className="space-y-4">
           {[
             {
@@ -627,6 +617,16 @@ export default function BestFreeResumeBuilders2026() {
             </div>
           ))}
         </div>
+
+        <p className="text-lg leading-relaxed text-stone-warm mt-6">
+          Community feedback can help narrow the choice, too: see{" "}
+          <Link
+            to="/best-free-resume-builder-reddit"
+            className="text-accent hover:underline"
+          >
+            which free resume builder Reddit users recommend
+          </Link>.
+        </p>
 
         {/* FAQ section */}
         <h2 className="text-3xl font-bold text-ink mt-12 mb-6">

--- a/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
+++ b/resume-builder-ui/src/components/blog/BestFreeResumeBuilders2026.tsx
@@ -565,6 +565,16 @@ export default function BestFreeResumeBuilders2026() {
           There&rsquo;s no single &ldquo;best&rdquo; resume builder &mdash; it depends on what you need:
         </p>
 
+        <p className="text-lg leading-relaxed text-stone-warm">
+          Community feedback can help narrow the choice, too: see{" "}
+          <Link
+            to="/best-free-resume-builder-reddit"
+            className="text-accent hover:underline"
+          >
+            which free resume builder Reddit users recommend
+          </Link>.
+        </p>
+
         <div className="space-y-4">
           {[
             {

--- a/resume-builder-ui/src/components/blog/EasyFreeResumeFreeBlog.tsx
+++ b/resume-builder-ui/src/components/blog/EasyFreeResumeFreeBlog.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import BlogLayout from "../BlogLayout";
 
 export default function EasyFreeResumeFreeBlog() {
@@ -31,6 +32,15 @@ export default function EasyFreeResumeFreeBlog() {
           </p>
           <p className="text-ink font-bold text-2xl">
             The answer is simple: <span className="text-accent">Yes. 100%. No catch.</span>
+          </p>
+          <p className="text-yellow-700 mt-3">
+            For a second opinion from job seekers, see{" "}
+            <Link
+              to="/best-free-resume-builder-reddit"
+              className="text-accent underline"
+            >
+              the free resume builder Reddit recommends
+            </Link>.
           </p>
         </div>
 

--- a/resume-builder-ui/src/components/blog/ResumeBuilderHiddenCosts.tsx
+++ b/resume-builder-ui/src/components/blog/ResumeBuilderHiddenCosts.tsx
@@ -77,9 +77,14 @@ export default function ResumeBuilderHiddenCosts() {
             <strong>13 charges a year</strong>, or about{" "}
             <strong>$337 annually</strong>. The "free" export is usually
             watermarked or restricted and unusable for real applications.
-            EasyFreeResume is
-            the genuinely free contrast: no trial, no credit card, no
-            watermark, no sign-up.
+            For a reality check on the "free" label, see{" "}
+            <Link
+              to="/best-free-resume-builder-reddit"
+              className="text-accent hover:underline"
+            >
+              what Reddit users recommend instead
+            </Link>. EasyFreeResume is the genuinely free contrast: no trial, no credit
+            card, no watermark, no sign-up.
           </p>
         </div>
 

--- a/resume-builder-ui/src/components/blog/ResumeBuilderHiddenCosts.tsx
+++ b/resume-builder-ui/src/components/blog/ResumeBuilderHiddenCosts.tsx
@@ -77,14 +77,15 @@ export default function ResumeBuilderHiddenCosts() {
             <strong>13 charges a year</strong>, or about{" "}
             <strong>$337 annually</strong>. The "free" export is usually
             watermarked or restricted and unusable for real applications.
-            For a reality check on the "free" label, see{" "}
+            EasyFreeResume is the genuinely free contrast: no trial, no credit
+            card, no watermark, no sign-up. For a reality check on the "free"
+            label, see{" "}
             <Link
               to="/best-free-resume-builder-reddit"
               className="text-accent hover:underline"
             >
               what Reddit users recommend instead
-            </Link>. EasyFreeResume is the genuinely free contrast: no trial, no credit
-            card, no watermark, no sign-up.
+            </Link>.
           </p>
         </div>
 

--- a/resume-builder-ui/src/components/blog/ResumeGeniusVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/ResumeGeniusVsEasyFreeResume.tsx
@@ -100,6 +100,15 @@ export default function ResumeGeniusVsEasyFreeResume() {
             "I spent an hour building my resume on Resume Genius, then found out I had to pay
             just to download it. Felt like a bait and switch."
           </p>
+          <p className="text-yellow-700 mt-3">
+            Before paying, compare it with{" "}
+            <Link
+              to="/best-free-resume-builder-reddit"
+              className="text-accent underline"
+            >
+              the builder r/resumes keeps pointing people to
+            </Link>.
+          </p>
         </div>
 
         <h2 className="text-3xl font-bold text-ink mt-12 mb-6">

--- a/resume-builder-ui/src/components/blog/ZetyVsEasyFreeResume.tsx
+++ b/resume-builder-ui/src/components/blog/ZetyVsEasyFreeResume.tsx
@@ -869,7 +869,14 @@ export default function ZetyVsEasyFreeResume() {
           For the vast majority of job seekers - especially those who value
           privacy, hate hidden fees, and want a straightforward tool to create a
           professional document -{" "}
-          <strong>a free builder is more than enough.</strong>
+          <strong>a free builder is more than enough.</strong> If you want
+          another perspective, see{" "}
+          <Link
+            to="/best-free-resume-builder-reddit"
+            className="text-accent underline"
+          >
+            what Reddit actually recommends for free resume builders
+          </Link>.
         </p>
 
         <p className="text-lg leading-relaxed text-stone-warm mt-6">


### PR DESCRIPTION
Adds one contextual in-body link to /best-free-resume-builder-reddit from five relevant blog pages. Anchor text varies by page and existing internal-link patterns are preserved. Verification: npm run build (120 sitemap URLs), npx vitest run (1474 passed, 23 skipped), and npx tsc -b.