### PR TITLE
🎨 Palette: [UX improvement] Add confirmation dialog for deleting sections

### DIFF
--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -53,11 +56,23 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsDeleteDialogOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />
       </button>
+      <ResponsiveConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={() => {
+          deleteSection();
+          setIsDeleteDialogOpen(false);
+        }}
+        title="Delete Section"
+        message="Are you sure you want to delete this section? This action cannot be undone."
+        confirmText="Delete Section"
+        isDestructive={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
💡 **What:** Added a confirmation dialog using `ResponsiveConfirmDialog` before a section can be deleted in the editor.
🎯 **Why:** To prevent users from accidentally deleting a section and losing their data. Destructive actions should have a clear confirmation step.
♿ **Accessibility:** Leverages the existing `ResponsiveConfirmDialog` which provides proper `role="dialog"`, `aria-modal`, focus trapping, and mobile responsiveness out of the box, ensuring the confirmation step is fully accessible.

---
*PR created automatically by Jules for task [17923207384993997514](https://jules.google.com/task/17923207384993997514) started by @aafre*