### PR TITLE
docs(design): establish PRODUCT.md and DESIGN.md as design authority

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,214 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-11T00:00:00.000Z",
+  "title": "Design System: EasyFreeResume",
+  "extensions": {
+    "colorMeta": {
+      "accent": {
+        "role": "primary",
+        "displayName": "Signal Green",
+        "canonical": "#00d47e",
+        "tonalRamp": ["#00281a", "#00432a", "#005f3b", "#007a48", "#009a5c", "#00b86e", "#00d47e", "#7ceab6"]
+      },
+      "accent-text": {
+        "role": "primary",
+        "displayName": "Deep Signal",
+        "canonical": "#007a48",
+        "tonalRamp": ["#00281a", "#00432a", "#005f3b", "#007a48", "#009a5c", "#00b86e", "#00d47e", "#7ceab6"]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "#0c0c0c",
+        "tonalRamp": ["#000000", "#0c0c0c", "#1a1a1a", "#333333", "#5c5c5c", "#8a8a8a", "#c2c2c2", "#f0f0f0"]
+      },
+      "ink-light": {
+        "role": "neutral",
+        "displayName": "Ink Light",
+        "canonical": "#1a1a1a",
+        "tonalRamp": ["#000000", "#0c0c0c", "#1a1a1a", "#333333", "#5c5c5c", "#8a8a8a", "#c2c2c2", "#f0f0f0"]
+      },
+      "chalk": {
+        "role": "neutral",
+        "displayName": "Chalk",
+        "canonical": "#fafaf8",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "chalk-dark": {
+        "role": "neutral",
+        "displayName": "Chalk Dark",
+        "canonical": "#f0efe9",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "stone-warm": {
+        "role": "neutral",
+        "displayName": "Stone Warm",
+        "canonical": "#8a8680",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#8a8680", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "mist": {
+        "role": "neutral",
+        "displayName": "Mist",
+        "canonical": "#a8a4a0",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page H1 only, one per page. Weight 800 against a 1.08 line-height." },
+      "headline": { "displayName": "Headline", "purpose": "Section H2s, always preceded by a mono eyebrow." },
+      "title": { "displayName": "Title", "purpose": "Card and panel H3s. Weight 700 marks it as interface, not prose." },
+      "body": { "displayName": "Body", "purpose": "Paragraphs and subtitles at weight 200. Constrain the measure to max-w-3xl/4xl." },
+      "label": { "displayName": "Mono Label", "purpose": "Section eyebrows and filing markers. Uppercase, 0.15em tracking, always Deep Signal." }
+    },
+    "shadows": [
+      { "name": "resting-app", "value": "0 1px 2px 0 rgba(0,0,0,0.05)", "purpose": "Baseline edge for cards inside the application. Establishes edge, not lift." },
+      { "name": "responsive-lift", "value": "0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)", "purpose": "The hover answer to resting-app. Always paired with transition-shadow duration-200." },
+      { "name": "premium-ambient", "value": "0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04)", "purpose": "Four-layer resting depth. Marketing feature cards only — never app surfaces." },
+      { "name": "premium-response", "value": "0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06)", "purpose": "Hover deepening with an accent bloom. The only sanctioned atmospheric use of green." },
+      { "name": "floating", "value": "0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1)", "purpose": "Genuinely detached elements: modals, toasts, drag overlays, the sticky header." },
+      { "name": "drag-overlay", "value": "0 25px 50px -12px rgba(0,0,0,0.25)", "purpose": "Item lifted under an active drag, paired with a 2px rgba(0,212,126,0.5) border." }
+    ],
+    "motion": [
+      { "name": "ease-premium", "value": "cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "The system's signature easing. Scroll reveals, premium shadow transitions, FAQ expansion, hero sequence." },
+      { "name": "duration-control", "value": "200ms", "purpose": "Buttons, nav links, inputs, and every other direct-manipulation control." },
+      { "name": "duration-surface", "value": "300ms", "purpose": "Card hovers, background and border transitions." },
+      { "name": "duration-glass", "value": "500ms", "purpose": "Glass and premium-shadow transitions, where slowness reads as weight." },
+      { "name": "duration-reveal", "value": "800ms", "purpose": "Scroll-triggered entrance animations." },
+      { "name": "press-response", "value": "scale(0.98)", "purpose": "Active-state compression on all three button variants. The core tactile cue." },
+      { "name": "reveal-stagger", "value": "0ms, 100ms, 180ms, 240ms, 300ms, 360ms, 400ms", "purpose": "Transition delays applied to nth-child of a [data-reveal-stagger] grid; clamps at 400ms from the seventh child on." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The system's one loud element. Signal Green fill, ink label, visible press compression.",
+      "html": "<button class=\"ds-btn-primary\">Create Free Resume</button>",
+      "css": ".ds-btn-primary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #00d47e; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 700; font-size: 1rem; border: none; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; overflow: hidden; transition: box-shadow 200ms, transform 200ms; } .ds-btn-primary:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-primary:active { transform: scale(0.98); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "White field with a near-invisible stroke. Same geometry and press response as primary.",
+      "html": "<button class=\"ds-btn-secondary\">Browse Templates</button>",
+      "css": ".ds-btn-secondary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #ffffff; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 600; font-size: 1rem; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; transition: box-shadow 200ms, border-color 200ms, transform 200ms; } .ds-btn-secondary:hover { border-color: #d1d5db; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-secondary:active { transform: scale(0.98); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Tertiary and navigation actions. No fill until touched.",
+      "html": "<button class=\"ds-btn-ghost\">Templates</button>",
+      "css": ".ds-btn-ghost { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 8px 12px; background: transparent; color: #374151; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 500; font-size: 0.875rem; border: none; border-radius: 8px; cursor: pointer; transition: background-color 200ms, color 200ms; } .ds-btn-ghost:hover { background: rgba(0,0,0,0.05); color: #0c0c0c; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Ghost Add Button",
+      "kind": "custom",
+      "refersTo": "button-ghost",
+      "description": "Signature affordance. Full-width dashed field meaning 'there could be more here'. The only sanctioned dashed border in the system.",
+      "html": "<button class=\"ds-btn-add\"><svg width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M12 5v14M5 12h14\"/></svg><span>Add Experience</span></button>",
+      "css": ".ds-btn-add { width: 100%; min-height: 44px; padding: 12px 16px; display: flex; align-items: center; justify-content: center; gap: 8px; background: transparent; color: #6b7280; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; border: 2px dashed #d1d5db; border-radius: 8px; cursor: pointer; transition: border-color 150ms, color 150ms, background-color 150ms; } .ds-btn-add:hover { border-color: rgba(0,212,126,0.7); color: #007a48; background: rgba(0,212,126,0.06); } .ds-btn-add:focus-visible { outline: none; box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #00d47e; } .ds-btn-add:disabled { opacity: 0.5; cursor: not-allowed; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input-field",
+      "description": "Wrapper-focused field. The ring lands on the container because several fields wrap rich-text editors rather than bare inputs.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">Job Title</span><input class=\"ds-input\" type=\"text\" placeholder=\"Senior Product Designer\" /></label>",
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 6px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-field-label { font-size: 0.875rem; font-weight: 500; color: #0c0c0c; } .ds-input { width: 100%; padding: 12px; font-size: 1rem; font-family: inherit; color: #0c0c0c; background: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; transition: box-shadow 200ms, border-color 200ms; } .ds-input::placeholder { color: #a8a4a0; } .ds-input:focus { outline: none; border-color: #00d47e; box-shadow: 0 0 0 2px #00d47e; }"
+    },
+    {
+      "name": "App Card",
+      "kind": "card",
+      "refersTo": "card-app",
+      "description": "The workbench surface. Flat at rest, lifts only on hover.",
+      "html": "<article class=\"ds-card-app\"><h3 class=\"ds-card-app-title\">Product Designer Resume</h3><p class=\"ds-card-app-meta\">Edited 2 days ago</p></article>",
+      "css": ".ds-card-app { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: box-shadow 200ms; } .ds-card-app:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-card-app-title { margin: 0 0 8px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-app-meta { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+    },
+    {
+      "name": "Marketing Feature Card",
+      "kind": "card",
+      "refersTo": "card-feature",
+      "description": "The one place resting depth is permitted. Four-layer shadow, gradient hairline border, hover lift with an accent bloom.",
+      "html": "<article class=\"ds-card-feature\"><h3 class=\"ds-card-feature-title\">No paywall at download</h3><p class=\"ds-card-feature-body\">Your PDF is generated and downloaded without payment, and without an account.</p></article>",
+      "css": ".ds-card-feature { position: relative; background: #ffffff; border: 1px solid transparent; border-radius: 16px; padding: 32px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04); transition: box-shadow 500ms cubic-bezier(0.16,1,0.3,1), transform 300ms cubic-bezier(0.16,1,0.3,1); } .ds-card-feature::before { content: ''; position: absolute; inset: -1px; border-radius: inherit; padding: 1px; background: linear-gradient(135deg, rgba(0,212,126,0.2), rgba(0,212,126,0.12), rgba(0,212,126,0.2)); -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: xor; mask-composite: exclude; pointer-events: none; } .ds-card-feature:hover { transform: translateY(-4px); box-shadow: 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06); } .ds-card-feature-title { margin: 0 0 12px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-feature-body { margin: 0; font-size: 1.125rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+    },
+    {
+      "name": "Resource Card",
+      "kind": "card",
+      "refersTo": "card-resource",
+      "description": "Brightens toward the user on hover rather than lifting. Chalk Dark resting fill resolving to white.",
+      "html": "<a class=\"ds-card-resource\" href=\"#\"><h3 class=\"ds-card-resource-title\">Resume Keywords Guide</h3><p class=\"ds-card-resource-body\">Which terms an ATS actually scores, by industry.</p></a>",
+      "css": ".ds-card-resource { display: block; background: #f0efe9; border: 1px solid transparent; border-radius: 12px; padding: 20px; text-decoration: none; font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: background-color 300ms, box-shadow 300ms, border-color 300ms; } .ds-card-resource:hover { background: #ffffff; border-color: rgba(0,0,0,0.04); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); } .ds-card-resource:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; } .ds-card-resource-title { margin: 0 0 4px; font-size: 1rem; font-weight: 700; color: #0c0c0c; } .ds-card-resource-body { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+    },
+    {
+      "name": "Section Eyebrow",
+      "kind": "custom",
+      "refersTo": "label",
+      "description": "The filing label that opens every section. Mono, uppercase, wide tracking, always Deep Signal — never Signal Green.",
+      "html": "<div class=\"ds-section-head\"><p class=\"ds-eyebrow\">How it works</p><h2 class=\"ds-h2\">Three steps to a finished PDF</h2><p class=\"ds-sub\">No account, no trial, no card.</p></div>",
+      "css": ".ds-section-head { font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-eyebrow { margin: 0 0 16px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.75rem; font-weight: 400; letter-spacing: 0.15em; text-transform: uppercase; color: #007a48; } .ds-h2 { margin: 0 0 16px; font-size: 2.25rem; font-weight: 800; line-height: 1.15; letter-spacing: -0.025em; color: #0c0c0c; } .ds-sub { margin: 0; font-size: 1.25rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+    },
+    {
+      "name": "Ad Surface",
+      "kind": "custom",
+      "refersTo": "card-app",
+      "description": "Ads fund the product's central promise, so they are a designed component. Labelled, bordered, and reserving its own space when unfilled.",
+      "html": "<div class=\"ds-ad-surface\"></div>",
+      "css": ".ds-ad-surface { position: relative; min-height: 250px; border: 1px solid rgba(15,23,42,0.08); border-radius: 8px; background: linear-gradient(180deg, rgba(248,250,252,0.88), rgba(255,255,255,0.96)), repeating-linear-gradient(135deg, rgba(15,23,42,0.035) 0 1px, transparent 1px 12px); box-shadow: inset 0 1px 0 rgba(255,255,255,0.75); } .ds-ad-surface::before { content: 'Advertisement'; position: absolute; top: 0.5rem; left: 0.75rem; z-index: 1; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.625rem; font-weight: 700; letter-spacing: 0.08em; line-height: 1; text-transform: uppercase; color: rgba(71,85,105,0.72); pointer-events: none; } .ds-ad-surface:empty::after { content: ''; position: absolute; inset: 2.25rem 0.75rem 0.75rem; border-radius: 6px; background: rgba(255,255,255,0.44); pointer-events: none; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Honest Workshop",
+    "overview": "A well-lit workbench, not a showroom. The surfaces are paper-white and slightly warm, the tools sit out in the open where you can see them, and nothing is hidden behind glass or held back for a fee. This is the visual argument the product has to make before it makes any other one: a visitor arrives here having been burned by a builder that let them do the work and then asked for money at the download button. Every design decision either supports the claim that there is nothing behind the curtain, or it undermines it.\n\nThe system gets its force from typography, not decoration. Headings are set at weight 800 and body text at weight 200 — a gap wide enough that the page has an obvious spine and nothing else has to compete for attention. Backgrounds stay in a narrow band of warm off-whites, so the eye reads structure from type size and spacing rather than from boxes and rules. Green appears rarely, and when it does it means something is live, passing, or actionable. Depth is earned: surfaces sit flat until you touch them.\n\nComponents feel tactile and confident. Targets are generous (44px minimum, everywhere, including the dense editor), presses respond visibly, and states are unambiguous. The audience includes people writing their first resume at 11pm and unsure whether they are doing it right, so the interface must feel forgiving to touch rather than delicate and expensive.",
+    "keyCharacteristics": [
+      "Light-dominant: warm off-white grounds (#fafaf8, #f0efe9), near-black ink, no dark mode",
+      "Extreme type contrast: weight 800 against weight 200, with nothing decorative in between",
+      "One accent, used as a signal rather than as a brand wash",
+      "Flat at rest; shadow is a response to state, not a property of cards",
+      "Generous, unambiguous touch targets — confidence through hand-feel, not ornament",
+      "Two typefaces only: Bricolage Grotesque (variable, 200–800) and JetBrains Mono for labels"
+    ],
+    "rules": [
+      { "name": "The 10% Rule", "body": "Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, 'this passed' and 'click this' stop meaning anything.", "section": "colors" },
+      { "name": "The Deep Signal Rule", "body": "#00d47e on a light ground fails WCAG contrast for text (1.87:1 on chalk). Any accent-colored text below 24px uses #007a48 (text-accent-text) instead — 5.18:1, which clears AA. #00d47e is for fills only, where the surrounding text carries the contrast (ink on green measures 9.98:1). Note the accent focus ring at 1.87:1 does NOT meet the 3:1 focus-appearance threshold on light grounds; this is a known open finding.", "section": "colors" },
+      { "name": "The One Accent Rule", "body": "There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.", "section": "colors" },
+      { "name": "The Two-Weight Rule", "body": "Editorial type uses 800 or 200. Nothing in between. The intermediate weights (500/600/700) exist only for interface chrome — buttons, nav links, form labels, card titles — where they signal 'this is a control, not prose'. A 600-weight paragraph is off-system.", "section": "typography" },
+      { "name": "The Eyebrow Rule", "body": "Every section heading block runs mono eyebrow → H2 → subtitle paragraph, then a mb-12 md:mb-16 gap before content. The eyebrow is what makes a section feel filed rather than merely stacked, and it is set in Deep Signal, never Signal Green.", "section": "typography" },
+      { "name": "The Reserved Space Rule", "body": "Anything that arrives late — ads, images, async status, revealed sections — reserves its final height before it arrives. The scroll-reveal system animates opacity and transform only, never height or width, for exactly this reason. Ad slots carry explicit min-heights.", "section": "layout" },
+      { "name": "The Flat-At-Rest Rule", "body": "If a surface is not being interacted with and is not floating above the page, it has no shadow. A resting card that carries lift is claiming an importance it has not earned.", "section": "elevation" },
+      { "name": "The Glass Restraint Rule", "body": "backdrop-blur is reserved for elements that genuinely overlay content: the sticky header, toasts, modal scrims. Glass on a static in-flow card is decoration, and it costs paint performance on the editor's long lists.", "section": "elevation" },
+      { "name": "The 12px Default Rule", "body": "When unsure, use rounded-xl. Radius steps down to 8px for things you press and up to 16px/24px for things you look at.", "section": "shapes" }
+    ],
+    "dos": [
+      "Do use text-accent-text (#007a48) for any accent-colored text under 24px. text-accent is for fills, rings, and strokes.",
+      "Do keep every interactive control at min-h-11 (44px), including in the editor's densest rows.",
+      "Do pair .cv-auto with a .cv-h-* intrinsic-size class on every new below-fold section.",
+      "Do reserve explicit height for anything that loads late — ads, images, async status.",
+      "Do wrap below-fold marketing sections in <RevealSection>; the reveal system animates opacity and transform only, never geometry.",
+      "Do lead every section with the mono eyebrow → H2 → subtitle block.",
+      "Do use overflow: clip rather than overflow: hidden on layout containers — hidden silently creates a scroll container and has broken this app's flex layout before.",
+      "Do verify a design still works with the webfont unloaded; font-display: optional means it will be, for some visitors."
+    ],
+    "donts": [
+      "Don't use gray-* or slate-* for text or backgrounds on a migrated page. Use ink, stone-warm, mist, chalk, chalk-dark.",
+      "Don't let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.",
+      "Don't apply scroll reveals, hover lifts, or .shadow-premium to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.",
+      "Don't introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.",
+      "Don't reinstate the .btn-primary shimmer sweep. Its removal was deliberate.",
+      "Don't put a resting shadow on an app card.",
+      "Don't restyle, shrink, or remove ad surfaces for visual tidiness.",
+      "Don't introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.",
+      "Don't put unique or task-critical information in Mist. At 2.37:1 it fails every threshold.",
+      "Don't assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,319 @@
+---
+name: EasyFreeResume
+description: Light-dominant, type-led resume builder where green means "live" and nothing is hidden behind glass.
+colors:
+  ink: "#0c0c0c"
+  ink-light: "#1a1a1a"
+  chalk: "#fafaf8"
+  chalk-dark: "#f0efe9"
+  stone-warm: "#8a8680"
+  mist: "#a8a4a0"
+  accent: "#00d47e"
+  accent-text: "#007a48"
+typography:
+  display:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(2.5rem, 5.5vw, 4.5rem)"
+    fontWeight: 800
+    lineHeight: 1.08
+    letterSpacing: "-0.025em"
+  headline:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(1.875rem, 3vw, 2.25rem)"
+    fontWeight: 800
+    lineHeight: 1.15
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 700
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(1.125rem, 2vw, 1.25rem)"
+    fontWeight: 200
+    lineHeight: 1.625
+    letterSpacing: "normal"
+  label:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.75rem"
+    fontWeight: 400
+    lineHeight: 1
+    letterSpacing: "0.15em"
+rounded:
+  control: "8px"
+  surface: "12px"
+  card: "16px"
+  feature: "24px"
+  pill: "9999px"
+spacing:
+  xs: "8px"
+  sm: "16px"
+  md: "24px"
+  lg: "32px"
+  xl: "48px"
+  section: "80px"
+components:
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "14px 32px"
+    height: "44px"
+  button-secondary:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "14px 32px"
+    height: "44px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "#374151"
+    rounded: "{rounded.control}"
+    padding: "8px 12px"
+    height: "44px"
+  button-ghost-hover:
+    backgroundColor: "rgba(0,0,0,0.05)"
+    textColor: "{colors.ink}"
+  input-field:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "12px"
+  card-app:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.surface}"
+    padding: "16px"
+  card-feature:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.card}"
+    padding: "32px"
+  card-resource:
+    backgroundColor: "{colors.chalk-dark}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.surface}"
+    padding: "20px"
+  cta-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "#ffffff"
+    rounded: "{rounded.feature}"
+    padding: "80px 24px"
+---
+
+# Design System: EasyFreeResume
+
+## Overview
+
+**Creative North Star: "The Honest Workshop"**
+
+A well-lit workbench, not a showroom. The surfaces are paper-white and slightly warm, the tools sit out in the open where you can see them, and nothing is hidden behind glass or held back for a fee. This is the visual argument the product has to make before it makes any other one: a visitor arrives here having been burned by a builder that let them do the work and then asked for money at the download button. Every design decision either supports the claim that there is nothing behind the curtain, or it undermines it.
+
+The system gets its force from typography, not decoration. Headings are set at weight 800 and body text at weight 200 — a gap wide enough that the page has an obvious spine and nothing else has to compete for attention. Backgrounds stay in a narrow band of warm off-whites, so the eye reads structure from type size and spacing rather than from boxes and rules. Green appears rarely, and when it does it means something is live, passing, or actionable. Depth is earned: surfaces sit flat until you touch them.
+
+Components feel **tactile and confident**. Targets are generous (44px minimum, everywhere, including the dense editor), presses respond visibly, and states are unambiguous. The audience includes people writing their first resume at 11pm and unsure whether they are doing it right, so the interface must feel forgiving to touch rather than delicate and expensive.
+
+**Key Characteristics:**
+- Light-dominant: warm off-white grounds (`#fafaf8`, `#f0efe9`), near-black ink, no dark mode
+- Extreme type contrast: weight 800 against weight 200, with nothing decorative in between
+- One accent, used as a signal rather than as a brand wash
+- Flat at rest; shadow is a response to state, not a property of cards
+- Generous, unambiguous touch targets — confidence through hand-feel, not ornament
+- Two typefaces only: Bricolage Grotesque (variable, 200–800) and JetBrains Mono for labels
+
+## Colors
+
+A near-monochrome warm-grey system carrying a single high-chroma green that is spent sparingly.
+
+### Primary
+- **Signal Green** (`#00d47e`): Primary CTA fills, focus rings, live/passing status, badge dots, active drag indicators, and the accent sweep on the hero headline. It is the only saturated color in the system and its scarcity is what makes it readable as a signal.
+- **Deep Signal** (`#007a48`): The text-safe sibling. Identical intent, darker so it survives contrast requirements on light grounds. Used for accent-colored text — mono eyebrows, inline links, small accent labels.
+
+### Neutral
+- **Ink** (`#0c0c0c`): All primary text and headings, and the fill for the dark CTA blocks that close marketing pages.
+- **Ink Light** (`#1a1a1a`): Dark chrome surfaces — the demo/mockup shell on the landing page. Distinguishes a device frame from a true ink block.
+- **Chalk** (`#fafaf8`): The default page ground and the resting state of most sections. Warm enough to read as paper rather than as a UI grey.
+- **Chalk Dark** (`#f0efe9`): The alternate surface — resource cards, the footer, and every other section when sections alternate. Provides depth by tone rather than by shadow.
+- **Stone Warm** (`#8a8680`): Body copy, subtitles, and supporting text. The workhorse secondary text color. **Measures 3.46:1 on Chalk — large-text AA only.** See the measured-contrast table below; this is a live compliance gap, not a licence.
+- **Mist** (`#a8a4a0`): Tertiary and muted text only — timestamps, counts, disabled labels. Never for anything the user has to read to complete a task. **Measures 2.37:1 on Chalk and passes nothing.**
+
+Standard Tailwind `gray-{200,300,600,700}` remains acceptable for borders, form strokes, and interactive chrome inside app surfaces. It is **not** acceptable for text or backgrounds on any migrated page; that is what the tokens above are for.
+
+### Named Rules
+
+**The 10% Rule.** Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, "this passed" and "click this" stop meaning anything.
+
+**The Deep Signal Rule.** `#00d47e` on a light ground fails WCAG contrast for text (1.87:1 on Chalk). Any accent-colored text below 24px uses `#007a48` (`text-accent-text`) instead — 5.18:1, which clears AA comfortably. `#00d47e` is for fills only, where the surrounding text carries the contrast (Ink on Signal Green measures 9.98:1, well clear). Reaching for `text-accent` on body-sized copy is the single most likely accessibility regression in this system.
+
+**The One Accent Rule.** There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.
+
+### Measured Contrast
+
+Computed against Chalk (`#fafaf8`), the default page ground. WCAG 2.2 AA requires 4.5:1 for text under 24px (or under 19px bold), 3:1 for large text, and 3:1 for focus indicators and non-text UI boundaries.
+
+| Pairing | Ratio | Verdict |
+|---|---|---|
+| Ink on Chalk | 18.72:1 | Passes everything |
+| Ink on Signal Green (primary button label) | 9.98:1 | Passes everything |
+| Deep Signal on Chalk | 5.18:1 | Passes AA text |
+| **Stone Warm on Chalk** | **3.46:1** | **Large text only — fails AA for body copy** |
+| **Mist on Chalk** | **2.37:1** | **Fails all thresholds** |
+| **Signal Green on Chalk** | **1.87:1** | **Fails the 3:1 focus-indicator threshold** |
+
+Three known gaps, recorded here so no future work assumes this palette is already compliant:
+
+1. **Stone Warm is the system's body-copy color and does not clear AA at body sizes.** It is used for nearly every paragraph and subtitle on the marketing and content surfaces. Fixing it means darkening the token (roughly `#6f6b65` reaches 4.5:1) rather than avoiding it, because avoiding it is not realistic at its current usage volume.
+2. **Mist fails at every size.** It is only defensible on genuinely decorative text that duplicates information available elsewhere. Any Mist text carrying unique meaning is a defect.
+3. **The accent focus ring does not meet the 3:1 focus-appearance requirement on light grounds.** `ring-offset-white` separates the ring from the control but does not raise the ring's own contrast against the page. The ring is applied via `.btn-primary:focus-visible` and repeated across the header and cards, so this is a system-wide finding rather than a page-level one.
+
+These are stated, not resolved. Resolving them is an `/impeccable audit` pass with its own PR, because changing `stone-warm` repaints most of the site and deserves to be reviewed as a deliberate change.
+
+## Typography
+
+**Display Font:** Bricolage Grotesque (variable, weights 200–800), self-hosted, with a metric-matched `Bricolage Fallback` built from local system faces
+**Body Font:** Bricolage Grotesque — the same family, separated by weight rather than by family
+**Label/Mono Font:** JetBrains Mono (400), self-hosted, Latin subset only
+
+**Character:** A single quirky variable grotesque doing all the work, split so far apart by weight that it reads as two voices. The 800 is dense and slightly eccentric — it has personality without being a novelty face. The 200 is nearly hairline and gives long-form copy an airy, unhurried quality that offsets the urgency of the subject matter. JetBrains Mono appears only in small tracked-out capitals, where it functions as a machine-set filing label.
+
+Both faces load with `font-display: optional` against a metric-matched fallback, which means **the fonts may never paint at all on a cold visit**. This is deliberate — it buys zero CLS on a search-traffic-dependent site. Any design that only works once the webfont has loaded is a design that breaks for a first-time visitor.
+
+### Hierarchy
+- **Display** (800, `clamp(2.5rem, 5.5vw, 4.5rem)`, 1.08, tracking-tight): Page H1 only. One per page.
+- **Headline** (800, `text-3xl md:text-4xl`, tracking-tight): Section H2s. Always preceded by a mono eyebrow.
+- **Title** (700, `1.25rem`): Card and panel H3s.
+- **Body** (200, `text-lg md:text-xl`, `leading-relaxed`): Paragraphs, subtitles, descriptions. Constrain to `max-w-3xl` / `max-w-4xl` so the extralight weight never has to hold a long measure.
+- **Label** (400 mono, `0.75rem`, `0.15em` tracking, uppercase, Deep Signal): Section eyebrows, category markers, the "Advertisement" tag.
+- **Meta** (400, `0.875rem`, Stone Warm): Timestamps, counts, secondary controls.
+
+### Named Rules
+
+**The Two-Weight Rule.** Editorial type uses 800 or 200. Nothing in between. The intermediate weights (500/600/700) exist only for interface chrome — buttons, nav links, form labels, card titles — where they signal "this is a control, not prose". A 600-weight paragraph is off-system.
+
+**The Eyebrow Rule.** Every section heading block runs mono eyebrow → H2 → subtitle paragraph, then a `mb-12 md:mb-16` gap before content. The eyebrow is what makes a section feel filed rather than merely stacked, and it is set in Deep Signal, never Signal Green.
+
+## Layout
+
+Centered single-column measures on a warm ground; the system has no visible grid and no vertical rules.
+
+Sections use `py-12 md:py-20 px-4 sm:px-6 lg:px-8` on marketing and content surfaces, widening to `py-20`–`py-24` on the landing page. Inner containers step down by content type: `max-w-6xl` for wide grids, `max-w-4xl` for standard sections, `max-w-3xl` for text-focused reading. App surfaces (editor, my-resumes) run wider — the header container reaches `max-w-[1800px]` — because they are workbenches, not documents.
+
+Grids are `grid md:grid-cols-2 lg:grid-cols-3 gap-8 lg:gap-12`. Alternating sections swap Chalk and Chalk Dark rather than introducing borders.
+
+Fixed chrome heights are exposed as CSS custom properties and consumed as Tailwind spacing (`--header-height-mobile: 64px`, `--header-height-desktop: 72px`, `--footer-height: 200px`, `--mobile-action-bar-height: 110px`, `--tablet-toolbar-height: 80px`). Anything that needs to offset against chrome reads these rather than hardcoding a number.
+
+Below-fold sections carry `content-visibility: auto` with a paired `.cv-h-*` intrinsic-size hint. Adding a new below-fold section without an intrinsic-size estimate reintroduces layout shift on a site whose traffic depends on Core Web Vitals.
+
+### Named Rules
+
+**The Reserved Space Rule.** Anything that arrives late — ads, images, async status, revealed sections — reserves its final height before it arrives. The scroll-reveal system animates opacity and transform only, never height or width, for exactly this reason. Ad slots carry explicit min-heights. This rule is not negotiable on a site funded by search traffic.
+
+## Elevation & Depth
+
+**Flat at rest; depth is a response.** Surfaces sit flush against their ground by default and gain shadow only when something is happening to them — hover, focus, drag, or genuine floating above the page. Where a resting surface needs to separate from its ground, it does so tonally (Chalk against Chalk Dark against white), not with a shadow.
+
+The one sanctioned exception is marketing feature cards, which may carry `.shadow-premium` at rest. That is a deliberate register shift: a landing page is a printed brochure and is allowed physical presence, while a workbench is not.
+
+### Shadow Vocabulary
+- **Resting app surface** (`shadow-sm`): The baseline for cards inside the application. Barely present; establishes edge, not lift.
+- **Responsive lift** (`shadow-md`): The hover answer to `shadow-sm`. Paired with `transition-shadow duration-200`.
+- **Premium ambient** (`.shadow-premium`, four stacked layers from `0 1px 2px` to `0 24px 48px` at 4–6% black): Marketing feature cards only.
+- **Premium response** (`.shadow-premium-hover`): Deepens the stack and adds a `0 40px 80px rgba(0,212,126,0.06)` accent bloom. The only place green is allowed to become atmospheric, and only because it is at 6% opacity behind a card.
+- **Floating** (`shadow-xl` / `shadow-2xl`): Genuinely detached elements — modals, toasts, drag overlays, the glass header.
+
+### Named Rules
+
+**The Flat-At-Rest Rule.** If a surface is not being interacted with and is not floating above the page, it has no shadow. A resting card that carries lift is claiming an importance it has not earned.
+
+**The Glass Restraint Rule.** `backdrop-blur` is reserved for elements that genuinely overlay content: the sticky header, toasts, modal scrims. Glass on a static in-flow card is decoration, and it costs paint performance on the editor's long lists.
+
+## Shapes
+
+Softly rounded throughout, with radius carrying meaning: the smaller the radius, the more the element behaves like a control.
+
+- **8px** (`rounded-lg`) — buttons, inputs, nav links, icon buttons. Everything you operate.
+- **12px** (`rounded-xl`) — the default surface radius and by far the most-used value in the codebase. Panels, app cards, containers.
+- **16px** (`rounded-2xl`) — marketing feature cards and larger composed blocks.
+- **24px** (`rounded-3xl`) — reserved for full-width statement blocks: the dark closing CTA, hero mockup frames.
+- **Full** (`rounded-full`) — badges, status dots, avatars, pills.
+
+Borders are near-invisible: `border-black/[0.06]` on marketing surfaces, `border-gray-200`/`border-slate-200` on app chrome. Where a border must read as a container edge rather than a line, the system prefers `.card-gradient-border` — a 1px accent gradient applied via mask-composite so the edge glows faintly rather than drawing.
+
+Sharp corners do not appear anywhere in this system.
+
+### Named Rules
+
+**The 12px Default Rule.** When unsure, use `rounded-xl`. Radius steps down to 8px for things you press and up to 16px/24px for things you look at.
+
+## Components
+
+### Buttons
+
+Three variants, all sharing a 44px minimum height and a `active:scale-[0.98]` press response — the physical confirmation that makes the system feel tactile.
+
+- **Shape:** Control radius (8px), `inline-flex`, centered content.
+- **Primary:** Signal Green fill, Ink text, weight 700, `shadow-sm` resting → `shadow-md` hover. Sizes: `py-3.5 px-8` default, `py-4 px-10` hero, `py-2.5 px-5` compact/header.
+- **Secondary:** White fill, `border-gray-200` → `border-gray-300` on hover, Ink text, weight 600, same shadow behavior.
+- **Ghost:** No fill, `text-gray-700` → Ink, `hover:bg-black/5`, weight 500, `px-3 py-2`. Tertiary and nav use.
+- **Focus:** All three share `ring-2 ring-accent ring-offset-2 ring-offset-white` on `:focus-visible`. Never remove this without an equivalent replacement.
+- **Deliberately absent:** the primary button's shimmer sweep. `.btn-primary::before { content: none }` is an intentional removal, not dead code.
+
+### Inputs / Fields
+
+- **Style:** White fill, `border-gray-300`, control radius (8px), `p-2` to `p-3` internal padding.
+- **Focus:** `focus-within:ring-2 ring-accent` plus `focus-within:border-accent`, over `transition-all duration-200`. The ring is on the wrapper (`focus-within`) rather than the input, because several fields wrap rich-text editors rather than bare inputs.
+- **Mobile:** Font size is forced to 16px below 768px to prevent iOS Safari's zoom-on-focus. This override is load-bearing; a `text-sm` utility on a mobile input will be defeated by it on purpose.
+
+### Cards / Containers
+
+- **App card:** White, 12px radius, `border-slate-200`, `shadow-sm` → `shadow-md` on hover, `p-4`.
+- **Marketing feature card:** White, 16px radius, `p-8`, `.card-gradient-border`, `.shadow-premium` + `.shadow-premium-hover`, `hover:-translate-y-1`, `transition-all duration-300`.
+- **Resource card:** Chalk Dark fill, 12px radius, `p-5`, transparent border that resolves to `border-black/[0.04]` and a white fill on hover — the surface brightens toward the user rather than lifting.
+
+### Navigation
+
+Sticky header on `bg-white/95` with `backdrop-blur-xl` and a `border-slate-200/80` underline. Nav links are 8px-radius ghost buttons at `text-sm` weight 500 with a 44px minimum height. Active state is carried by weight and Ink color, not by an underline or a pill. Counts and unread state attach as Signal Green dots with a white ring, positioned absolutely at the target's top-right. The primary CTA ("Create Free Resume") stays visible at every breakpoint, contracting its label rather than disappearing.
+
+### Ghost Add Button
+
+Full-width dashed `border-2 border-gray-300` at control radius, muted grey label with a leading plus icon. On hover it resolves to `border-accent/70`, accent text, and a `bg-accent/[0.06]` wash. It is the system's signature "there could be more here" affordance and appears throughout the editor for adding sections and items. It is the one place a dashed border is permitted.
+
+### Ad Surface
+
+A documented, deliberately styled component rather than an afterthought — ads fund the product's central promise, so they get real design. `.ad-surface` renders a 1px `rgba(15,23,42,0.08)` border at 8px radius over a two-layer background (a vertical white gradient plus a 135° hairline repeating stripe), with an inset top highlight. A `::before` pseudo-element sets the word "Advertisement" in 10px 700-weight tracked capitals at the top-left, and an `:empty::after` fills the body with a soft placeholder so an unfilled slot reads as reserved space instead of a broken box.
+
+Ad slots must never be restyled to blend into content, and must never be removed to make a layout tidier.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** use `text-accent-text` (`#007a48`) for any accent-colored text under 24px. `text-accent` is for fills, rings, and strokes.
+- **Do** keep every interactive control at `min-h-11` (44px), including in the editor's densest rows.
+- **Do** pair `.cv-auto` with a `.cv-h-*` intrinsic-size class on every new below-fold section.
+- **Do** reserve explicit height for anything that loads late — ads, images, async status.
+- **Do** wrap below-fold *marketing* sections in `<RevealSection>`; the reveal system animates opacity and transform only, never geometry.
+- **Do** lead every section with the mono eyebrow → H2 → subtitle block.
+- **Do** use `overflow: clip` rather than `overflow: hidden` on layout containers — `hidden` silently creates a scroll container and has broken this app's flex layout before.
+- **Do** verify a design still works with the webfont unloaded; `font-display: optional` means it will be, for some visitors.
+- **Do** check any new text color against the measured-contrast table before using it. Three of this palette's own tokens currently fail AA at body size.
+
+### Don't:
+- **Don't** use `gray-*` or `slate-*` for text or backgrounds on a migrated page. Use `ink`, `stone-warm`, `mist`, `chalk`, `chalk-dark`. (`ResumeCard.tsx` currently uses `slate-200`, `gray-900`, and `gray-500` — it is un-migrated, not a precedent.)
+- **Don't** let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.
+- **Don't** apply scroll reveals, hover lifts, or `.shadow-premium` to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.
+- **Don't** introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.
+- **Don't** reinstate the `.btn-primary` shimmer sweep. Its removal was deliberate.
+- **Don't** put a resting shadow on an app card.
+- **Don't** restyle, shrink, or remove ad surfaces for visual tidiness.
+- **Don't** introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.
+- **Don't** put unique or task-critical information in Mist. At 2.37:1 it fails every threshold; if the user must read it to finish a job, it is the wrong color.
+- **Don't** assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check rather than copying the existing one.
+
+<!--
+Anti-reference: the owner has not yet confirmed a full visual don't-list. The only
+rejection recorded above is the one the codebase itself proves — the upsell-dense
+competitor register (Zety / Resume.io), which seven comparison pages are written
+against. Revisit this section when the owner has a firmer view.
+-->

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,88 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+EasyFreeResume serves three audiences, **weighted equally** — no single one is the primary persona, and design decisions are made per surface rather than around one person:
+
+1. **The cold, skeptical search visitor.** Arrives from Google having been burned by a "free" builder that paywalled the download. Must be convinced the product is genuinely free before investing effort, then reach a finished PDF quickly.
+2. **The entry-level / first-resume writer.** Student, career-starter, career-changer, or returner with sparse material and no reference for what good looks like. Needs structure, examples, and guardrails more than speed.
+3. **The mid-career ATS tailorer.** Already has a resume and is adapting it per job posting. Cares about keyword coverage and ATS pass rate. The editor + keyword scanner loop is their core workflow.
+
+Acquisition-side segments (students, veterans, IT professionals, nurses) have dedicated landing pages. These are search entry points, not separate product personas.
+
+## Product Purpose
+
+Create professional, ATS-friendly resumes in minutes, free, with no paywall at the download step. Success is a completed PDF in the user's hands — the download is the conversion event, not a signup or an upgrade.
+
+## Positioning
+
+**Actually free, verified at the download step.** The category norm is a free editor with a paid export; EasyFreeResume's differentiator is that the resume is generated and downloaded without payment, and without an account being required. The product is monetized by ads, not by gating the user's own document — a claim competitors structurally cannot copy without abandoning their revenue model.
+
+Secondary differentiators: local-first data handling (the resume lives on the user's device unless they choose otherwise), YAML export so the user can take their data and leave, and server-side PDF generation from HTML/CSS templates that keeps output text-based and machine-parseable.
+
+## Operating Context
+
+- **Anonymous by default.** Users can build and download a resume with no account at all.
+- **Optional accounts.** Signing in (Supabase auth) lets a user find their previous resumes and save **up to 5 versions / distinct resumes** in free cloud storage. Accounts are an unlock, never a gate on the core build-and-download path.
+- **Core surfaces:** landing page (`/`), templates hub (`/templates`), the editor (`/editor`, `/editor/:resumeId`), saved resumes (`/my-resumes`), keyword scanner (`/resume-keyword-scanner`), job/role example pages, and a large SEO content layer (~50 blog posts, comparison pages, keyword pages, jobs matrix).
+- **Traffic is search-dominant.** Most sessions begin on an SEO landing or blog page, not the home page. Entry is lateral and cold.
+- **Real usage scene:** a job seeker under time pressure, often on mobile, frequently mid-application. Interruption and return are normal.
+
+## Capabilities and Constraints
+
+**Capabilities**
+- Visual section-based resume editor (no YAML editing required); drag-to-reorder sections; auto-save; rich-text fields.
+- Section types: `text`, `bulleted-list`, `inline-list`, `icon-list`, `dynamic-column-list`, `experience`, `education`.
+- Four shipped templates: Professional (`classic-alex-rivera`), Elegant (`classic-jane-doe`), Minimalist (`modern-no-icons`), Modern (`modern-with-icons`).
+- Custom icon upload (PNG/JPG/SVG).
+- YAML import/export — the user's data is portable in and out.
+- Client-side keyword scanner comparing a resume against a job description.
+- Live preview of the generated resume.
+
+**Technical constraints**
+- PDF is generated server-side (Flask + Jinja2 + pdfkit) from HTML/CSS templates — the editor's visual language and the PDF's visual language are separate systems and must not be conflated.
+- Frontend is React 18 + TypeScript + Vite + Tailwind; the design system is documented in `CLAUDE.md` ("Design System (2026 Revamp)") with tokens in `tailwind.config.js`.
+- SEO pages are prerendered; Core Web Vitals (especially LCP and CLS) are actively monitored and have historically been regressed by layout and ad changes.
+
+**Binding constraints — all future design work must preserve these**
+- **AdSense placements are load-bearing.** Ads are the revenue that makes "actually free" possible. Slot inventory must stay intact; removing, burying, or shrinking units is a business decision, not a design one. Slot reference is in `CLAUDE.md`.
+- **SEO governance in `seo-tracking/` is authoritative.** Titles, H1s, meta, schema, and URLs are governed. Tier-1 pages require owner sign-off. Design cannot change them unilaterally. Read `seo-tracking/strategy.md`, `protected-pages.md`, `changelog.md`, and `mistakes-learned.md` before any SEO-affecting change, and log changes afterward.
+- **ATS-safe PDF output.** Generated PDFs must stay machine-parseable. Visual ambition in resume templates is capped by what ATS parsers survive — no multi-column tricks, images-as-text, or exotic glyphs in the output document.
+- **WCAG 2.2 AA.** Accessibility is held to a stated standard, not best-effort.
+
+**Undecided / not established**
+- Whether a paid tier exists in future. No pricing, licensing, or premium capability is confirmed — do not imply one.
+
+## Brand Commitments
+
+- Name is **EasyFreeResume**, one word. In title tags the brand name must always appear **first**, never trailing.
+- Public promise, used across marketing surfaces: **"No sign-up. No tracking. 100% free."** Design must not contradict it. Note the nuance that copy must respect: sign-up is *optional and additive*, and analytics (PostHog) exist in a privacy-conscious configuration — claims must stay accurate to what the product actually does.
+- Live product: `https://easyfreeresume.com`. Repo: `github.com/aafre/resume-builder`.
+- Design language is the documented 2026 revamp: light-dominant minimalism, chalk backgrounds, extreme type contrast (`font-extrabold` headings vs `font-extralight` body), green `#00d47e` accent used sparingly, soft multi-layer depth, rounded surfaces, scroll-triggered reveals. Tokens: `ink`, `ink-light`, `chalk`, `chalk-dark`, `stone-warm`, `mist`, `accent`. The landing page, header, and footer are the reference implementation; other pages are explicitly slated to be migrated to match.
+
+## Evidence on Hand
+
+- **Real product screenshots / template previews:** `docs/templates/*.png`, plus 26 job-example previews served from Supabase Storage CDN (runbook: `docs/templates/PREVIEW-IMAGES.md`).
+- **Real search performance data:** Google Search Console exports in `SearchConsole/` and snapshots in `seo-tracking/gsc-snapshots.md`.
+- **Real revenue data:** AdSense reporting (`scripts/adsense_report.py`).
+- **Real usage analytics:** PostHog (recently added).
+- **Working sample resumes:** `samples/classic/`, `samples/modern/`.
+- **Absent — must not be fabricated:** named customers, testimonials, user counts, review quotes, awards, press mentions, funding, team size, and any pricing or premium tier. If a surface needs social proof, it must come from something real (GitHub stars, template count, GSC-verifiable traffic) or be omitted.
+
+## Product Principles
+
+1. **The download is never held hostage.** Any flow that makes a user feel they might hit a paywall or a forced signup before getting their PDF is a product failure, regardless of how it looks.
+2. **Accounts add, never gate.** Every core capability works anonymously. Sign-in earns its place by offering something extra (finding past work, 5 cloud-saved versions), and is offered where that value is obvious rather than at the entrance.
+3. **The visitor arrives cold and lateral.** Most sessions do not start at the home page. Every surface must independently establish what this is, that it's free, and where to start.
+4. **Free is paid for by ads — respect both sides.** Ad inventory is protected, and ads must never degrade the build-and-download path or the Core Web Vitals that carry the search traffic funding it.
+5. **The PDF is the product; the UI is the workshop.** Editor and template design serve output quality and ATS survivability. Expressive design belongs in the marketing and content surfaces, not in the generated document.
+
+## Accessibility & Inclusion
+
+WCAG 2.2 AA is the required standard, confirmed as binding. Practical implications for this product: keyboard-operable editor including drag-to-reorder alternatives, visible focus states, contrast that survives the light-dominant palette (particularly `stone-warm` and `mist` on `chalk`), respect for `prefers-reduced-motion` across the scroll-reveal system, and correct labeling on the resume form controls.


### PR DESCRIPTION
Base of a stacked series. **Docs only — no runtime code changes, no dependency changes.**

This gives every subsequent UI PR a single visual authority to work against, so parallel work on the editor, my-resumes, modals, and content layouts converges instead of drifting.

## What's here

| File | What it is |
|---|---|
| `PRODUCT.md` | Durable product truth: users, positioning, operating context, binding constraints |
| `DESIGN.md` | The visual system, extracted from the code (frontmatter tokens + 8 canonical sections) |
| `.impeccable/design.json` | Machine-readable sidecar: tonal ramps, shadows, motion, 10 drop-in component snippets |

## Product record

Captured from the owner directly, not inferred:

- **Three co-equal audiences** — the cold skeptical searcher, the first-resume writer, the mid-career ATS tailorer. No single primary persona; mode is chosen per surface.
- **Anon-first account model** — building and downloading never require an account. Sign-in unlocks finding past work and **up to 5 free cloud-saved resumes**. This corrects the README's flat "No Sign-Up" framing, which no longer matches the code.
- **Four binding constraints** — AdSense inventory is load-bearing revenue, `seo-tracking/` governance is authoritative, WCAG 2.2 AA is a stated standard, and generated PDFs must stay ATS-parseable.
- **Explicitly undecided** — no paid tier exists or is committed. Future work must not imply one.

## Design system

**North star: "The Honest Workshop."** A well-lit workbench, not a showroom — the visual form of the product's no-paywall claim. Accent is signal-only, elevation is flat-at-rest, components are tactile and confident.

Named rules so future work has something citable: *The 10% Rule*, *The Deep Signal Rule*, *The Two-Weight Rule*, *The Eyebrow Rule*, *The Reserved Space Rule*, *The Flat-At-Rest Rule*, *The Glass Restraint Rule*, *The 12px Default Rule*.

## Two findings worth reviewer attention

**1. `CLAUDE.md`'s design section has drifted from the code.** It documents `.btn-primary` as `rounded-xl` / `shadow-lg` / shimmer hover. The actual rule in `styles.css` is `rounded-lg` / `shadow-sm`, with the shimmer deliberately disabled (`::before { content: none }`). DESIGN.md documents the code. A follow-up should trim CLAUDE.md's design section to a pointer rather than a duplicate.

**2. Three measured WCAG failures, recorded rather than assumed.** Computed against Chalk (`#fafaf8`):

| Pairing | Ratio | Verdict |
|---|---|---|
| Ink on Chalk | 18.72:1 | Passes |
| Ink on Signal Green (button label) | 9.98:1 | Passes |
| Deep Signal on Chalk | 5.18:1 | Passes AA text |
| **Stone Warm on Chalk** | **3.46:1** | **Large text only — fails AA for body copy** |
| **Mist on Chalk** | **2.37:1** | **Fails all thresholds** |
| **Signal Green on Chalk** | **1.87:1** | **Fails the 3:1 focus-indicator threshold** |

`stone-warm` is the body-copy color across the marketing and content surfaces, and the accent focus ring is repeated site-wide, so both are system-wide rather than page-level. `ring-offset-white` separates the ring from its control but does not raise the ring's own contrast against the page.

These are **stated here, not fixed here.** Darkening `stone-warm` repaints most of the site and lands in its own reviewed PR (`impeccable/a11y-contrast`) stacked on this one.

## Also noted, not actioned

`styles.css` carries ~70 lines of `.Toastify__*` / `.custom-toast` rules. The project uses `react-hot-toast` (5 files); `react-toastify` appears in zero. That CSS is dead and ships to every visitor.

## Review focus

This is a judgment document, so the useful review is on the calls, not the syntax: whether the north star and named rules match your intent for the product, and whether the recorded product truth is accurate.

https://claude.ai/code/session_01Hb7Wis9ypfYjrUYQVeZDic