### PR TITLE
🎨 Palette: Add focus-visible states to ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-07-29 - Focus states for interactive components
+**Learning:** Custom Tailwind buttons (especially in reusable components like ResponsiveConfirmDialog) can lose default browser focus outlines. This breaks keyboard accessibility on critical destructive flows.
+**Action:** Always explicitly include `focus-visible:outline-none focus-visible:ring-2` (and optionally `focus-visible:ring-offset-2`) utilities with appropriate colors when creating interactive elements or custom buttons to ensure clear visual indicators for keyboard users.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -42,8 +42,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -123,7 +123,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}


### PR DESCRIPTION
### 💡 What
Added `focus-visible` Tailwind classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`) to all interactive buttons (Cancel, Confirm, Close, Delete) in the `ResponsiveConfirmDialog` component.

### 🎯 Why
Custom Tailwind buttons often lose their default browser focus outlines. Since `ResponsiveConfirmDialog` handles critical and often destructive actions (like deleting a resume), it is essential that keyboard navigators clearly see which button is actively focused to prevent accidental deletions.

### ♿ Accessibility
This enhancement restores keyboard accessibility standard compliance by providing high-contrast visual focus rings to interactive elements, enabling confident navigation for non-mouse users.

---
*PR created automatically by Jules for task [7646497663567242609](https://jules.google.com/task/7646497663567242609) started by @aafre*