### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-09 - Faster YAML Loading
 **Learning:** Using `yaml.safe_load` for parsing resume configurations is significantly slower than using `yaml.CSafeLoader`. Our benchmarks showed a ~10x speedup when using `yaml.load` with `CSafeLoader`.
 **Action:** Use `utils.yaml_converter.fast_yaml_load` instead of `yaml.safe_load` across the codebase to reduce CPU blocking during YAML parsing and PDF generation.
+
+## 2025-03-09 - Faster YAML Dumping
+**Learning:** The default `yaml.dump` is pure Python and very slow. Using `yaml.dump` with `CSafeDumper` provides significant speedups during serialization. `CSafeDumper` throws an error if `width=float('inf')` is passed, so `width=int(1e9)` must be used instead.
+**Action:** Created `fast_yaml_dump` utility in `utils/yaml_converter.py` and replaced usages of `yaml.dump` across backend to reduce blocking time.

--- a/app.py
+++ b/app.py
@@ -21,15 +21,8 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 import requests as http_requests
 import yaml
 from dotenv import load_dotenv
-from flask import (
-    Flask,
-    jsonify,
-    redirect,
-    request,
-    send_file,
-    send_from_directory,
-    url_for,
-)
+from flask import (Flask, jsonify, redirect, request, send_file,
+                   send_from_directory, url_for)
 from flask_compress import Compress
 from flask_cors import CORS
 from jinja2 import Environment, FileSystemLoader
@@ -37,7 +30,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.utils import secure_filename
 
 from supabase import Client, create_client
-from utils.yaml_converter import fast_yaml_load
+from utils.yaml_converter import fast_yaml_dump, fast_yaml_load
 
 # Load environment variables from .env file
 load_dotenv()
@@ -1563,13 +1556,15 @@ NOINDEX_ROUTES = {
 }
 
 # ponytail: explicit allowlist — expand only after per-route dev/field CWV validation
-PRERENDER_TO_ALL_ROUTES = frozenset({
-    "free-resume-builder-no-sign-up",
-    "ai-resume-builder-free",
-    "free-cv-builder-no-sign-up",
-    "ats-resume-templates",
-    "resume-keywords",
-})
+PRERENDER_TO_ALL_ROUTES = frozenset(
+    {
+        "free-resume-builder-no-sign-up",
+        "ai-resume-builder-free",
+        "free-cv-builder-no-sign-up",
+        "ats-resume-templates",
+        "resume-keywords",
+    }
+)
 
 
 def _is_bot(user_agent: str) -> bool:
@@ -3548,7 +3543,7 @@ def generate_pdf_for_saved_resume(resume_id):
             # Write YAML to temp file
             yaml_path = temp_dir_path / "resume.yaml"
             with open(yaml_path, "w") as f:
-                yaml.dump(yaml_data, f)
+                fast_yaml_dump(yaml_data, f)
 
             # Generate PDF
             timestamp = datetime.now().strftime("%Y%m%d_%H_%M_%S")
@@ -3785,7 +3780,7 @@ def generate_thumbnail_for_resume(resume_id):
             # Write YAML to temp file
             yaml_path = temp_dir_path / "resume.yaml"
             with open(yaml_path, "w") as f:
-                yaml.dump(yaml_data, f)
+                fast_yaml_dump(yaml_data, f)
 
             # Generate PDF
             timestamp = datetime.now().strftime("%Y%m%d_%H_%M_%S")

--- a/utils/yaml_converter.py
+++ b/utils/yaml_converter.py
@@ -13,9 +13,18 @@ from typing import Any, Dict
 import yaml
 
 try:
+    from yaml import CSafeDumper as SafeDumper
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeDumper, SafeLoader
+
+
+def fast_yaml_dump(data, stream=None, **kwargs):
+    """
+    A significantly faster alternative to yaml.dump.
+    Uses C-based CSafeDumper if available.
+    """
+    return yaml.dump(data, stream, Dumper=SafeDumper, **kwargs)
 
 
 def fast_yaml_load(stream):
@@ -66,12 +75,13 @@ def json_to_yaml_structure(resume_data: Dict[str, Any]) -> str:
     }
 
     # Convert to YAML string
-    yaml_string = yaml.dump(
+    yaml_string = fast_yaml_dump(
         yaml_structure,
+        stream=None,
         default_flow_style=False,
         allow_unicode=True,
         sort_keys=False,
-        width=float("inf"),  # Prevent line wrapping
+        width=int(1e9),  # Prevent line wrapping (CSafeDumper doesn't accept float)
     )
 
     return yaml_string


### PR DESCRIPTION
💡 What: Implemented a `fast_yaml_dump` utility that leverages PyYAML's C-based `CSafeDumper` (similar to the existing `fast_yaml_load` utility). Replaced instances of `yaml.dump` in `utils/yaml_converter.py` and `app.py`. Added a safe workaround by using `width=int(1e9)` instead of `float("inf")` as the C emitter does not accept float values.

🎯 Why: PyYAML's default pure Python `yaml.dump` is notoriously slow. During PDF generation, large YAML strings are written to disk. Using the C-based emitter significantly speeds up serialization and reduces event loop blocking time.

📊 Impact: Reduces CPU blocking during large resume configuration serialization before PDF generation. This acts as a direct continuation of the previous `yaml.safe_load` optimization.

🔬 Measurement: Check the time spent writing the YAML file in the `generate_pdf` route using profiling tools, or run a generic benchmark comparing `yaml.dump` with `CSafeDumper` vs standard `yaml.dump`.

---
*PR created automatically by Jules for task [12548694275466689033](https://jules.google.com/task/12548694275466689033) started by @aafre*