### PR TITLE
🎨 Palette: Improve default focus for destructive dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2023-10-24 - Safe Default Focus for Destructive Dialogs
+**Learning:** In destructive confirmation dialogs (like `ResponsiveConfirmDialog`), if focus is not explicitly managed, users might accidentally trigger the destructive action by pressing 'Enter' immediately after the dialog mounts. Also, custom buttons often lose standard focus outlines.
+**Action:** Always place `autoFocus` on the safe cancellation action (e.g., the 'Cancel' button) in confirmation dialogs. Explicitly include focus-visible utilities (e.g., `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent`) on interactive elements to ensure clear visual indicators for keyboard navigation.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -120,8 +120,10 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -133,6 +135,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               disabled={isLoading}
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}


### PR DESCRIPTION
### 💡 What
Added `autoFocus` to the "Cancel" button within the `ResponsiveConfirmDialog` and explicitly defined `focus-visible` ring utilities on all interactive buttons (Cancel, Confirm, Close).

### 🎯 Why
When a destructive dialog (like confirming a deletion) opens, focus is easily lost or default-submitted if not explicitly managed. By putting default focus on the safe "Cancel" action, we prevent accidental data loss if a user happens to press "Enter" right as the dialog appears. Additionally, custom styled buttons often lose standard browser focus rings, so adding explicit `focus-visible` styles ensures keyboard users can clearly see where their focus is.

### 📸 Before/After
See attached verification screenshot demonstrating the clear `focus-visible` ring on the Cancel button upon dialog render.

### ♿ Accessibility
- Prevents accidental destructive actions for keyboard/screen reader users.
- Ensures clear, high-contrast visual focus indicators are present on all dialog actions.

---
*PR created automatically by Jules for task [6676542930566204152](https://jules.google.com/task/6676542930566204152) started by @aafre*