### PR TITLE
🎨 Palette: [UX improvement] Add autoFocus to safe cancellation actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2024-05-18 - autoFocus on Safe Actions
+**Learning:** In destructive confirmation dialogs (like `ResponsiveConfirmDialog`), users might accidentally press 'Enter' immediately after the dialog mounts, triggering the destructive action.
+**Action:** Always place `autoFocus` on the safe cancellation action (e.g., the 'Cancel' button) to prevent users from accidentally triggering the destructive action and ensure the focus state is clearly visible.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -120,10 +120,11 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}


### PR DESCRIPTION
💡 What: Added `autoFocus` and improved focus styling to the "Cancel" button in `ResponsiveConfirmDialog.tsx`.
🎯 Why: Prevents users from accidentally deleting data if they hit 'Enter' as the dialog opens. By defaulting focus to the safe action, we reduce the risk of unintended destructive actions.
♿ Accessibility: Improved keyboard accessibility by clearly indicating the focused element upon mount, guiding the user towards the safe option. Also added `focus:outline-none focus-visible:ring-2` to make the keyboard focus visible without adding a permanent ring for mouse users.

---
*PR created automatically by Jules for task [4187674013406178602](https://jules.google.com/task/4187674013406178602) started by @aafre*