### PR TITLE
🎨 Palette: Add keyboard focus styles to LinkInsertionModal buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2026-08-02 - Focus States in Modals
+**Learning:** Custom interactive elements (like the action buttons in the `LinkInsertionModal.tsx`) often lose clear focus styles, breaking keyboard navigation expectations. The default browser focus ring might be removed or obscured by Tailwind's resets and custom button styling (`bg-accent`, `bg-red-500`, etc.), leaving keyboard users (and those depending on screen readers) with no visual indication of their current position within the modal dialog.
+**Action:** Always verify keyboard accessibility (`Tab` key navigation) for custom dialogs and modal action buttons. Explicitly add focus-visible styles (e.g., `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2`) to all interactive elements to ensure a clear, consistent focus indicator across the application.

--- a/resume-builder-ui/src/components/LinkInsertionModal.tsx
+++ b/resume-builder-ui/src/components/LinkInsertionModal.tsx
@@ -167,7 +167,7 @@ export const LinkInsertionModal: React.FC<LinkInsertionModalProps> = ({
         <div className="flex gap-3 mt-6">
           <button
             onClick={handleInsert}
-            className="flex-1 bg-accent text-ink px-6 py-3 rounded-lg font-semibold hover:shadow-lg transition-all duration-200"
+            className="flex-1 bg-accent text-ink px-6 py-3 rounded-lg font-semibold hover:shadow-lg transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
           >
             {isEditMode ? 'Update Link' : 'Insert Link'}
           </button>
@@ -177,7 +177,7 @@ export const LinkInsertionModal: React.FC<LinkInsertionModalProps> = ({
                 onRemove();
                 onClose();
               }}
-              className="px-6 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-all duration-200"
+              className="px-6 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
               title="Remove Link"
             >
               Remove
@@ -185,7 +185,7 @@ export const LinkInsertionModal: React.FC<LinkInsertionModalProps> = ({
           )}
           <button
             onClick={onClose}
-            className="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-all duration-200"
+            className="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
           >
             Cancel
           </button>


### PR DESCRIPTION
💡 What: Added standard `focus-visible` Tailwind classes to the action buttons (Insert, Remove, Cancel) in `LinkInsertionModal.tsx`.
🎯 Why: Custom styled buttons often lose their default browser focus ring. This makes keyboard navigation difficult or impossible for users who rely on it (like screen reader users or power users navigating via the Tab key).
📸 Before/After: Visual focus rings are now clearly visible when tab-navigating through the modal buttons.
♿ Accessibility: Improves keyboard navigation accessibility by providing a clear, high-contrast visual indicator of the currently focused element.

---
*PR created automatically by Jules for task [2119262363923384528](https://jules.google.com/task/2119262363923384528) started by @aafre*