### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible and autoFocus to ResponsiveConfirmDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Accessible Buttons in Dialogs
+**Learning:** Buttons in custom dialogs often lack visible focus states, which impairs keyboard accessibility. Destructive actions in dialogs need safe cancellation paths; adding `autoFocus` to the Cancel button prevents accidental confirmation on component mount.
+**Action:** Always add `focus-visible` utilities to buttons in dialogs to ensure visual focus indicators, and apply `autoFocus` to the cancellation action in destructive confirmation dialogs.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -120,10 +120,12 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus={isDestructive}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -135,6 +137,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                ${isDestructive ? "focus-visible:ring-red-600" : "focus-visible:ring-accent"}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes to the interactive buttons (Close, Cancel, Confirm) in `ResponsiveConfirmDialog` and applied `autoFocus` to the Cancel button when the dialog performs a destructive action.
🎯 Why: Buttons in custom dialogs often lack visible focus states, impairing keyboard navigation. Furthermore, destructive actions in dialogs require a safe cancellation path; focusing the Cancel button by default prevents accidental confirmation if a user rapidly hits Enter.
📸 Before/After: Screenshots were verified visually via Playwright in the verification phase.
♿ Accessibility: Improves keyboard navigation with clear focus indicators and enhances safety by defaulting focus to the non-destructive action.

---
*PR created automatically by Jules for task [5459586091856595070](https://jules.google.com/task/5459586091856595070) started by @aafre*