### PR TITLE
feat(seo): restructure no-experience guide as 7-step how-to

### DIFF
--- a/resume-builder-ui/src/components/blog/ResumeNoExperience.tsx
+++ b/resume-builder-ui/src/components/blog/ResumeNoExperience.tsx
@@ -7,7 +7,7 @@ export default function ResumeNoExperience() {
       title="How to Write a Resume With No Experience (2026 Guide)"
       description="Step-by-step guide to writing a resume with no work experience. 5+ copy-paste examples, ATS-friendly template, and what to put instead of job history."
       publishDate="2026-01-20"
-      lastUpdated="2026-02-10"
+      lastUpdated="2026-07-25"
       readTime="14–18 min"
       keywords={[
         "entry level resume",
@@ -31,8 +31,9 @@ export default function ResumeNoExperience() {
         </p>
 
         <p className="text-lg leading-relaxed text-stone-warm">
-          This guide gives you copy-paste examples, role-specific keywords, and
-          a free ATS-friendly template you can use with our{" "}
+          This guide walks through how to build a resume with no experience,
+          step by step, with copy-paste examples, role-specific keywords, and a
+          free ATS-friendly template you can use with our{" "}
           <a
             href="/actual-free-resume-builder"
             className="text-accent hover:underline font-semibold"
@@ -51,8 +52,63 @@ export default function ResumeNoExperience() {
           </p>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          The Best Resume Format When You Have No Experience
+        {/* Step index — MUST stay in sync with the "Step 1-7" H2 ids below. */}
+        <nav className="bg-chalk-dark border border-black/[0.06] rounded-xl p-6 my-8">
+          <h2 className="text-xl font-bold text-ink mb-3">
+            How to Make a Resume With No Experience (7 Steps)
+          </h2>
+          <p className="text-ink/80 mb-4">
+            To create a resume with no work experience, lead with skills and
+            projects instead of job history. Pick a hybrid format, write a 2–3
+            sentence summary aimed at one specific role, then fill the page with
+            coursework, projects, volunteering, and part-time work – each
+            written as an action plus a measurable outcome. Here is the full
+            process, in order:
+          </p>
+          <ol className="space-y-2 text-ink/80 list-decimal list-inside">
+            <li>
+              <a href="#step-format" className="text-accent hover:underline">
+                Choose a format that leads with skills
+              </a>
+            </li>
+            <li>
+              <a href="#step-ats" className="text-accent hover:underline">
+                Make it ATS-friendly
+              </a>
+            </li>
+            <li>
+              <a href="#step-summary" className="text-accent hover:underline">
+                Write your professional summary
+              </a>
+            </li>
+            <li>
+              <a href="#step-bullets" className="text-accent hover:underline">
+                Write bullets with the action + outcome formula
+              </a>
+            </li>
+            <li>
+              <a href="#step-projects" className="text-accent hover:underline">
+                Use projects as your experience section
+              </a>
+            </li>
+            <li>
+              <a href="#step-skills" className="text-accent hover:underline">
+                Group the skills employers screen for
+              </a>
+            </li>
+            <li>
+              <a href="#step-keywords" className="text-accent hover:underline">
+                Mirror keywords from the job post
+              </a>
+            </li>
+          </ol>
+        </nav>
+
+        <h2
+          id="step-format"
+          className="text-3xl font-bold text-ink mt-12 mb-6"
+        >
+          Step 1: Choose the Best Resume Format When You Have No Experience
         </h2>
 
         <p className="text-lg leading-relaxed text-stone-warm mb-6">
@@ -89,8 +145,8 @@ export default function ResumeNoExperience() {
           </ol>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Make It ATS-Friendly (So You Get Seen)
+        <h2 id="step-ats" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 2: Make It ATS-Friendly (So You Get Seen)
         </h2>
 
         <div className="grid md:grid-cols-2 gap-6 my-8">
@@ -124,8 +180,8 @@ export default function ResumeNoExperience() {
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Professional Summary Examples (Copy-Paste)
+        <h2 id="step-summary" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 3: Write Your Professional Summary (Copy-Paste Examples)
         </h2>
 
         <p className="text-lg leading-relaxed text-stone-warm mb-6">
@@ -205,8 +261,8 @@ export default function ResumeNoExperience() {
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Bullet Formula (So Your Points Stand Out)
+        <h2 id="step-bullets" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 4: Write Bullets With the Action + Outcome Formula
         </h2>
 
         <div className="bg-accent/[0.06] border border-accent/20 rounded-xl p-6 my-6">
@@ -247,8 +303,8 @@ export default function ResumeNoExperience() {
           </p>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Projects: Your Fastest Path to Credibility
+        <h2 id="step-projects" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 5: Use Projects as Your Experience Section
         </h2>
 
         <p className="text-lg leading-relaxed text-stone-warm mb-6">
@@ -314,8 +370,8 @@ export default function ResumeNoExperience() {
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Skills That Win Entry-Level Interviews
+        <h2 id="step-skills" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 6: Group the Skills That Win Entry-Level Interviews
         </h2>
 
         <p className="text-lg leading-relaxed text-stone-warm mb-6">
@@ -343,8 +399,8 @@ export default function ResumeNoExperience() {
           </div>
         </div>
 
-        <h2 className="text-3xl font-bold text-ink mt-12 mb-6">
-          Role-Specific Keywords (Use Naturally)
+        <h2 id="step-keywords" className="text-3xl font-bold text-ink mt-12 mb-6">
+          Step 7: Mirror Role-Specific Keywords From the Job Post
         </h2>
 
         <p className="text-lg leading-relaxed text-stone-warm mb-6">

--- a/resume-builder-ui/src/data/sitemapUrls.ts
+++ b/resume-builder-ui/src/data/sitemapUrls.ts
@@ -66,7 +66,7 @@ export const STATIC_URLS: SitemapUrl[] = [
 
   // Blog Posts (0.5) - being updated with content refreshes
   { loc: '/blog/resume-keywords-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-03-22' },
-  { loc: '/blog/resume-no-experience', priority: 0.5, changefreq: 'monthly', lastmod: '2026-02-10' },
+  { loc: '/blog/resume-no-experience', priority: 0.5, changefreq: 'monthly', lastmod: '2026-07-25' },
   { loc: '/blog/job-interview-guide', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/ats-resume-optimization', priority: 0.5, changefreq: 'monthly', lastmod: '2026-01-25' },
   { loc: '/blog/ats-formatting-rules', priority: 0.5, changefreq: 'monthly', lastmod: '2026-07-01' },


### PR DESCRIPTION
## Why

`/blog/resume-no-experience` sits at the bottom of page 2 for a genuinely winnable, **100% non-branded** query cluster. Live GSC (28d, Jun 26 – Jul 23, pulled 2026-07-25): **98 impressions / 0 clicks / pos 32.8**.

Query breakdown for the page (76 imp attributed, 0 clicks):

| Query | Imp | Pos |
|---|---|---|
| how to create a resume with no experience | 15 | 20.2 |
| easy resume | 14 | 30.7 |
| how to make a resume with no experience | 11 | 29.5 |
| how to build resume with no experience | 10 | 17.9 |
| how to build a resume with no experience | 8 | 17.2 |
| no experience resume | 4 | 20.5 |
| + 8 long-tail build/create/make variants | 8 | 16–25 |

**50 of 76 impressions are `how to build/create/make a resume with no experience`.** This is a ranking problem, not a CTR problem — zero clicks at position 17–20 is arithmetic.

## The gap

The page is 903 lines and not thin, so "add words" is the wrong instinct. The actual mismatch: it ranks for **how-to** queries but reads as a **topical reference guide**. No numbered procedure, no step headings, no anchors, no answer block. Every page-1 result for these queries (Indeed, Zety, Coursera, Novoresume) is a step-by-step walkthrough.

## The change (one intervention)

Convert the page into the how-to it already ranks for, without rewriting it:

- The seven existing sections are renumbered **Step 1–7** with `id` anchors — **no sections reordered, no body content rewritten**. The existing order already reads as a procedure (format → ATS → summary → bullets → projects → skills → keywords).
- A step index with a concise answer paragraph is added above Step 1, carrying the `make` / `create` / `build` phrasing in an H2 and in the first ~100 words.
- `lastUpdated` → 2026-07-25, `lastmod` in `sitemapUrls.ts` → 2026-07-25.

Net: +74 / −18 lines.

## Deliberately not included

Per the one-change-at-a-time guardrail, so the position delta is attributable:

- **No title/H1 change.** The page ranks 17.2 for "how to *build*…" while titled "How to *Write*…", so the verb is not the ceiling; changing it risks the ranking it already has.
- **No `howToSteps` / `faqs` schema.** Google deprecated HowTo rich results; the props exist and can be added in a follow-up once the structural change is measured.
- **No internal-linking or meta-description pass.**

## Governance

- Not in `protected-pages.md` Tier 1/2; no recent changelog entries → no activation window to respect.
- Before-stats recorded in `seo-tracking/changelog.md`.
- URL unchanged (not a redirect source, already in sitemap).
- Pre-existing `border-l-4` design-hook findings in this file left untouched — out of scope.

## Verification

```
$ npx tsc -b        → exit 0, no output
$ npx vitest run    → 73 passed | 3 skipped (76 files)
                      1474 passed | 23 skipped (1497 tests)
```

**Do not merge without owner approval.** Watch GSC for 3 weeks; the read is whether the `build`/`create` head terms cross from 17–20 into the top 10.
