### PR TITLE
🎨 Palette: Add focus states and safe autofocus to confirmation dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2026-07-31 - Dialog Keyboard Accessibility & Safety
+**Learning:** Custom Tailwind buttons often lose default browser focus outlines. Always explicitly include `focus-visible` utilities (e.g., `focus-visible:ring-2`) to ensure clear visual indicators for keyboard navigation. Additionally, placing `autoFocus` on the safe "Cancel" action in destructive dialogs prevents users from accidentally confirming a destructive action (like deleting a resume) by pressing Enter when the dialog appears.
+**Action:** Always verify focus indicators on interactive elements in modals. Standardize using `focus-visible` for focus states and intentionally setting `autoFocus` on safe actions in confirmation dialogs.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -42,8 +42,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-600"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -120,10 +120,11 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -134,7 +135,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]
+                min-h-[48px] lg:min-h-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 **What**: Added visible focus states to the buttons in `ResponsiveConfirmDialog` and `autoFocus` to the Cancel button.
🎯 **Why**: Tailwind often removes default browser outlines on buttons, hurting keyboard accessibility. Adding `autoFocus` to the safe option in destructive dialogs is a standard pattern to prevent accidental data loss.
♿ **Accessibility**: Improved keyboard navigation inside modals and added safety against accidental Enter key presses.

---
*PR created automatically by Jules for task [12195399761641285229](https://jules.google.com/task/12195399761641285229) started by @aafre*