### PR TITLE
🎨 Palette: Add confirmation dialog for deleting sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-25 - ResponsiveConfirmDialog for Destructive Actions Update
+**Learning:** Even internal app components like SectionControls require confirmation dialogs for destructive actions to maintain accessible and secure UX consistency, despite it seemingly slowing down the flow slightly.
+**Action:** Consistently replace simple JS 'confirm' dialogs or direct actions with `ResponsiveConfirmDialog` anywhere a destructive action like "Delete section" is present.

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,6 +27,7 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
+    "@tiptap/core": "^3.29.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/package.json
+++ b/resume-builder-ui/package.json
@@ -27,7 +27,6 @@
     "@supabase/supabase-js": "^2.89.0",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
-    "@tiptap/core": "^3.29.0",
     "@tiptap/extension-bold": "^3.10.7",
     "@tiptap/extension-bubble-menu": "^3.10.7",
     "@tiptap/extension-hard-break": "^3.10.7",

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
@@ -13,13 +14,17 @@ const SectionControls: React.FC<{
     setSections(newSections);
   };
 
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   const deleteSection = () => {
     const newSections = [...sections];
     newSections.splice(sectionIndex, 1);
     setSections(newSections);
+    setIsDeleteDialogOpen(false);
   };
 
   return (
+    <>
     <div className="absolute top-4 right-4 flex gap-2">
       <button
         type="button"
@@ -53,12 +58,23 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsDeleteDialogOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
     </div>
+
+    <ResponsiveConfirmDialog
+      isOpen={isDeleteDialogOpen}
+      onClose={() => setIsDeleteDialogOpen(false)}
+      onConfirm={deleteSection}
+      title="Delete Section"
+      message={`Are you sure you want to delete the "${sections[sectionIndex]?.name || 'this'}" section? This action cannot be undone.`}
+      confirmText="Delete Section"
+      isDestructive={true}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
Wrapped the destructive "Delete section" action in `SectionControls.tsx` with the standard `ResponsiveConfirmDialog`. This prevents users from accidentally deleting a resume section and losing their data with a single accidental click, improving data safety and usability. Reuses `ResponsiveConfirmDialog` which properly handles focus, provides accessible roles, and supports mobile interactions (bottom sheets) gracefully.

---
*PR created automatically by Jules for task [4719947518473271519](https://jules.google.com/task/4719947518473271519) started by @aafre*