### PR TITLE
🎨 Palette: [UX improvement] Add confirmation dialog for deleting sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2025-02-14 - Accessible Destruction Confirmations
+**Learning:** Destructive actions (like deleting entire sections in `SectionControls`) lacked accessible confirmations. `ResponsiveConfirmDialog` is our standard for this, preventing accidental data loss and providing a mobile-friendly bottom sheet pattern.
+**Action:** Always implement `ResponsiveConfirmDialog` (or similar standard accessible dialogs) for destructive actions rather than immediate unconfirmed execution, ensuring users are warned effectively.

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MdArrowUpward, MdArrowDownward, MdDeleteOutline } from 'react-icons/md';
+import ResponsiveConfirmDialog from './ResponsiveConfirmDialog';
 
 const SectionControls: React.FC<{
   sectionIndex: number;
   sections: any[];
   setSections: (sections: any[]) => void;
 }> = ({ sectionIndex, sections, setSections }) => {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   const moveSection = (fromIndex: number, toIndex: number) => {
     const newSections = [...sections];
     const [removedSection] = newSections.splice(fromIndex, 1);
@@ -19,8 +22,20 @@ const SectionControls: React.FC<{
     setSections(newSections);
   };
 
+  const sectionName = sections[sectionIndex]?.name || 'this section';
+
   return (
     <div className="absolute top-4 right-4 flex gap-2">
+      <ResponsiveConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={deleteSection}
+        title="Delete Section?"
+        message={`Are you sure you want to delete ${sectionName}?\nThis will permanently remove the section and all its contents.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        isDestructive={true}
+      />
       <button
         type="button"
         aria-label="Move section up"
@@ -53,7 +68,7 @@ const SectionControls: React.FC<{
         type="button"
         aria-label="Delete section"
         title="Delete section"
-        onClick={deleteSection}
+        onClick={() => setIsDeleteDialogOpen(true)}
         className="p-2 rounded bg-red-500 hover:bg-red-600 text-white focus-visible:ring-2 focus-visible:ring-red-600"
       >
         <MdDeleteOutline className="text-lg" />


### PR DESCRIPTION
💡 What: Added `ResponsiveConfirmDialog` to the `SectionControls` component to confirm before a section is deleted.
🎯 Why: Prevents accidental data loss by immediately executing a destructive action. The `ResponsiveConfirmDialog` also provides a mobile-friendly bottom sheet and is built with accessibility in mind (ARIA attributes).
📸 Before/After: Clicking the delete (trash can) icon in a section previously instantly deleted the section. Now, it pops up a confirmation modal asking the user to confirm.
♿ Accessibility: Uses the standard accessible `ResponsiveConfirmDialog` which contains correct `role="dialog"`, `aria-modal="true"`, and focuses effectively.

---
*PR created automatically by Jules for task [3648770175073019956](https://jules.google.com/task/3648770175073019956) started by @aafre*