### PR TITLE
fix(a11y): clear WCAG AA on stone-warm, mist, and focus rings

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -43,14 +43,14 @@
       "stone-warm": {
         "role": "neutral",
         "displayName": "Stone Warm",
-        "canonical": "#8a8680",
-        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#8a8680", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+        "canonical": "#6b6761",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#6b6761", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9"]
       },
       "mist": {
         "role": "neutral",
         "displayName": "Mist",
-        "canonical": "#a8a4a0",
-        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+        "canonical": "#706c68",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#706c68", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9"]
       }
     },
     "typographyMeta": {
@@ -91,7 +91,7 @@
       "refersTo": "button-primary",
       "description": "The system's one loud element. Signal Green fill, ink label, visible press compression.",
       "html": "<button class=\"ds-btn-primary\">Create Free Resume</button>",
-      "css": ".ds-btn-primary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #00d47e; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 700; font-size: 1rem; border: none; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; overflow: hidden; transition: box-shadow 200ms, transform 200ms; } .ds-btn-primary:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-primary:active { transform: scale(0.98); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+      "css": ".ds-btn-primary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #00d47e; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 700; font-size: 1rem; border: none; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; overflow: hidden; transition: box-shadow 200ms, transform 200ms; } .ds-btn-primary:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-primary:active { transform: scale(0.98); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #007a48; }"
     },
     {
       "name": "Secondary Button",
@@ -99,7 +99,7 @@
       "refersTo": "button-secondary",
       "description": "White field with a near-invisible stroke. Same geometry and press response as primary.",
       "html": "<button class=\"ds-btn-secondary\">Browse Templates</button>",
-      "css": ".ds-btn-secondary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #ffffff; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 600; font-size: 1rem; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; transition: box-shadow 200ms, border-color 200ms, transform 200ms; } .ds-btn-secondary:hover { border-color: #d1d5db; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-secondary:active { transform: scale(0.98); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+      "css": ".ds-btn-secondary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #ffffff; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 600; font-size: 1rem; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; transition: box-shadow 200ms, border-color 200ms, transform 200ms; } .ds-btn-secondary:hover { border-color: #d1d5db; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-secondary:active { transform: scale(0.98); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #007a48; }"
     },
     {
       "name": "Ghost Button",
@@ -107,7 +107,7 @@
       "refersTo": "button-ghost",
       "description": "Tertiary and navigation actions. No fill until touched.",
       "html": "<button class=\"ds-btn-ghost\">Templates</button>",
-      "css": ".ds-btn-ghost { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 8px 12px; background: transparent; color: #374151; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 500; font-size: 0.875rem; border: none; border-radius: 8px; cursor: pointer; transition: background-color 200ms, color 200ms; } .ds-btn-ghost:hover { background: rgba(0,0,0,0.05); color: #0c0c0c; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+      "css": ".ds-btn-ghost { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 8px 12px; background: transparent; color: #374151; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 500; font-size: 0.875rem; border: none; border-radius: 8px; cursor: pointer; transition: background-color 200ms, color 200ms; } .ds-btn-ghost:hover { background: rgba(0,0,0,0.05); color: #0c0c0c; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #007a48; }"
     },
     {
       "name": "Ghost Add Button",
@@ -115,7 +115,7 @@
       "refersTo": "button-ghost",
       "description": "Signature affordance. Full-width dashed field meaning 'there could be more here'. The only sanctioned dashed border in the system.",
       "html": "<button class=\"ds-btn-add\"><svg width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M12 5v14M5 12h14\"/></svg><span>Add Experience</span></button>",
-      "css": ".ds-btn-add { width: 100%; min-height: 44px; padding: 12px 16px; display: flex; align-items: center; justify-content: center; gap: 8px; background: transparent; color: #6b7280; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; border: 2px dashed #d1d5db; border-radius: 8px; cursor: pointer; transition: border-color 150ms, color 150ms, background-color 150ms; } .ds-btn-add:hover { border-color: rgba(0,212,126,0.7); color: #007a48; background: rgba(0,212,126,0.06); } .ds-btn-add:focus-visible { outline: none; box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #00d47e; } .ds-btn-add:disabled { opacity: 0.5; cursor: not-allowed; }"
+      "css": ".ds-btn-add { width: 100%; min-height: 44px; padding: 12px 16px; display: flex; align-items: center; justify-content: center; gap: 8px; background: transparent; color: #6b7280; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; border: 2px dashed #d1d5db; border-radius: 8px; cursor: pointer; transition: border-color 150ms, color 150ms, background-color 150ms; } .ds-btn-add:hover { border-color: rgba(0,212,126,0.7); color: #007a48; background: rgba(0,212,126,0.06); } .ds-btn-add:focus-visible { outline: none; box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #007a48; } .ds-btn-add:disabled { opacity: 0.5; cursor: not-allowed; }"
     },
     {
       "name": "Input Field",
@@ -123,7 +123,7 @@
       "refersTo": "input-field",
       "description": "Wrapper-focused field. The ring lands on the container because several fields wrap rich-text editors rather than bare inputs.",
       "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">Job Title</span><input class=\"ds-input\" type=\"text\" placeholder=\"Senior Product Designer\" /></label>",
-      "css": ".ds-field { display: flex; flex-direction: column; gap: 6px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-field-label { font-size: 0.875rem; font-weight: 500; color: #0c0c0c; } .ds-input { width: 100%; padding: 12px; font-size: 1rem; font-family: inherit; color: #0c0c0c; background: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; transition: box-shadow 200ms, border-color 200ms; } .ds-input::placeholder { color: #a8a4a0; } .ds-input:focus { outline: none; border-color: #00d47e; box-shadow: 0 0 0 2px #00d47e; }"
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 6px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-field-label { font-size: 0.875rem; font-weight: 500; color: #0c0c0c; } .ds-input { width: 100%; padding: 12px; font-size: 1rem; font-family: inherit; color: #0c0c0c; background: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; transition: box-shadow 200ms, border-color 200ms; } .ds-input::placeholder { color: #706c68; } .ds-input:focus { outline: none; border-color: #00d47e; box-shadow: 0 0 0 2px #007a48; }"
     },
     {
       "name": "App Card",
@@ -131,7 +131,7 @@
       "refersTo": "card-app",
       "description": "The workbench surface. Flat at rest, lifts only on hover.",
       "html": "<article class=\"ds-card-app\"><h3 class=\"ds-card-app-title\">Product Designer Resume</h3><p class=\"ds-card-app-meta\">Edited 2 days ago</p></article>",
-      "css": ".ds-card-app { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: box-shadow 200ms; } .ds-card-app:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-card-app-title { margin: 0 0 8px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-app-meta { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+      "css": ".ds-card-app { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: box-shadow 200ms; } .ds-card-app:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-card-app-title { margin: 0 0 8px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-app-meta { margin: 0; font-size: 0.875rem; color: #6b6761; }"
     },
     {
       "name": "Marketing Feature Card",
@@ -139,7 +139,7 @@
       "refersTo": "card-feature",
       "description": "The one place resting depth is permitted. Four-layer shadow, gradient hairline border, hover lift with an accent bloom.",
       "html": "<article class=\"ds-card-feature\"><h3 class=\"ds-card-feature-title\">No paywall at download</h3><p class=\"ds-card-feature-body\">Your PDF is generated and downloaded without payment, and without an account.</p></article>",
-      "css": ".ds-card-feature { position: relative; background: #ffffff; border: 1px solid transparent; border-radius: 16px; padding: 32px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04); transition: box-shadow 500ms cubic-bezier(0.16,1,0.3,1), transform 300ms cubic-bezier(0.16,1,0.3,1); } .ds-card-feature::before { content: ''; position: absolute; inset: -1px; border-radius: inherit; padding: 1px; background: linear-gradient(135deg, rgba(0,212,126,0.2), rgba(0,212,126,0.12), rgba(0,212,126,0.2)); -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: xor; mask-composite: exclude; pointer-events: none; } .ds-card-feature:hover { transform: translateY(-4px); box-shadow: 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06); } .ds-card-feature-title { margin: 0 0 12px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-feature-body { margin: 0; font-size: 1.125rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+      "css": ".ds-card-feature { position: relative; background: #ffffff; border: 1px solid transparent; border-radius: 16px; padding: 32px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04); transition: box-shadow 500ms cubic-bezier(0.16,1,0.3,1), transform 300ms cubic-bezier(0.16,1,0.3,1); } .ds-card-feature::before { content: ''; position: absolute; inset: -1px; border-radius: inherit; padding: 1px; background: linear-gradient(135deg, rgba(0,212,126,0.2), rgba(0,212,126,0.12), rgba(0,212,126,0.2)); -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: xor; mask-composite: exclude; pointer-events: none; } .ds-card-feature:hover { transform: translateY(-4px); box-shadow: 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06); } .ds-card-feature-title { margin: 0 0 12px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-feature-body { margin: 0; font-size: 1.125rem; font-weight: 200; line-height: 1.625; color: #6b6761; }"
     },
     {
       "name": "Resource Card",
@@ -147,7 +147,7 @@
       "refersTo": "card-resource",
       "description": "Brightens toward the user on hover rather than lifting. Chalk Dark resting fill resolving to white.",
       "html": "<a class=\"ds-card-resource\" href=\"#\"><h3 class=\"ds-card-resource-title\">Resume Keywords Guide</h3><p class=\"ds-card-resource-body\">Which terms an ATS actually scores, by industry.</p></a>",
-      "css": ".ds-card-resource { display: block; background: #f0efe9; border: 1px solid transparent; border-radius: 12px; padding: 20px; text-decoration: none; font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: background-color 300ms, box-shadow 300ms, border-color 300ms; } .ds-card-resource:hover { background: #ffffff; border-color: rgba(0,0,0,0.04); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); } .ds-card-resource:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; } .ds-card-resource-title { margin: 0 0 4px; font-size: 1rem; font-weight: 700; color: #0c0c0c; } .ds-card-resource-body { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+      "css": ".ds-card-resource { display: block; background: #f0efe9; border: 1px solid transparent; border-radius: 12px; padding: 20px; text-decoration: none; font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: background-color 300ms, box-shadow 300ms, border-color 300ms; } .ds-card-resource:hover { background: #ffffff; border-color: rgba(0,0,0,0.04); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); } .ds-card-resource:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #007a48; } .ds-card-resource-title { margin: 0 0 4px; font-size: 1rem; font-weight: 700; color: #0c0c0c; } .ds-card-resource-body { margin: 0; font-size: 0.875rem; color: #6b6761; }"
     },
     {
       "name": "Section Eyebrow",
@@ -155,7 +155,7 @@
       "refersTo": "label",
       "description": "The filing label that opens every section. Mono, uppercase, wide tracking, always Deep Signal — never Signal Green.",
       "html": "<div class=\"ds-section-head\"><p class=\"ds-eyebrow\">How it works</p><h2 class=\"ds-h2\">Three steps to a finished PDF</h2><p class=\"ds-sub\">No account, no trial, no card.</p></div>",
-      "css": ".ds-section-head { font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-eyebrow { margin: 0 0 16px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.75rem; font-weight: 400; letter-spacing: 0.15em; text-transform: uppercase; color: #007a48; } .ds-h2 { margin: 0 0 16px; font-size: 2.25rem; font-weight: 800; line-height: 1.15; letter-spacing: -0.025em; color: #0c0c0c; } .ds-sub { margin: 0; font-size: 1.25rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+      "css": ".ds-section-head { font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-eyebrow { margin: 0 0 16px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.75rem; font-weight: 400; letter-spacing: 0.15em; text-transform: uppercase; color: #007a48; } .ds-h2 { margin: 0 0 16px; font-size: 2.25rem; font-weight: 800; line-height: 1.15; letter-spacing: -0.025em; color: #0c0c0c; } .ds-sub { margin: 0; font-size: 1.25rem; font-weight: 200; line-height: 1.625; color: #6b6761; }"
     },
     {
       "name": "Ad Surface",
@@ -178,8 +178,8 @@
       "Two typefaces only: Bricolage Grotesque (variable, 200–800) and JetBrains Mono for labels"
     ],
     "rules": [
-      { "name": "The 10% Rule", "body": "Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, 'this passed' and 'click this' stop meaning anything.", "section": "colors" },
-      { "name": "The Deep Signal Rule", "body": "#00d47e on a light ground fails WCAG contrast for text (1.87:1 on chalk). Any accent-colored text below 24px uses #007a48 (text-accent-text) instead — 5.18:1, which clears AA. #00d47e is for fills only, where the surrounding text carries the contrast (ink on green measures 9.98:1). Note the accent focus ring at 1.87:1 does NOT meet the 3:1 focus-appearance threshold on light grounds; this is a known open finding.", "section": "colors" },
+      { "name": "The 10% Rule", "body": "Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, 'this passed' and 'click this' stop meaning anything.", "section": "colors" },
+      { "name": "The Deep Signal Rule", "body": "#00d47e on a light ground measures 1.87:1 on chalk and clears neither the 4.5:1 text threshold nor the 3:1 non-text one. Any accent-colored text below 24px, and every focus ring, uses #007a48 (text-accent-text / ring-accent-text) instead — 5.18:1 on chalk, 4.70:1 on chalk-dark. #00d47e is for fills and decorative halos only, where the surrounding text carries the contrast (ink on green measures 9.98:1).", "section": "colors" },
       { "name": "The One Accent Rule", "body": "There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.", "section": "colors" },
       { "name": "The Two-Weight Rule", "body": "Editorial type uses 800 or 200. Nothing in between. The intermediate weights (500/600/700) exist only for interface chrome — buttons, nav links, form labels, card titles — where they signal 'this is a control, not prose'. A 600-weight paragraph is off-system.", "section": "typography" },
       { "name": "The Eyebrow Rule", "body": "Every section heading block runs mono eyebrow → H2 → subtitle paragraph, then a mb-12 md:mb-16 gap before content. The eyebrow is what makes a section feel filed rather than merely stacked, and it is set in Deep Signal, never Signal Green.", "section": "typography" },
@@ -189,7 +189,8 @@
       { "name": "The 12px Default Rule", "body": "When unsure, use rounded-xl. Radius steps down to 8px for things you press and up to 16px/24px for things you look at.", "section": "shapes" }
     ],
     "dos": [
-      "Do use text-accent-text (#007a48) for any accent-colored text under 24px. text-accent is for fills, rings, and strokes.",
+      "Do use text-accent-text / ring-accent-text (#007a48) for any accent-colored text under 24px and for every focus ring. text-accent is for fills and decorative halos.",
+      "Do measure new foreground colors against chalk-dark (#f0efe9), not white — chalk-dark is the darkest ground the system paints text on and the one that fails first.",
       "Do keep every interactive control at min-h-11 (44px), including in the editor's densest rows.",
       "Do pair .cv-auto with a .cv-h-* intrinsic-size class on every new below-fold section.",
       "Do reserve explicit height for anything that loads late — ads, images, async status.",
@@ -207,8 +208,8 @@
       "Don't put a resting shadow on an app card.",
       "Don't restyle, shrink, or remove ad surfaces for visual tidiness.",
       "Don't introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.",
-      "Don't put unique or task-critical information in Mist. At 2.37:1 it fails every threshold.",
-      "Don't assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check."
+      "Don't lighten stone-warm or mist back toward their pre-audit values (#8a8680 / #a8a4a0). Both failed AA at body size; the current values (5.38:1 and 4.98:1 on chalk, 4.88:1 and 4.52:1 on chalk-dark) came from a measured pass.",
+      "Don't use ring-accent for a focus state. Signal Green is 1.87:1 on chalk and cannot carry a focus indicator; ring-accent-text is the system's focus ring."
     ]
   }
 }

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,214 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-11T00:00:00.000Z",
+  "title": "Design System: EasyFreeResume",
+  "extensions": {
+    "colorMeta": {
+      "accent": {
+        "role": "primary",
+        "displayName": "Signal Green",
+        "canonical": "#00d47e",
+        "tonalRamp": ["#00281a", "#00432a", "#005f3b", "#007a48", "#009a5c", "#00b86e", "#00d47e", "#7ceab6"]
+      },
+      "accent-text": {
+        "role": "primary",
+        "displayName": "Deep Signal",
+        "canonical": "#007a48",
+        "tonalRamp": ["#00281a", "#00432a", "#005f3b", "#007a48", "#009a5c", "#00b86e", "#00d47e", "#7ceab6"]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "#0c0c0c",
+        "tonalRamp": ["#000000", "#0c0c0c", "#1a1a1a", "#333333", "#5c5c5c", "#8a8a8a", "#c2c2c2", "#f0f0f0"]
+      },
+      "ink-light": {
+        "role": "neutral",
+        "displayName": "Ink Light",
+        "canonical": "#1a1a1a",
+        "tonalRamp": ["#000000", "#0c0c0c", "#1a1a1a", "#333333", "#5c5c5c", "#8a8a8a", "#c2c2c2", "#f0f0f0"]
+      },
+      "chalk": {
+        "role": "neutral",
+        "displayName": "Chalk",
+        "canonical": "#fafaf8",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "chalk-dark": {
+        "role": "neutral",
+        "displayName": "Chalk Dark",
+        "canonical": "#f0efe9",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "stone-warm": {
+        "role": "neutral",
+        "displayName": "Stone Warm",
+        "canonical": "#8a8680",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#8a8680", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      },
+      "mist": {
+        "role": "neutral",
+        "displayName": "Mist",
+        "canonical": "#a8a4a0",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9", "#fafaf8"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page H1 only, one per page. Weight 800 against a 1.08 line-height." },
+      "headline": { "displayName": "Headline", "purpose": "Section H2s, always preceded by a mono eyebrow." },
+      "title": { "displayName": "Title", "purpose": "Card and panel H3s. Weight 700 marks it as interface, not prose." },
+      "body": { "displayName": "Body", "purpose": "Paragraphs and subtitles at weight 200. Constrain the measure to max-w-3xl/4xl." },
+      "label": { "displayName": "Mono Label", "purpose": "Section eyebrows and filing markers. Uppercase, 0.15em tracking, always Deep Signal." }
+    },
+    "shadows": [
+      { "name": "resting-app", "value": "0 1px 2px 0 rgba(0,0,0,0.05)", "purpose": "Baseline edge for cards inside the application. Establishes edge, not lift." },
+      { "name": "responsive-lift", "value": "0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)", "purpose": "The hover answer to resting-app. Always paired with transition-shadow duration-200." },
+      { "name": "premium-ambient", "value": "0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04)", "purpose": "Four-layer resting depth. Marketing feature cards only — never app surfaces." },
+      { "name": "premium-response", "value": "0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06)", "purpose": "Hover deepening with an accent bloom. The only sanctioned atmospheric use of green." },
+      { "name": "floating", "value": "0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1)", "purpose": "Genuinely detached elements: modals, toasts, drag overlays, the sticky header." },
+      { "name": "drag-overlay", "value": "0 25px 50px -12px rgba(0,0,0,0.25)", "purpose": "Item lifted under an active drag, paired with a 2px rgba(0,212,126,0.5) border." }
+    ],
+    "motion": [
+      { "name": "ease-premium", "value": "cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "The system's signature easing. Scroll reveals, premium shadow transitions, FAQ expansion, hero sequence." },
+      { "name": "duration-control", "value": "200ms", "purpose": "Buttons, nav links, inputs, and every other direct-manipulation control." },
+      { "name": "duration-surface", "value": "300ms", "purpose": "Card hovers, background and border transitions." },
+      { "name": "duration-glass", "value": "500ms", "purpose": "Glass and premium-shadow transitions, where slowness reads as weight." },
+      { "name": "duration-reveal", "value": "800ms", "purpose": "Scroll-triggered entrance animations." },
+      { "name": "press-response", "value": "scale(0.98)", "purpose": "Active-state compression on all three button variants. The core tactile cue." },
+      { "name": "reveal-stagger", "value": "0ms, 100ms, 180ms, 240ms, 300ms, 360ms, 400ms", "purpose": "Transition delays applied to nth-child of a [data-reveal-stagger] grid; clamps at 400ms from the seventh child on." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The system's one loud element. Signal Green fill, ink label, visible press compression.",
+      "html": "<button class=\"ds-btn-primary\">Create Free Resume</button>",
+      "css": ".ds-btn-primary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #00d47e; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 700; font-size: 1rem; border: none; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; overflow: hidden; transition: box-shadow 200ms, transform 200ms; } .ds-btn-primary:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-primary:active { transform: scale(0.98); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "White field with a near-invisible stroke. Same geometry and press response as primary.",
+      "html": "<button class=\"ds-btn-secondary\">Browse Templates</button>",
+      "css": ".ds-btn-secondary { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 14px 32px; background: #ffffff; color: #0c0c0c; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 600; font-size: 1rem; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); cursor: pointer; transition: box-shadow 200ms, border-color 200ms, transform 200ms; } .ds-btn-secondary:hover { border-color: #d1d5db; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-btn-secondary:active { transform: scale(0.98); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Tertiary and navigation actions. No fill until touched.",
+      "html": "<button class=\"ds-btn-ghost\">Templates</button>",
+      "css": ".ds-btn-ghost { position: relative; display: inline-flex; align-items: center; justify-content: center; min-height: 44px; padding: 8px 12px; background: transparent; color: #374151; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-weight: 500; font-size: 0.875rem; border: none; border-radius: 8px; cursor: pointer; transition: background-color 200ms, color 200ms; } .ds-btn-ghost:hover { background: rgba(0,0,0,0.05); color: #0c0c0c; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; }"
+    },
+    {
+      "name": "Ghost Add Button",
+      "kind": "custom",
+      "refersTo": "button-ghost",
+      "description": "Signature affordance. Full-width dashed field meaning 'there could be more here'. The only sanctioned dashed border in the system.",
+      "html": "<button class=\"ds-btn-add\"><svg width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"><path d=\"M12 5v14M5 12h14\"/></svg><span>Add Experience</span></button>",
+      "css": ".ds-btn-add { width: 100%; min-height: 44px; padding: 12px 16px; display: flex; align-items: center; justify-content: center; gap: 8px; background: transparent; color: #6b7280; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; border: 2px dashed #d1d5db; border-radius: 8px; cursor: pointer; transition: border-color 150ms, color 150ms, background-color 150ms; } .ds-btn-add:hover { border-color: rgba(0,212,126,0.7); color: #007a48; background: rgba(0,212,126,0.06); } .ds-btn-add:focus-visible { outline: none; box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #00d47e; } .ds-btn-add:disabled { opacity: 0.5; cursor: not-allowed; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input-field",
+      "description": "Wrapper-focused field. The ring lands on the container because several fields wrap rich-text editors rather than bare inputs.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">Job Title</span><input class=\"ds-input\" type=\"text\" placeholder=\"Senior Product Designer\" /></label>",
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 6px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-field-label { font-size: 0.875rem; font-weight: 500; color: #0c0c0c; } .ds-input { width: 100%; padding: 12px; font-size: 1rem; font-family: inherit; color: #0c0c0c; background: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; transition: box-shadow 200ms, border-color 200ms; } .ds-input::placeholder { color: #a8a4a0; } .ds-input:focus { outline: none; border-color: #00d47e; box-shadow: 0 0 0 2px #00d47e; }"
+    },
+    {
+      "name": "App Card",
+      "kind": "card",
+      "refersTo": "card-app",
+      "description": "The workbench surface. Flat at rest, lifts only on hover.",
+      "html": "<article class=\"ds-card-app\"><h3 class=\"ds-card-app-title\">Product Designer Resume</h3><p class=\"ds-card-app-meta\">Edited 2 days ago</p></article>",
+      "css": ".ds-card-app { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 16px; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05); font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: box-shadow 200ms; } .ds-card-app:hover { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1); } .ds-card-app-title { margin: 0 0 8px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-app-meta { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+    },
+    {
+      "name": "Marketing Feature Card",
+      "kind": "card",
+      "refersTo": "card-feature",
+      "description": "The one place resting depth is permitted. Four-layer shadow, gradient hairline border, hover lift with an accent bloom.",
+      "html": "<article class=\"ds-card-feature\"><h3 class=\"ds-card-feature-title\">No paywall at download</h3><p class=\"ds-card-feature-body\">Your PDF is generated and downloaded without payment, and without an account.</p></article>",
+      "css": ".ds-card-feature { position: relative; background: #ffffff; border: 1px solid transparent; border-radius: 16px; padding: 32px; font-family: 'Bricolage Grotesque', system-ui, sans-serif; box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 8px rgba(0,0,0,0.04), 0 12px 24px rgba(0,0,0,0.06), 0 24px 48px rgba(0,0,0,0.04); transition: box-shadow 500ms cubic-bezier(0.16,1,0.3,1), transform 300ms cubic-bezier(0.16,1,0.3,1); } .ds-card-feature::before { content: ''; position: absolute; inset: -1px; border-radius: inherit; padding: 1px; background: linear-gradient(135deg, rgba(0,212,126,0.2), rgba(0,212,126,0.12), rgba(0,212,126,0.2)); -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: xor; mask-composite: exclude; pointer-events: none; } .ds-card-feature:hover { transform: translateY(-4px); box-shadow: 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.06), 0 20px 40px rgba(0,0,0,0.08), 0 40px 80px rgba(0,212,126,0.06); } .ds-card-feature-title { margin: 0 0 12px; font-size: 1.25rem; font-weight: 700; color: #0c0c0c; } .ds-card-feature-body { margin: 0; font-size: 1.125rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+    },
+    {
+      "name": "Resource Card",
+      "kind": "card",
+      "refersTo": "card-resource",
+      "description": "Brightens toward the user on hover rather than lifting. Chalk Dark resting fill resolving to white.",
+      "html": "<a class=\"ds-card-resource\" href=\"#\"><h3 class=\"ds-card-resource-title\">Resume Keywords Guide</h3><p class=\"ds-card-resource-body\">Which terms an ATS actually scores, by industry.</p></a>",
+      "css": ".ds-card-resource { display: block; background: #f0efe9; border: 1px solid transparent; border-radius: 12px; padding: 20px; text-decoration: none; font-family: 'Bricolage Grotesque', system-ui, sans-serif; transition: background-color 300ms, box-shadow 300ms, border-color 300ms; } .ds-card-resource:hover { background: #ffffff; border-color: rgba(0,0,0,0.04); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1); } .ds-card-resource:focus-visible { outline: none; box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #00d47e; } .ds-card-resource-title { margin: 0 0 4px; font-size: 1rem; font-weight: 700; color: #0c0c0c; } .ds-card-resource-body { margin: 0; font-size: 0.875rem; color: #8a8680; }"
+    },
+    {
+      "name": "Section Eyebrow",
+      "kind": "custom",
+      "refersTo": "label",
+      "description": "The filing label that opens every section. Mono, uppercase, wide tracking, always Deep Signal — never Signal Green.",
+      "html": "<div class=\"ds-section-head\"><p class=\"ds-eyebrow\">How it works</p><h2 class=\"ds-h2\">Three steps to a finished PDF</h2><p class=\"ds-sub\">No account, no trial, no card.</p></div>",
+      "css": ".ds-section-head { font-family: 'Bricolage Grotesque', system-ui, sans-serif; } .ds-eyebrow { margin: 0 0 16px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.75rem; font-weight: 400; letter-spacing: 0.15em; text-transform: uppercase; color: #007a48; } .ds-h2 { margin: 0 0 16px; font-size: 2.25rem; font-weight: 800; line-height: 1.15; letter-spacing: -0.025em; color: #0c0c0c; } .ds-sub { margin: 0; font-size: 1.25rem; font-weight: 200; line-height: 1.625; color: #8a8680; }"
+    },
+    {
+      "name": "Ad Surface",
+      "kind": "custom",
+      "refersTo": "card-app",
+      "description": "Ads fund the product's central promise, so they are a designed component. Labelled, bordered, and reserving its own space when unfilled.",
+      "html": "<div class=\"ds-ad-surface\"></div>",
+      "css": ".ds-ad-surface { position: relative; min-height: 250px; border: 1px solid rgba(15,23,42,0.08); border-radius: 8px; background: linear-gradient(180deg, rgba(248,250,252,0.88), rgba(255,255,255,0.96)), repeating-linear-gradient(135deg, rgba(15,23,42,0.035) 0 1px, transparent 1px 12px); box-shadow: inset 0 1px 0 rgba(255,255,255,0.75); } .ds-ad-surface::before { content: 'Advertisement'; position: absolute; top: 0.5rem; left: 0.75rem; z-index: 1; font-family: 'Bricolage Grotesque', system-ui, sans-serif; font-size: 0.625rem; font-weight: 700; letter-spacing: 0.08em; line-height: 1; text-transform: uppercase; color: rgba(71,85,105,0.72); pointer-events: none; } .ds-ad-surface:empty::after { content: ''; position: absolute; inset: 2.25rem 0.75rem 0.75rem; border-radius: 6px; background: rgba(255,255,255,0.44); pointer-events: none; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Honest Workshop",
+    "overview": "A well-lit workbench, not a showroom. The surfaces are paper-white and slightly warm, the tools sit out in the open where you can see them, and nothing is hidden behind glass or held back for a fee. This is the visual argument the product has to make before it makes any other one: a visitor arrives here having been burned by a builder that let them do the work and then asked for money at the download button. Every design decision either supports the claim that there is nothing behind the curtain, or it undermines it.\n\nThe system gets its force from typography, not decoration. Headings are set at weight 800 and body text at weight 200 — a gap wide enough that the page has an obvious spine and nothing else has to compete for attention. Backgrounds stay in a narrow band of warm off-whites, so the eye reads structure from type size and spacing rather than from boxes and rules. Green appears rarely, and when it does it means something is live, passing, or actionable. Depth is earned: surfaces sit flat until you touch them.\n\nComponents feel tactile and confident. Targets are generous (44px minimum, everywhere, including the dense editor), presses respond visibly, and states are unambiguous. The audience includes people writing their first resume at 11pm and unsure whether they are doing it right, so the interface must feel forgiving to touch rather than delicate and expensive.",
+    "keyCharacteristics": [
+      "Light-dominant: warm off-white grounds (#fafaf8, #f0efe9), near-black ink, no dark mode",
+      "Extreme type contrast: weight 800 against weight 200, with nothing decorative in between",
+      "One accent, used as a signal rather than as a brand wash",
+      "Flat at rest; shadow is a response to state, not a property of cards",
+      "Generous, unambiguous touch targets — confidence through hand-feel, not ornament",
+      "Two typefaces only: Bricolage Grotesque (variable, 200–800) and JetBrains Mono for labels"
+    ],
+    "rules": [
+      { "name": "The 10% Rule", "body": "Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, 'this passed' and 'click this' stop meaning anything.", "section": "colors" },
+      { "name": "The Deep Signal Rule", "body": "#00d47e on a light ground fails WCAG contrast for text (1.87:1 on chalk). Any accent-colored text below 24px uses #007a48 (text-accent-text) instead — 5.18:1, which clears AA. #00d47e is for fills only, where the surrounding text carries the contrast (ink on green measures 9.98:1). Note the accent focus ring at 1.87:1 does NOT meet the 3:1 focus-appearance threshold on light grounds; this is a known open finding.", "section": "colors" },
+      { "name": "The One Accent Rule", "body": "There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.", "section": "colors" },
+      { "name": "The Two-Weight Rule", "body": "Editorial type uses 800 or 200. Nothing in between. The intermediate weights (500/600/700) exist only for interface chrome — buttons, nav links, form labels, card titles — where they signal 'this is a control, not prose'. A 600-weight paragraph is off-system.", "section": "typography" },
+      { "name": "The Eyebrow Rule", "body": "Every section heading block runs mono eyebrow → H2 → subtitle paragraph, then a mb-12 md:mb-16 gap before content. The eyebrow is what makes a section feel filed rather than merely stacked, and it is set in Deep Signal, never Signal Green.", "section": "typography" },
+      { "name": "The Reserved Space Rule", "body": "Anything that arrives late — ads, images, async status, revealed sections — reserves its final height before it arrives. The scroll-reveal system animates opacity and transform only, never height or width, for exactly this reason. Ad slots carry explicit min-heights.", "section": "layout" },
+      { "name": "The Flat-At-Rest Rule", "body": "If a surface is not being interacted with and is not floating above the page, it has no shadow. A resting card that carries lift is claiming an importance it has not earned.", "section": "elevation" },
+      { "name": "The Glass Restraint Rule", "body": "backdrop-blur is reserved for elements that genuinely overlay content: the sticky header, toasts, modal scrims. Glass on a static in-flow card is decoration, and it costs paint performance on the editor's long lists.", "section": "elevation" },
+      { "name": "The 12px Default Rule", "body": "When unsure, use rounded-xl. Radius steps down to 8px for things you press and up to 16px/24px for things you look at.", "section": "shapes" }
+    ],
+    "dos": [
+      "Do use text-accent-text (#007a48) for any accent-colored text under 24px. text-accent is for fills, rings, and strokes.",
+      "Do keep every interactive control at min-h-11 (44px), including in the editor's densest rows.",
+      "Do pair .cv-auto with a .cv-h-* intrinsic-size class on every new below-fold section.",
+      "Do reserve explicit height for anything that loads late — ads, images, async status.",
+      "Do wrap below-fold marketing sections in <RevealSection>; the reveal system animates opacity and transform only, never geometry.",
+      "Do lead every section with the mono eyebrow → H2 → subtitle block.",
+      "Do use overflow: clip rather than overflow: hidden on layout containers — hidden silently creates a scroll container and has broken this app's flex layout before.",
+      "Do verify a design still works with the webfont unloaded; font-display: optional means it will be, for some visitors."
+    ],
+    "donts": [
+      "Don't use gray-* or slate-* for text or backgrounds on a migrated page. Use ink, stone-warm, mist, chalk, chalk-dark.",
+      "Don't let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.",
+      "Don't apply scroll reveals, hover lifts, or .shadow-premium to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.",
+      "Don't introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.",
+      "Don't reinstate the .btn-primary shimmer sweep. Its removal was deliberate.",
+      "Don't put a resting shadow on an app card.",
+      "Don't restyle, shrink, or remove ad surfaces for visual tidiness.",
+      "Don't introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.",
+      "Don't put unique or task-critical information in Mist. At 2.37:1 it fails every threshold.",
+      "Don't assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check."
+    ]
+  }
+}

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -46,11 +46,13 @@
         "canonical": "#6b6761",
         "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#6b6761", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9"]
       },
-      "mist": {
+      "stone-warm-inverse": {
         "role": "neutral",
-        "displayName": "Mist",
-        "canonical": "#706c68",
-        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#706c68", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9"]
+        "displayName": "Stone Warm Inverse",
+        "canonical": "#a8a4a0",
+        "surfacePolarity": "dark",
+        "note": "Stone Warm's pair for dark grounds. 7.90:1 on ink, 7.03:1 on ink-light, 6.19:1 on a bg-white/5 chip over ink-light. Fails AA on every light ground (2.15:1 on chalk-dark) — the two are mutually exclusive by polarity, not interchangeable.",
+        "tonalRamp": ["#26251f", "#3d3b33", "#5c5950", "#6b6761", "#807c72", "#a8a4a0", "#cdc9c1", "#f0efe9"]
       }
     },
     "typographyMeta": {
@@ -200,7 +202,7 @@
       "Do verify a design still works with the webfont unloaded; font-display: optional means it will be, for some visitors."
     ],
     "donts": [
-      "Don't use gray-* or slate-* for text or backgrounds on a migrated page. Use ink, stone-warm, mist, chalk, chalk-dark.",
+      "Don't use gray-* or slate-* for text or backgrounds on a migrated page. Use ink, stone-warm, stone-warm-inverse, chalk, chalk-dark.",
       "Don't let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.",
       "Don't apply scroll reveals, hover lifts, or .shadow-premium to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.",
       "Don't introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.",
@@ -208,7 +210,9 @@
       "Don't put a resting shadow on an app card.",
       "Don't restyle, shrink, or remove ad surfaces for visual tidiness.",
       "Don't introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.",
-      "Don't lighten stone-warm or mist back toward their pre-audit values (#8a8680 / #a8a4a0). Both failed AA at body size; the current values (5.38:1 and 4.98:1 on chalk, 4.88:1 and 4.52:1 on chalk-dark) came from a measured pass.",
+      "Don't lighten stone-warm back toward its pre-audit value (#8a8680). It failed AA at body size on light grounds; #6b6761 (5.38:1 on chalk, 4.88:1 on chalk-dark) came from a measured pass. On dark grounds reach for stone-warm-inverse, not a lighter stone-warm.",
+      "Don't use a warm grey on the wrong surface polarity. stone-warm is 3.48:1 on ink; stone-warm-inverse is 2.15:1 on chalk-dark. Both fail. Measure both polarities whenever a neutral changes — a light-grounds-only pass reads as complete and is not.",
+      "Don't reintroduce a third warm grey to recover a tertiary step. The last one (mist) compressed to within five points of stone-warm under AA and was collapsed into it. Carry that hierarchy with size and weight.",
       "Don't use ring-accent for a focus state. Signal Green is 1.87:1 on chalk and cannot carry a focus indicator; ring-accent-text is the system's focus ring."
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,8 @@ The landing page, header, and footer have been revamped with a modern design lan
 | `ink-light` | `#1a1a1a` | Dark surfaces (demo chrome) |
 | `chalk` | `#fafaf8` | Page/section backgrounds |
 | `chalk-dark` | `#f0efe9` | Alternate surface (cards, footer) |
-| `stone-warm` | `#8a8680` | Body text, subtitles |
-| `mist` | `#a8a4a0` | Tertiary/muted text |
+| `stone-warm` | `#6b6761` | Body text, subtitles |
+| `mist` | `#706c68` | Tertiary/muted text |
 | `accent` | `#00d47e` | CTAs, highlights, badges |
 
 Standard Tailwind `gray-{200,300,600}` for borders and secondary text. Avoid introducing new brand colors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,8 @@ The landing page, header, and footer have been revamped with a modern design lan
 | `ink-light` | `#1a1a1a` | Dark surfaces (demo chrome) |
 | `chalk` | `#fafaf8` | Page/section backgrounds |
 | `chalk-dark` | `#f0efe9` | Alternate surface (cards, footer) |
-| `stone-warm` | `#6b6761` | Body text, subtitles |
-| `mist` | `#706c68` | Tertiary/muted text |
+| `stone-warm` | `#6b6761` | Body text, subtitles — **light grounds only** |
+| `stone-warm-inverse` | `#a8a4a0` | Same role on **dark grounds** (`bg-ink`, `bg-ink-light`) |
 | `accent` | `#00d47e` | CTAs, highlights, badges |
 
 Standard Tailwind `gray-{200,300,600}` for borders and secondary text. Avoid introducing new brand colors.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,7 +7,7 @@ colors:
   chalk: "#fafaf8"
   chalk-dark: "#f0efe9"
   stone-warm: "#6b6761"
-  mist: "#706c68"
+  stone-warm-inverse: "#a8a4a0"
   accent: "#00d47e"
   accent-text: "#007a48"
 typography:
@@ -137,9 +137,9 @@ A near-monochrome warm-grey system carrying a single high-chroma green that is s
 - **Chalk** (`#fafaf8`): The default page ground and the resting state of most sections. Warm enough to read as paper rather than as a UI grey.
 - **Chalk Dark** (`#f0efe9`): The alternate surface — resource cards, the footer, and every other section when sections alternate. Provides depth by tone rather than by shadow.
 - **Stone Warm** (`#6b6761`): Body copy, subtitles, and supporting text. The workhorse secondary text color. **Measures 5.38:1 on Chalk, 5.62:1 on white, 4.88:1 on Chalk Dark — clears AA at body size on every ground in the system.** The extra margin over the 4.5:1 floor is deliberate: this token carries weight-200 copy, and hairline type needs headroom that WCAG's size-only thresholds do not model.
-- **Mist** (`#706c68`): Tertiary and muted text — timestamps, counts, meta rows, placeholder text, secondary labels. **Measures 4.98:1 on Chalk, 5.21:1 on white, 4.52:1 on Chalk Dark — clears AA at body size on every ground.**
+- **Stone Warm Inverse** (`#a8a4a0`): The same role as Stone Warm, for dark grounds. Supporting text inside Ink and Ink Light blocks — the closing-CTA subtitle, the featured-post meta row, the mockup chrome label. **Measures 7.90:1 on Ink, 7.03:1 on Ink Light, 6.19:1 on a white-5% chip over Ink Light.**
 
-Stone Warm and Mist now sit one tonal step apart rather than the wide step they used to. That compression is forced, not sloppy: the light end of a warm-grey ramp is not available to text under AA on a near-white ground, so the tertiary token had to come up to meet the secondary one. The two remain separate tokens because the *role* distinction still holds — Mist marks text that supports rather than carries — but the separation is now read from size, weight, and placement rather than from a large tonal drop. Do not "restore" Mist to a lighter grey.
+There used to be a third warm grey, `mist`, holding a "tertiary" step below Stone Warm. The AA pass compressed it to `#706c68` against Stone Warm's `#6b6761` — five points per channel, which is not a tonal step, it is a rounding error with a name. It was collapsed into Stone Warm; the role distinction it claimed to carry is now read from size, weight, and placement, which is where it was actually being read from anyway. The freed value became the inverse token.
 
 Standard Tailwind `gray-{200,300,600,700}` remains acceptable for borders, form strokes, and interactive chrome inside app surfaces. It is **not** acceptable for text or backgrounds on any migrated page; that is what the tokens above are for.
 
@@ -148,6 +148,8 @@ Standard Tailwind `gray-{200,300,600,700}` remains acceptable for borders, form 
 **The 10% Rule.** Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, "this passed" and "click this" stop meaning anything.
 
 **The Deep Signal Rule.** `#00d47e` on a light ground measures 1.87:1 on Chalk, which clears neither the 4.5:1 text threshold nor the 3:1 non-text one. Any accent-colored text below 24px, **and every focus ring**, uses `#007a48` (`text-accent-text` / `ring-accent-text`) instead — 5.18:1 on Chalk, 4.70:1 on Chalk Dark. `#00d47e` is for fills and decorative halos only, where the surrounding text carries the contrast (Ink on Signal Green measures 9.98:1, well clear). Reaching for `text-accent` or `ring-accent` on anything that has to be seen is the single most likely accessibility regression in this system.
+
+**The Surface Polarity Rule.** Warm greys are surface-polarity-paired, and **a token is only AA-valid against the polarity it was measured on.** `stone-warm` is for light grounds (Chalk, white, Chalk Dark); `stone-warm-inverse` is for dark grounds (Ink, Ink Light). Using either on the other's polarity fails AA in both directions — `stone-warm` drops to 3.48:1 on Ink, `stone-warm-inverse` drops to 2.15:1 on Chalk Dark. This is not a style preference, and it is the failure mode this system is most prone to: a single-axis contrast pass reads as complete, passes every number it checks, and silently inverts the problem on the other polarity. Measure both, always. Note also that translucent chips (`bg-white/5` over Ink Light composites to `#252525`) are a *third* ground — lighter than Ink Light, so stricter — and must be composited before measuring.
 
 **The One Accent Rule.** There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.
 
@@ -163,14 +165,26 @@ Ratios are given against all three light grounds the system actually paints text
 | Ink on Signal Green (primary button label) | — | — | — | 9.98:1, passes everything |
 | Deep Signal | 5.18:1 | 5.42:1 | 4.70:1 | Passes AA text on all three, and the 3:1 non-text threshold |
 | Stone Warm | 5.38:1 | 5.62:1 | 4.88:1 | Passes AA at body size on all three |
-| Mist | 4.98:1 | 5.21:1 | 4.52:1 | Passes AA at body size on all three |
+| Stone Warm Inverse | 2.37:1 | 2.48:1 | 2.15:1 | **Fails AA on light grounds — dark grounds only** |
 | Deep Signal focus ring | 5.18:1 | 5.42:1 | 4.70:1 | Passes the 3:1 focus-indicator threshold with margin |
 | Signal Green | 1.87:1 | 1.96:1 | 1.70:1 | **Fills and decorative halos only — never text, never a focus ring** |
 
-Two caveats that survive the audit and must not be re-litigated by eye:
+And against the dark grounds, which the system paints text on in the closing-CTA blocks, the blog featured card, the editor mobile banner, and the landing-page mockup chrome:
+
+| Pairing | on Ink `#0c0c0c` | on Ink Light `#1a1a1a` | on `bg-white/5` over Ink Light (`#252525`) | Verdict |
+|---|---|---|---|---|
+| White | 19.56:1 | 17.40:1 | 15.33:1 | Passes everything |
+| Stone Warm Inverse | 7.90:1 | 7.03:1 | 6.19:1 | Passes AA at body size on all three |
+| Stone Warm | 3.48:1 | 3.10:1 | 2.73:1 | **Fails AA — never use on a dark ground** |
+| Signal Green | 9.98:1 | 8.88:1 | 7.82:1 | Passes AA text — the one ground where `text-accent` is contrast-safe |
+
+Note the last row: Signal Green inverts too. On light grounds it is a fill color and `text-accent-text` carries any accent text; on dark grounds `text-accent` clears AA comfortably, which is why the mono eyebrows inside the dark closing-CTA blocks correctly use `text-accent` and not `text-accent-text`. Deep Signal on Ink would be the wrong call — measure before "fixing" one to match the other. The 10% Rule still caps how much green appears either way.
+
+Three caveats that survive the audit and must not be re-litigated by eye:
 
 1. **Deep Signal clears 4.5:1 on Chalk Dark by only 0.20.** It passes, with little room. Do not set Deep Signal text on any ground darker than Chalk Dark without re-measuring.
-2. **Signal Green remains non-compliant as a foreground at every size, by design.** It is a fill color. The moment it appears as text, an icon that carries meaning alone, or a focus ring, that is a regression — check it against this table rather than trusting that it "looks green enough".
+2. **Signal Green remains non-compliant as a foreground on light grounds at every size, by design.** It is a fill color. The moment it appears as text, an icon that carries meaning alone, or a focus ring, that is a regression — check it against this table rather than trusting that it "looks green enough".
+3. **The two warm greys are mutually exclusive by ground, not interchangeable.** See the Surface Polarity Rule. Every row above that reads "fails" is a token being used on the wrong polarity, not a token that needs replacing.
 
 ## Typography
 
@@ -299,10 +313,11 @@ Ad slots must never be restyled to blend into content, and must never be removed
 - **Do** lead every section with the mono eyebrow → H2 → subtitle block.
 - **Do** use `overflow: clip` rather than `overflow: hidden` on layout containers — `hidden` silently creates a scroll container and has broken this app's flex layout before.
 - **Do** verify a design still works with the webfont unloaded; `font-display: optional` means it will be, for some visitors.
-- **Do** check any new text color against the measured-contrast table before using it, and measure against Chalk Dark rather than white — Chalk Dark is the darkest ground and the one that fails first.
+- **Do** check any new text color against the measured-contrast table before using it, and measure against Chalk Dark rather than white — Chalk Dark is the strictest light ground and the one that fails first.
+- **Do** measure **both** polarities whenever a neutral changes. A pass against light grounds alone reads as complete and is not. See the Surface Polarity Rule.
 
 ### Don't:
-- **Don't** use `gray-*` or `slate-*` for text or backgrounds on a migrated page. Use `ink`, `stone-warm`, `mist`, `chalk`, `chalk-dark`. (`ResumeCard.tsx` currently uses `slate-200`, `gray-900`, and `gray-500` — it is un-migrated, not a precedent.)
+- **Don't** use `gray-*` or `slate-*` for text or backgrounds on a migrated page. Use `ink`, `stone-warm`, `stone-warm-inverse`, `chalk`, `chalk-dark`. (`ResumeCard.tsx` currently uses `slate-200`, `gray-900`, and `gray-500` — it is un-migrated, not a precedent.)
 - **Don't** let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.
 - **Don't** apply scroll reveals, hover lifts, or `.shadow-premium` to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.
 - **Don't** introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.
@@ -310,7 +325,8 @@ Ad slots must never be restyled to blend into content, and must never be removed
 - **Don't** put a resting shadow on an app card.
 - **Don't** restyle, shrink, or remove ad surfaces for visual tidiness.
 - **Don't** introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.
-- **Don't** lighten Stone Warm or Mist back toward their pre-audit values (`#8a8680` / `#a8a4a0`). Both failed AA; the current values are the result of a measured pass, not a taste call.
+- **Don't** lighten Stone Warm back toward its pre-audit value (`#8a8680`). It failed AA on light grounds; `#6b6761` is the result of a measured pass, not a taste call. On dark grounds you want `stone-warm-inverse`, not a lighter Stone Warm.
+- **Don't** reintroduce a third warm grey to recover a "tertiary" step. The last one compressed to within five points of Stone Warm and was collapsed. Carry that hierarchy with size and weight.
 - **Don't** use `ring-accent` for a focus state. Signal Green is 1.87:1 on Chalk and cannot carry a focus indicator; `ring-accent-text` is the system's focus ring.
 
 <!--

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,319 @@
+---
+name: EasyFreeResume
+description: Light-dominant, type-led resume builder where green means "live" and nothing is hidden behind glass.
+colors:
+  ink: "#0c0c0c"
+  ink-light: "#1a1a1a"
+  chalk: "#fafaf8"
+  chalk-dark: "#f0efe9"
+  stone-warm: "#8a8680"
+  mist: "#a8a4a0"
+  accent: "#00d47e"
+  accent-text: "#007a48"
+typography:
+  display:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(2.5rem, 5.5vw, 4.5rem)"
+    fontWeight: 800
+    lineHeight: 1.08
+    letterSpacing: "-0.025em"
+  headline:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(1.875rem, 3vw, 2.25rem)"
+    fontWeight: 800
+    lineHeight: 1.15
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 700
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Bricolage Grotesque, Bricolage Fallback, system-ui, sans-serif"
+    fontSize: "clamp(1.125rem, 2vw, 1.25rem)"
+    fontWeight: 200
+    lineHeight: 1.625
+    letterSpacing: "normal"
+  label:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.75rem"
+    fontWeight: 400
+    lineHeight: 1
+    letterSpacing: "0.15em"
+rounded:
+  control: "8px"
+  surface: "12px"
+  card: "16px"
+  feature: "24px"
+  pill: "9999px"
+spacing:
+  xs: "8px"
+  sm: "16px"
+  md: "24px"
+  lg: "32px"
+  xl: "48px"
+  section: "80px"
+components:
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "14px 32px"
+    height: "44px"
+  button-secondary:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "14px 32px"
+    height: "44px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "#374151"
+    rounded: "{rounded.control}"
+    padding: "8px 12px"
+    height: "44px"
+  button-ghost-hover:
+    backgroundColor: "rgba(0,0,0,0.05)"
+    textColor: "{colors.ink}"
+  input-field:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.control}"
+    padding: "12px"
+  card-app:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.surface}"
+    padding: "16px"
+  card-feature:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.card}"
+    padding: "32px"
+  card-resource:
+    backgroundColor: "{colors.chalk-dark}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.surface}"
+    padding: "20px"
+  cta-dark:
+    backgroundColor: "{colors.ink}"
+    textColor: "#ffffff"
+    rounded: "{rounded.feature}"
+    padding: "80px 24px"
+---
+
+# Design System: EasyFreeResume
+
+## Overview
+
+**Creative North Star: "The Honest Workshop"**
+
+A well-lit workbench, not a showroom. The surfaces are paper-white and slightly warm, the tools sit out in the open where you can see them, and nothing is hidden behind glass or held back for a fee. This is the visual argument the product has to make before it makes any other one: a visitor arrives here having been burned by a builder that let them do the work and then asked for money at the download button. Every design decision either supports the claim that there is nothing behind the curtain, or it undermines it.
+
+The system gets its force from typography, not decoration. Headings are set at weight 800 and body text at weight 200 — a gap wide enough that the page has an obvious spine and nothing else has to compete for attention. Backgrounds stay in a narrow band of warm off-whites, so the eye reads structure from type size and spacing rather than from boxes and rules. Green appears rarely, and when it does it means something is live, passing, or actionable. Depth is earned: surfaces sit flat until you touch them.
+
+Components feel **tactile and confident**. Targets are generous (44px minimum, everywhere, including the dense editor), presses respond visibly, and states are unambiguous. The audience includes people writing their first resume at 11pm and unsure whether they are doing it right, so the interface must feel forgiving to touch rather than delicate and expensive.
+
+**Key Characteristics:**
+- Light-dominant: warm off-white grounds (`#fafaf8`, `#f0efe9`), near-black ink, no dark mode
+- Extreme type contrast: weight 800 against weight 200, with nothing decorative in between
+- One accent, used as a signal rather than as a brand wash
+- Flat at rest; shadow is a response to state, not a property of cards
+- Generous, unambiguous touch targets — confidence through hand-feel, not ornament
+- Two typefaces only: Bricolage Grotesque (variable, 200–800) and JetBrains Mono for labels
+
+## Colors
+
+A near-monochrome warm-grey system carrying a single high-chroma green that is spent sparingly.
+
+### Primary
+- **Signal Green** (`#00d47e`): Primary CTA fills, focus rings, live/passing status, badge dots, active drag indicators, and the accent sweep on the hero headline. It is the only saturated color in the system and its scarcity is what makes it readable as a signal.
+- **Deep Signal** (`#007a48`): The text-safe sibling. Identical intent, darker so it survives contrast requirements on light grounds. Used for accent-colored text — mono eyebrows, inline links, small accent labels.
+
+### Neutral
+- **Ink** (`#0c0c0c`): All primary text and headings, and the fill for the dark CTA blocks that close marketing pages.
+- **Ink Light** (`#1a1a1a`): Dark chrome surfaces — the demo/mockup shell on the landing page. Distinguishes a device frame from a true ink block.
+- **Chalk** (`#fafaf8`): The default page ground and the resting state of most sections. Warm enough to read as paper rather than as a UI grey.
+- **Chalk Dark** (`#f0efe9`): The alternate surface — resource cards, the footer, and every other section when sections alternate. Provides depth by tone rather than by shadow.
+- **Stone Warm** (`#8a8680`): Body copy, subtitles, and supporting text. The workhorse secondary text color. **Measures 3.46:1 on Chalk — large-text AA only.** See the measured-contrast table below; this is a live compliance gap, not a licence.
+- **Mist** (`#a8a4a0`): Tertiary and muted text only — timestamps, counts, disabled labels. Never for anything the user has to read to complete a task. **Measures 2.37:1 on Chalk and passes nothing.**
+
+Standard Tailwind `gray-{200,300,600,700}` remains acceptable for borders, form strokes, and interactive chrome inside app surfaces. It is **not** acceptable for text or backgrounds on any migrated page; that is what the tokens above are for.
+
+### Named Rules
+
+**The 10% Rule.** Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, "this passed" and "click this" stop meaning anything.
+
+**The Deep Signal Rule.** `#00d47e` on a light ground fails WCAG contrast for text (1.87:1 on Chalk). Any accent-colored text below 24px uses `#007a48` (`text-accent-text`) instead — 5.18:1, which clears AA comfortably. `#00d47e` is for fills only, where the surrounding text carries the contrast (Ink on Signal Green measures 9.98:1, well clear). Reaching for `text-accent` on body-sized copy is the single most likely accessibility regression in this system.
+
+**The One Accent Rule.** There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.
+
+### Measured Contrast
+
+Computed against Chalk (`#fafaf8`), the default page ground. WCAG 2.2 AA requires 4.5:1 for text under 24px (or under 19px bold), 3:1 for large text, and 3:1 for focus indicators and non-text UI boundaries.
+
+| Pairing | Ratio | Verdict |
+|---|---|---|
+| Ink on Chalk | 18.72:1 | Passes everything |
+| Ink on Signal Green (primary button label) | 9.98:1 | Passes everything |
+| Deep Signal on Chalk | 5.18:1 | Passes AA text |
+| **Stone Warm on Chalk** | **3.46:1** | **Large text only — fails AA for body copy** |
+| **Mist on Chalk** | **2.37:1** | **Fails all thresholds** |
+| **Signal Green on Chalk** | **1.87:1** | **Fails the 3:1 focus-indicator threshold** |
+
+Three known gaps, recorded here so no future work assumes this palette is already compliant:
+
+1. **Stone Warm is the system's body-copy color and does not clear AA at body sizes.** It is used for nearly every paragraph and subtitle on the marketing and content surfaces. Fixing it means darkening the token (roughly `#6f6b65` reaches 4.5:1) rather than avoiding it, because avoiding it is not realistic at its current usage volume.
+2. **Mist fails at every size.** It is only defensible on genuinely decorative text that duplicates information available elsewhere. Any Mist text carrying unique meaning is a defect.
+3. **The accent focus ring does not meet the 3:1 focus-appearance requirement on light grounds.** `ring-offset-white` separates the ring from the control but does not raise the ring's own contrast against the page. The ring is applied via `.btn-primary:focus-visible` and repeated across the header and cards, so this is a system-wide finding rather than a page-level one.
+
+These are stated, not resolved. Resolving them is an `/impeccable audit` pass with its own PR, because changing `stone-warm` repaints most of the site and deserves to be reviewed as a deliberate change.
+
+## Typography
+
+**Display Font:** Bricolage Grotesque (variable, weights 200–800), self-hosted, with a metric-matched `Bricolage Fallback` built from local system faces
+**Body Font:** Bricolage Grotesque — the same family, separated by weight rather than by family
+**Label/Mono Font:** JetBrains Mono (400), self-hosted, Latin subset only
+
+**Character:** A single quirky variable grotesque doing all the work, split so far apart by weight that it reads as two voices. The 800 is dense and slightly eccentric — it has personality without being a novelty face. The 200 is nearly hairline and gives long-form copy an airy, unhurried quality that offsets the urgency of the subject matter. JetBrains Mono appears only in small tracked-out capitals, where it functions as a machine-set filing label.
+
+Both faces load with `font-display: optional` against a metric-matched fallback, which means **the fonts may never paint at all on a cold visit**. This is deliberate — it buys zero CLS on a search-traffic-dependent site. Any design that only works once the webfont has loaded is a design that breaks for a first-time visitor.
+
+### Hierarchy
+- **Display** (800, `clamp(2.5rem, 5.5vw, 4.5rem)`, 1.08, tracking-tight): Page H1 only. One per page.
+- **Headline** (800, `text-3xl md:text-4xl`, tracking-tight): Section H2s. Always preceded by a mono eyebrow.
+- **Title** (700, `1.25rem`): Card and panel H3s.
+- **Body** (200, `text-lg md:text-xl`, `leading-relaxed`): Paragraphs, subtitles, descriptions. Constrain to `max-w-3xl` / `max-w-4xl` so the extralight weight never has to hold a long measure.
+- **Label** (400 mono, `0.75rem`, `0.15em` tracking, uppercase, Deep Signal): Section eyebrows, category markers, the "Advertisement" tag.
+- **Meta** (400, `0.875rem`, Stone Warm): Timestamps, counts, secondary controls.
+
+### Named Rules
+
+**The Two-Weight Rule.** Editorial type uses 800 or 200. Nothing in between. The intermediate weights (500/600/700) exist only for interface chrome — buttons, nav links, form labels, card titles — where they signal "this is a control, not prose". A 600-weight paragraph is off-system.
+
+**The Eyebrow Rule.** Every section heading block runs mono eyebrow → H2 → subtitle paragraph, then a `mb-12 md:mb-16` gap before content. The eyebrow is what makes a section feel filed rather than merely stacked, and it is set in Deep Signal, never Signal Green.
+
+## Layout
+
+Centered single-column measures on a warm ground; the system has no visible grid and no vertical rules.
+
+Sections use `py-12 md:py-20 px-4 sm:px-6 lg:px-8` on marketing and content surfaces, widening to `py-20`–`py-24` on the landing page. Inner containers step down by content type: `max-w-6xl` for wide grids, `max-w-4xl` for standard sections, `max-w-3xl` for text-focused reading. App surfaces (editor, my-resumes) run wider — the header container reaches `max-w-[1800px]` — because they are workbenches, not documents.
+
+Grids are `grid md:grid-cols-2 lg:grid-cols-3 gap-8 lg:gap-12`. Alternating sections swap Chalk and Chalk Dark rather than introducing borders.
+
+Fixed chrome heights are exposed as CSS custom properties and consumed as Tailwind spacing (`--header-height-mobile: 64px`, `--header-height-desktop: 72px`, `--footer-height: 200px`, `--mobile-action-bar-height: 110px`, `--tablet-toolbar-height: 80px`). Anything that needs to offset against chrome reads these rather than hardcoding a number.
+
+Below-fold sections carry `content-visibility: auto` with a paired `.cv-h-*` intrinsic-size hint. Adding a new below-fold section without an intrinsic-size estimate reintroduces layout shift on a site whose traffic depends on Core Web Vitals.
+
+### Named Rules
+
+**The Reserved Space Rule.** Anything that arrives late — ads, images, async status, revealed sections — reserves its final height before it arrives. The scroll-reveal system animates opacity and transform only, never height or width, for exactly this reason. Ad slots carry explicit min-heights. This rule is not negotiable on a site funded by search traffic.
+
+## Elevation & Depth
+
+**Flat at rest; depth is a response.** Surfaces sit flush against their ground by default and gain shadow only when something is happening to them — hover, focus, drag, or genuine floating above the page. Where a resting surface needs to separate from its ground, it does so tonally (Chalk against Chalk Dark against white), not with a shadow.
+
+The one sanctioned exception is marketing feature cards, which may carry `.shadow-premium` at rest. That is a deliberate register shift: a landing page is a printed brochure and is allowed physical presence, while a workbench is not.
+
+### Shadow Vocabulary
+- **Resting app surface** (`shadow-sm`): The baseline for cards inside the application. Barely present; establishes edge, not lift.
+- **Responsive lift** (`shadow-md`): The hover answer to `shadow-sm`. Paired with `transition-shadow duration-200`.
+- **Premium ambient** (`.shadow-premium`, four stacked layers from `0 1px 2px` to `0 24px 48px` at 4–6% black): Marketing feature cards only.
+- **Premium response** (`.shadow-premium-hover`): Deepens the stack and adds a `0 40px 80px rgba(0,212,126,0.06)` accent bloom. The only place green is allowed to become atmospheric, and only because it is at 6% opacity behind a card.
+- **Floating** (`shadow-xl` / `shadow-2xl`): Genuinely detached elements — modals, toasts, drag overlays, the glass header.
+
+### Named Rules
+
+**The Flat-At-Rest Rule.** If a surface is not being interacted with and is not floating above the page, it has no shadow. A resting card that carries lift is claiming an importance it has not earned.
+
+**The Glass Restraint Rule.** `backdrop-blur` is reserved for elements that genuinely overlay content: the sticky header, toasts, modal scrims. Glass on a static in-flow card is decoration, and it costs paint performance on the editor's long lists.
+
+## Shapes
+
+Softly rounded throughout, with radius carrying meaning: the smaller the radius, the more the element behaves like a control.
+
+- **8px** (`rounded-lg`) — buttons, inputs, nav links, icon buttons. Everything you operate.
+- **12px** (`rounded-xl`) — the default surface radius and by far the most-used value in the codebase. Panels, app cards, containers.
+- **16px** (`rounded-2xl`) — marketing feature cards and larger composed blocks.
+- **24px** (`rounded-3xl`) — reserved for full-width statement blocks: the dark closing CTA, hero mockup frames.
+- **Full** (`rounded-full`) — badges, status dots, avatars, pills.
+
+Borders are near-invisible: `border-black/[0.06]` on marketing surfaces, `border-gray-200`/`border-slate-200` on app chrome. Where a border must read as a container edge rather than a line, the system prefers `.card-gradient-border` — a 1px accent gradient applied via mask-composite so the edge glows faintly rather than drawing.
+
+Sharp corners do not appear anywhere in this system.
+
+### Named Rules
+
+**The 12px Default Rule.** When unsure, use `rounded-xl`. Radius steps down to 8px for things you press and up to 16px/24px for things you look at.
+
+## Components
+
+### Buttons
+
+Three variants, all sharing a 44px minimum height and a `active:scale-[0.98]` press response — the physical confirmation that makes the system feel tactile.
+
+- **Shape:** Control radius (8px), `inline-flex`, centered content.
+- **Primary:** Signal Green fill, Ink text, weight 700, `shadow-sm` resting → `shadow-md` hover. Sizes: `py-3.5 px-8` default, `py-4 px-10` hero, `py-2.5 px-5` compact/header.
+- **Secondary:** White fill, `border-gray-200` → `border-gray-300` on hover, Ink text, weight 600, same shadow behavior.
+- **Ghost:** No fill, `text-gray-700` → Ink, `hover:bg-black/5`, weight 500, `px-3 py-2`. Tertiary and nav use.
+- **Focus:** All three share `ring-2 ring-accent ring-offset-2 ring-offset-white` on `:focus-visible`. Never remove this without an equivalent replacement.
+- **Deliberately absent:** the primary button's shimmer sweep. `.btn-primary::before { content: none }` is an intentional removal, not dead code.
+
+### Inputs / Fields
+
+- **Style:** White fill, `border-gray-300`, control radius (8px), `p-2` to `p-3` internal padding.
+- **Focus:** `focus-within:ring-2 ring-accent` plus `focus-within:border-accent`, over `transition-all duration-200`. The ring is on the wrapper (`focus-within`) rather than the input, because several fields wrap rich-text editors rather than bare inputs.
+- **Mobile:** Font size is forced to 16px below 768px to prevent iOS Safari's zoom-on-focus. This override is load-bearing; a `text-sm` utility on a mobile input will be defeated by it on purpose.
+
+### Cards / Containers
+
+- **App card:** White, 12px radius, `border-slate-200`, `shadow-sm` → `shadow-md` on hover, `p-4`.
+- **Marketing feature card:** White, 16px radius, `p-8`, `.card-gradient-border`, `.shadow-premium` + `.shadow-premium-hover`, `hover:-translate-y-1`, `transition-all duration-300`.
+- **Resource card:** Chalk Dark fill, 12px radius, `p-5`, transparent border that resolves to `border-black/[0.04]` and a white fill on hover — the surface brightens toward the user rather than lifting.
+
+### Navigation
+
+Sticky header on `bg-white/95` with `backdrop-blur-xl` and a `border-slate-200/80` underline. Nav links are 8px-radius ghost buttons at `text-sm` weight 500 with a 44px minimum height. Active state is carried by weight and Ink color, not by an underline or a pill. Counts and unread state attach as Signal Green dots with a white ring, positioned absolutely at the target's top-right. The primary CTA ("Create Free Resume") stays visible at every breakpoint, contracting its label rather than disappearing.
+
+### Ghost Add Button
+
+Full-width dashed `border-2 border-gray-300` at control radius, muted grey label with a leading plus icon. On hover it resolves to `border-accent/70`, accent text, and a `bg-accent/[0.06]` wash. It is the system's signature "there could be more here" affordance and appears throughout the editor for adding sections and items. It is the one place a dashed border is permitted.
+
+### Ad Surface
+
+A documented, deliberately styled component rather than an afterthought — ads fund the product's central promise, so they get real design. `.ad-surface` renders a 1px `rgba(15,23,42,0.08)` border at 8px radius over a two-layer background (a vertical white gradient plus a 135° hairline repeating stripe), with an inset top highlight. A `::before` pseudo-element sets the word "Advertisement" in 10px 700-weight tracked capitals at the top-left, and an `:empty::after` fills the body with a soft placeholder so an unfilled slot reads as reserved space instead of a broken box.
+
+Ad slots must never be restyled to blend into content, and must never be removed to make a layout tidier.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** use `text-accent-text` (`#007a48`) for any accent-colored text under 24px. `text-accent` is for fills, rings, and strokes.
+- **Do** keep every interactive control at `min-h-11` (44px), including in the editor's densest rows.
+- **Do** pair `.cv-auto` with a `.cv-h-*` intrinsic-size class on every new below-fold section.
+- **Do** reserve explicit height for anything that loads late — ads, images, async status.
+- **Do** wrap below-fold *marketing* sections in `<RevealSection>`; the reveal system animates opacity and transform only, never geometry.
+- **Do** lead every section with the mono eyebrow → H2 → subtitle block.
+- **Do** use `overflow: clip` rather than `overflow: hidden` on layout containers — `hidden` silently creates a scroll container and has broken this app's flex layout before.
+- **Do** verify a design still works with the webfont unloaded; `font-display: optional` means it will be, for some visitors.
+- **Do** check any new text color against the measured-contrast table before using it. Three of this palette's own tokens currently fail AA at body size.
+
+### Don't:
+- **Don't** use `gray-*` or `slate-*` for text or backgrounds on a migrated page. Use `ink`, `stone-warm`, `mist`, `chalk`, `chalk-dark`. (`ResumeCard.tsx` currently uses `slate-200`, `gray-900`, and `gray-500` — it is un-migrated, not a precedent.)
+- **Don't** let Signal Green back a large surface, tint a section, or appear decoratively. Ten percent is the ceiling.
+- **Don't** apply scroll reveals, hover lifts, or `.shadow-premium` to the editor or my-resumes. Motion on a workbench is feedback; anything else is friction on a surface people use for forty minutes.
+- **Don't** introduce a third typeface, or reach for a weight between 200 and 800 for editorial text.
+- **Don't** reinstate the `.btn-primary` shimmer sweep. Its removal was deliberate.
+- **Don't** put a resting shadow on an app card.
+- **Don't** restyle, shrink, or remove ad surfaces for visual tidiness.
+- **Don't** introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.
+- **Don't** put unique or task-critical information in Mist. At 2.37:1 it fails every threshold; if the user must read it to finish a job, it is the wrong color.
+- **Don't** assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check rather than copying the existing one.
+
+<!--
+Anti-reference: the owner has not yet confirmed a full visual don't-list. The only
+rejection recorded above is the one the codebase itself proves — the upsell-dense
+competitor register (Zety / Resume.io), which seven comparison pages are written
+against. Revisit this section when the owner has a firmer view.
+-->

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,8 +6,8 @@ colors:
   ink-light: "#1a1a1a"
   chalk: "#fafaf8"
   chalk-dark: "#f0efe9"
-  stone-warm: "#8a8680"
-  mist: "#a8a4a0"
+  stone-warm: "#6b6761"
+  mist: "#706c68"
   accent: "#00d47e"
   accent-text: "#007a48"
 typography:
@@ -136,39 +136,41 @@ A near-monochrome warm-grey system carrying a single high-chroma green that is s
 - **Ink Light** (`#1a1a1a`): Dark chrome surfaces — the demo/mockup shell on the landing page. Distinguishes a device frame from a true ink block.
 - **Chalk** (`#fafaf8`): The default page ground and the resting state of most sections. Warm enough to read as paper rather than as a UI grey.
 - **Chalk Dark** (`#f0efe9`): The alternate surface — resource cards, the footer, and every other section when sections alternate. Provides depth by tone rather than by shadow.
-- **Stone Warm** (`#8a8680`): Body copy, subtitles, and supporting text. The workhorse secondary text color. **Measures 3.46:1 on Chalk — large-text AA only.** See the measured-contrast table below; this is a live compliance gap, not a licence.
-- **Mist** (`#a8a4a0`): Tertiary and muted text only — timestamps, counts, disabled labels. Never for anything the user has to read to complete a task. **Measures 2.37:1 on Chalk and passes nothing.**
+- **Stone Warm** (`#6b6761`): Body copy, subtitles, and supporting text. The workhorse secondary text color. **Measures 5.38:1 on Chalk, 5.62:1 on white, 4.88:1 on Chalk Dark — clears AA at body size on every ground in the system.** The extra margin over the 4.5:1 floor is deliberate: this token carries weight-200 copy, and hairline type needs headroom that WCAG's size-only thresholds do not model.
+- **Mist** (`#706c68`): Tertiary and muted text — timestamps, counts, meta rows, placeholder text, secondary labels. **Measures 4.98:1 on Chalk, 5.21:1 on white, 4.52:1 on Chalk Dark — clears AA at body size on every ground.**
+
+Stone Warm and Mist now sit one tonal step apart rather than the wide step they used to. That compression is forced, not sloppy: the light end of a warm-grey ramp is not available to text under AA on a near-white ground, so the tertiary token had to come up to meet the secondary one. The two remain separate tokens because the *role* distinction still holds — Mist marks text that supports rather than carries — but the separation is now read from size, weight, and placement rather than from a large tonal drop. Do not "restore" Mist to a lighter grey.
 
 Standard Tailwind `gray-{200,300,600,700}` remains acceptable for borders, form strokes, and interactive chrome inside app surfaces. It is **not** acceptable for text or backgrounds on any migrated page; that is what the tokens above are for.
 
 ### Named Rules
 
-**The 10% Rule.** Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs, focus rings, and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, "this passed" and "click this" stop meaning anything.
+**The 10% Rule.** Signal Green covers no more than roughly a tenth of any screen. It fills primary CTAs and status indicators. It never backs a section, never tints a large surface, and never appears decoratively. The moment green becomes ambient, "this passed" and "click this" stop meaning anything.
 
-**The Deep Signal Rule.** `#00d47e` on a light ground fails WCAG contrast for text (1.87:1 on Chalk). Any accent-colored text below 24px uses `#007a48` (`text-accent-text`) instead — 5.18:1, which clears AA comfortably. `#00d47e` is for fills only, where the surrounding text carries the contrast (Ink on Signal Green measures 9.98:1, well clear). Reaching for `text-accent` on body-sized copy is the single most likely accessibility regression in this system.
+**The Deep Signal Rule.** `#00d47e` on a light ground measures 1.87:1 on Chalk, which clears neither the 4.5:1 text threshold nor the 3:1 non-text one. Any accent-colored text below 24px, **and every focus ring**, uses `#007a48` (`text-accent-text` / `ring-accent-text`) instead — 5.18:1 on Chalk, 4.70:1 on Chalk Dark. `#00d47e` is for fills and decorative halos only, where the surrounding text carries the contrast (Ink on Signal Green measures 9.98:1, well clear). Reaching for `text-accent` or `ring-accent` on anything that has to be seen is the single most likely accessibility regression in this system.
 
 **The One Accent Rule.** There is no secondary or tertiary brand color. Semantic reds, ambers, and blues exist only inside status affordances (toasts, validation, warning banners) and are never promoted into the brand palette.
 
 ### Measured Contrast
 
-Computed against Chalk (`#fafaf8`), the default page ground. WCAG 2.2 AA requires 4.5:1 for text under 24px (or under 19px bold), 3:1 for large text, and 3:1 for focus indicators and non-text UI boundaries.
+WCAG 2.2 AA requires 4.5:1 for text under 24px (or under 19px bold), 3:1 for large text, and 3:1 for focus indicators and non-text UI boundaries.
 
-| Pairing | Ratio | Verdict |
-|---|---|---|
-| Ink on Chalk | 18.72:1 | Passes everything |
-| Ink on Signal Green (primary button label) | 9.98:1 | Passes everything |
-| Deep Signal on Chalk | 5.18:1 | Passes AA text |
-| **Stone Warm on Chalk** | **3.46:1** | **Large text only — fails AA for body copy** |
-| **Mist on Chalk** | **2.37:1** | **Fails all thresholds** |
-| **Signal Green on Chalk** | **1.87:1** | **Fails the 3:1 focus-indicator threshold** |
+Ratios are given against all three light grounds the system actually paints text on. **Chalk Dark (`#f0efe9`) is the strictest of the three, not white** — every foreground token must be chosen against it, because resource cards, the footer, and every alternating section sit on it.
 
-Three known gaps, recorded here so no future work assumes this palette is already compliant:
+| Pairing | on Chalk `#fafaf8` | on white `#ffffff` | on Chalk Dark `#f0efe9` | Verdict |
+|---|---|---|---|---|
+| Ink | 18.72:1 | 19.56:1 | 16.98:1 | Passes everything |
+| Ink on Signal Green (primary button label) | — | — | — | 9.98:1, passes everything |
+| Deep Signal | 5.18:1 | 5.42:1 | 4.70:1 | Passes AA text on all three, and the 3:1 non-text threshold |
+| Stone Warm | 5.38:1 | 5.62:1 | 4.88:1 | Passes AA at body size on all three |
+| Mist | 4.98:1 | 5.21:1 | 4.52:1 | Passes AA at body size on all three |
+| Deep Signal focus ring | 5.18:1 | 5.42:1 | 4.70:1 | Passes the 3:1 focus-indicator threshold with margin |
+| Signal Green | 1.87:1 | 1.96:1 | 1.70:1 | **Fills and decorative halos only — never text, never a focus ring** |
 
-1. **Stone Warm is the system's body-copy color and does not clear AA at body sizes.** It is used for nearly every paragraph and subtitle on the marketing and content surfaces. Fixing it means darkening the token (roughly `#6f6b65` reaches 4.5:1) rather than avoiding it, because avoiding it is not realistic at its current usage volume.
-2. **Mist fails at every size.** It is only defensible on genuinely decorative text that duplicates information available elsewhere. Any Mist text carrying unique meaning is a defect.
-3. **The accent focus ring does not meet the 3:1 focus-appearance requirement on light grounds.** `ring-offset-white` separates the ring from the control but does not raise the ring's own contrast against the page. The ring is applied via `.btn-primary:focus-visible` and repeated across the header and cards, so this is a system-wide finding rather than a page-level one.
+Two caveats that survive the audit and must not be re-litigated by eye:
 
-These are stated, not resolved. Resolving them is an `/impeccable audit` pass with its own PR, because changing `stone-warm` repaints most of the site and deserves to be reviewed as a deliberate change.
+1. **Deep Signal clears 4.5:1 on Chalk Dark by only 0.20.** It passes, with little room. Do not set Deep Signal text on any ground darker than Chalk Dark without re-measuring.
+2. **Signal Green remains non-compliant as a foreground at every size, by design.** It is a fill color. The moment it appears as text, an icon that carries meaning alone, or a focus ring, that is a regression — check it against this table rather than trusting that it "looks green enough".
 
 ## Typography
 
@@ -257,13 +259,13 @@ Three variants, all sharing a 44px minimum height and a `active:scale-[0.98]` pr
 - **Primary:** Signal Green fill, Ink text, weight 700, `shadow-sm` resting → `shadow-md` hover. Sizes: `py-3.5 px-8` default, `py-4 px-10` hero, `py-2.5 px-5` compact/header.
 - **Secondary:** White fill, `border-gray-200` → `border-gray-300` on hover, Ink text, weight 600, same shadow behavior.
 - **Ghost:** No fill, `text-gray-700` → Ink, `hover:bg-black/5`, weight 500, `px-3 py-2`. Tertiary and nav use.
-- **Focus:** All three share `ring-2 ring-accent ring-offset-2 ring-offset-white` on `:focus-visible`. Never remove this without an equivalent replacement.
+- **Focus:** All three share `ring-2 ring-accent-text ring-offset-2 ring-offset-white` on `:focus-visible` — a 2px Deep Signal ring over a 2px white gap. The white offset separates the ring from the control; the Deep Signal ring is what carries the 3:1 contrast against the page. Never remove either half, and never substitute `ring-accent`.
 - **Deliberately absent:** the primary button's shimmer sweep. `.btn-primary::before { content: none }` is an intentional removal, not dead code.
 
 ### Inputs / Fields
 
 - **Style:** White fill, `border-gray-300`, control radius (8px), `p-2` to `p-3` internal padding.
-- **Focus:** `focus-within:ring-2 ring-accent` plus `focus-within:border-accent`, over `transition-all duration-200`. The ring is on the wrapper (`focus-within`) rather than the input, because several fields wrap rich-text editors rather than bare inputs.
+- **Focus:** `focus-within:ring-2 ring-accent-text` plus `focus-within:border-accent`, over `transition-all duration-200`. The ring is Deep Signal so it clears 3:1; the Signal Green border is a secondary cue and is not relied on alone. The ring is on the wrapper (`focus-within`) rather than the input, because several fields wrap rich-text editors rather than bare inputs.
 - **Mobile:** Font size is forced to 16px below 768px to prevent iOS Safari's zoom-on-focus. This override is load-bearing; a `text-sm` utility on a mobile input will be defeated by it on purpose.
 
 ### Cards / Containers
@@ -289,7 +291,7 @@ Ad slots must never be restyled to blend into content, and must never be removed
 ## Do's and Don'ts
 
 ### Do:
-- **Do** use `text-accent-text` (`#007a48`) for any accent-colored text under 24px. `text-accent` is for fills, rings, and strokes.
+- **Do** use `text-accent-text` / `ring-accent-text` (`#007a48`) for any accent-colored text under 24px and for every focus ring. `text-accent` is for fills and decorative halos.
 - **Do** keep every interactive control at `min-h-11` (44px), including in the editor's densest rows.
 - **Do** pair `.cv-auto` with a `.cv-h-*` intrinsic-size class on every new below-fold section.
 - **Do** reserve explicit height for anything that loads late — ads, images, async status.
@@ -297,7 +299,7 @@ Ad slots must never be restyled to blend into content, and must never be removed
 - **Do** lead every section with the mono eyebrow → H2 → subtitle block.
 - **Do** use `overflow: clip` rather than `overflow: hidden` on layout containers — `hidden` silently creates a scroll container and has broken this app's flex layout before.
 - **Do** verify a design still works with the webfont unloaded; `font-display: optional` means it will be, for some visitors.
-- **Do** check any new text color against the measured-contrast table before using it. Three of this palette's own tokens currently fail AA at body size.
+- **Do** check any new text color against the measured-contrast table before using it, and measure against Chalk Dark rather than white — Chalk Dark is the darkest ground and the one that fails first.
 
 ### Don't:
 - **Don't** use `gray-*` or `slate-*` for text or backgrounds on a migrated page. Use `ink`, `stone-warm`, `mist`, `chalk`, `chalk-dark`. (`ResumeCard.tsx` currently uses `slate-200`, `gray-900`, and `gray-500` — it is un-migrated, not a precedent.)
@@ -308,8 +310,8 @@ Ad slots must never be restyled to blend into content, and must never be removed
 - **Don't** put a resting shadow on an app card.
 - **Don't** restyle, shrink, or remove ad surfaces for visual tidiness.
 - **Don't** introduce a dark mode. This system has one light world and every token, shadow, and contrast decision assumes it.
-- **Don't** put unique or task-critical information in Mist. At 2.37:1 it fails every threshold; if the user must read it to finish a job, it is the wrong color.
-- **Don't** assume the accent focus ring is accessible. It is not, on light grounds — treat any new focus treatment as needing its own contrast check rather than copying the existing one.
+- **Don't** lighten Stone Warm or Mist back toward their pre-audit values (`#8a8680` / `#a8a4a0`). Both failed AA; the current values are the result of a measured pass, not a taste call.
+- **Don't** use `ring-accent` for a focus state. Signal Green is 1.87:1 on Chalk and cannot carry a focus indicator; `ring-accent-text` is the system's focus ring.
 
 <!--
 Anti-reference: the owner has not yet confirmed a full visual don't-list. The only

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,88 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+EasyFreeResume serves three audiences, **weighted equally** — no single one is the primary persona, and design decisions are made per surface rather than around one person:
+
+1. **The cold, skeptical search visitor.** Arrives from Google having been burned by a "free" builder that paywalled the download. Must be convinced the product is genuinely free before investing effort, then reach a finished PDF quickly.
+2. **The entry-level / first-resume writer.** Student, career-starter, career-changer, or returner with sparse material and no reference for what good looks like. Needs structure, examples, and guardrails more than speed.
+3. **The mid-career ATS tailorer.** Already has a resume and is adapting it per job posting. Cares about keyword coverage and ATS pass rate. The editor + keyword scanner loop is their core workflow.
+
+Acquisition-side segments (students, veterans, IT professionals, nurses) have dedicated landing pages. These are search entry points, not separate product personas.
+
+## Product Purpose
+
+Create professional, ATS-friendly resumes in minutes, free, with no paywall at the download step. Success is a completed PDF in the user's hands — the download is the conversion event, not a signup or an upgrade.
+
+## Positioning
+
+**Actually free, verified at the download step.** The category norm is a free editor with a paid export; EasyFreeResume's differentiator is that the resume is generated and downloaded without payment, and without an account being required. The product is monetized by ads, not by gating the user's own document — a claim competitors structurally cannot copy without abandoning their revenue model.
+
+Secondary differentiators: local-first data handling (the resume lives on the user's device unless they choose otherwise), YAML export so the user can take their data and leave, and server-side PDF generation from HTML/CSS templates that keeps output text-based and machine-parseable.
+
+## Operating Context
+
+- **Anonymous by default.** Users can build and download a resume with no account at all.
+- **Optional accounts.** Signing in (Supabase auth) lets a user find their previous resumes and save **up to 5 versions / distinct resumes** in free cloud storage. Accounts are an unlock, never a gate on the core build-and-download path.
+- **Core surfaces:** landing page (`/`), templates hub (`/templates`), the editor (`/editor`, `/editor/:resumeId`), saved resumes (`/my-resumes`), keyword scanner (`/resume-keyword-scanner`), job/role example pages, and a large SEO content layer (~50 blog posts, comparison pages, keyword pages, jobs matrix).
+- **Traffic is search-dominant.** Most sessions begin on an SEO landing or blog page, not the home page. Entry is lateral and cold.
+- **Real usage scene:** a job seeker under time pressure, often on mobile, frequently mid-application. Interruption and return are normal.
+
+## Capabilities and Constraints
+
+**Capabilities**
+- Visual section-based resume editor (no YAML editing required); drag-to-reorder sections; auto-save; rich-text fields.
+- Section types: `text`, `bulleted-list`, `inline-list`, `icon-list`, `dynamic-column-list`, `experience`, `education`.
+- Four shipped templates: Professional (`classic-alex-rivera`), Elegant (`classic-jane-doe`), Minimalist (`modern-no-icons`), Modern (`modern-with-icons`).
+- Custom icon upload (PNG/JPG/SVG).
+- YAML import/export — the user's data is portable in and out.
+- Client-side keyword scanner comparing a resume against a job description.
+- Live preview of the generated resume.
+
+**Technical constraints**
+- PDF is generated server-side (Flask + Jinja2 + pdfkit) from HTML/CSS templates — the editor's visual language and the PDF's visual language are separate systems and must not be conflated.
+- Frontend is React 18 + TypeScript + Vite + Tailwind; the design system is documented in `CLAUDE.md` ("Design System (2026 Revamp)") with tokens in `tailwind.config.js`.
+- SEO pages are prerendered; Core Web Vitals (especially LCP and CLS) are actively monitored and have historically been regressed by layout and ad changes.
+
+**Binding constraints — all future design work must preserve these**
+- **AdSense placements are load-bearing.** Ads are the revenue that makes "actually free" possible. Slot inventory must stay intact; removing, burying, or shrinking units is a business decision, not a design one. Slot reference is in `CLAUDE.md`.
+- **SEO governance in `seo-tracking/` is authoritative.** Titles, H1s, meta, schema, and URLs are governed. Tier-1 pages require owner sign-off. Design cannot change them unilaterally. Read `seo-tracking/strategy.md`, `protected-pages.md`, `changelog.md`, and `mistakes-learned.md` before any SEO-affecting change, and log changes afterward.
+- **ATS-safe PDF output.** Generated PDFs must stay machine-parseable. Visual ambition in resume templates is capped by what ATS parsers survive — no multi-column tricks, images-as-text, or exotic glyphs in the output document.
+- **WCAG 2.2 AA.** Accessibility is held to a stated standard, not best-effort.
+
+**Undecided / not established**
+- Whether a paid tier exists in future. No pricing, licensing, or premium capability is confirmed — do not imply one.
+
+## Brand Commitments
+
+- Name is **EasyFreeResume**, one word. In title tags the brand name must always appear **first**, never trailing.
+- Public promise, used across marketing surfaces: **"No sign-up. No tracking. 100% free."** Design must not contradict it. Note the nuance that copy must respect: sign-up is *optional and additive*, and analytics (PostHog) exist in a privacy-conscious configuration — claims must stay accurate to what the product actually does.
+- Live product: `https://easyfreeresume.com`. Repo: `github.com/aafre/resume-builder`.
+- Design language is the documented 2026 revamp: light-dominant minimalism, chalk backgrounds, extreme type contrast (`font-extrabold` headings vs `font-extralight` body), green `#00d47e` accent used sparingly, soft multi-layer depth, rounded surfaces, scroll-triggered reveals. Tokens: `ink`, `ink-light`, `chalk`, `chalk-dark`, `stone-warm`, `mist`, `accent`. The landing page, header, and footer are the reference implementation; other pages are explicitly slated to be migrated to match.
+
+## Evidence on Hand
+
+- **Real product screenshots / template previews:** `docs/templates/*.png`, plus 26 job-example previews served from Supabase Storage CDN (runbook: `docs/templates/PREVIEW-IMAGES.md`).
+- **Real search performance data:** Google Search Console exports in `SearchConsole/` and snapshots in `seo-tracking/gsc-snapshots.md`.
+- **Real revenue data:** AdSense reporting (`scripts/adsense_report.py`).
+- **Real usage analytics:** PostHog (recently added).
+- **Working sample resumes:** `samples/classic/`, `samples/modern/`.
+- **Absent — must not be fabricated:** named customers, testimonials, user counts, review quotes, awards, press mentions, funding, team size, and any pricing or premium tier. If a surface needs social proof, it must come from something real (GitHub stars, template count, GSC-verifiable traffic) or be omitted.
+
+## Product Principles
+
+1. **The download is never held hostage.** Any flow that makes a user feel they might hit a paywall or a forced signup before getting their PDF is a product failure, regardless of how it looks.
+2. **Accounts add, never gate.** Every core capability works anonymously. Sign-in earns its place by offering something extra (finding past work, 5 cloud-saved versions), and is offered where that value is obvious rather than at the entrance.
+3. **The visitor arrives cold and lateral.** Most sessions do not start at the home page. Every surface must independently establish what this is, that it's free, and where to start.
+4. **Free is paid for by ads — respect both sides.** Ad inventory is protected, and ads must never degrade the build-and-download path or the Core Web Vitals that carry the search traffic funding it.
+5. **The PDF is the product; the UI is the workshop.** Editor and template design serve output quality and ATS survivability. Expressive design belongs in the marketing and content surfaces, not in the generated document.
+
+## Accessibility & Inclusion
+
+WCAG 2.2 AA is the required standard, confirmed as binding. Practical implications for this product: keyboard-operable editor including drag-to-reorder alternatives, visible focus states, contrast that survives the light-dominant palette (particularly `stone-warm` and `mist` on `chalk`), respect for `prefers-reduced-motion` across the scroll-reveal system, and correct labeling on the resume form controls.

--- a/resume-builder-ui/index.html
+++ b/resume-builder-ui/index.html
@@ -117,13 +117,13 @@
               <!-- Must match LandingPage.tsx hero section: pt-12 pb-20 = 3rem/5rem, clamp(2.5rem,5.5vw,4.5rem), mb-6 -->
               <div id="shell-landing" style="position:relative;padding:3rem 0 5rem;background:#fafaf8">
                 <div style="max-width:72rem;margin:0 auto;padding:0 1.5rem;width:100%">
-                  <div style="font-family:'JetBrains Mono',monospace;font-size:.75rem;letter-spacing:.15em;color:#00d47e;margin-bottom:1.5rem;text-transform:uppercase">
+                  <div style="font-family:'JetBrains Mono',monospace;font-size:.75rem;letter-spacing:.15em;color:#007a48;margin-bottom:1.5rem;text-transform:uppercase">
                     FREE FOREVER. NO SIGN-UP.
                   </div>
                   <h1 style="font-family:'Bricolage Grotesque','Bricolage Fallback',system-ui,sans-serif;font-size:clamp(2.5rem,5.5vw,4.5rem);font-weight:800;line-height:1.08;color:#0c0c0c;margin-bottom:1.5rem;letter-spacing:-.025em">
                     Free Resume Builder &mdash; Build Resumes That Get You Hired
                   </h1>
-                  <p style="font-family:'Bricolage Grotesque','Bricolage Fallback',system-ui,sans-serif;font-size:1.125rem;font-weight:200;color:#8a8680;max-width:32rem;line-height:1.6;margin-bottom:2rem">
+                  <p style="font-family:'Bricolage Grotesque','Bricolage Fallback',system-ui,sans-serif;font-size:1.125rem;font-weight:200;color:#6b6761;max-width:32rem;line-height:1.6;margin-bottom:2rem">
                     Build your resume for free online with ATS-friendly templates. Download as PDF instantly &mdash; no sign up, no payment, no watermarks.
                   </p>
                   <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
@@ -134,7 +134,7 @@
                       View Templates
                     </a>
                   </div>
-                  <p style="font-family:'JetBrains Mono',monospace;font-size:.75rem;letter-spacing:.05em;color:#8a8680">
+                  <p style="font-family:'JetBrains Mono',monospace;font-size:.75rem;letter-spacing:.05em;color:#6b6761">
                     100% free · No sign-up
                   </p>
                 </div>
@@ -161,7 +161,7 @@
             </div>
           </div>
         </main>
-        <footer id="app-footer" data-nosnippet style="background:#f0efe9;color:#8a8680;border-top:1px solid rgba(0,0,0,.06);margin-top:auto;contain:layout style paint;overflow:clip">
+        <footer id="app-footer" data-nosnippet style="background:#f0efe9;color:#6b6761;border-top:1px solid rgba(0,0,0,.06);margin-top:auto;contain:layout style paint;overflow:clip">
           <div style="padding:3rem 1rem;min-height:550px"></div>
         </footer>
       </div>

--- a/resume-builder-ui/src/components/AboutUs.tsx
+++ b/resume-builder-ui/src/components/AboutUs.tsx
@@ -43,7 +43,7 @@ export default function AboutUs() {
                   Home
                 </Link>
               </li>
-              <li className="text-mist">/</li>
+              <li className="text-stone-warm">/</li>
               <li className="text-ink font-medium">About Us</li>
             </ol>
           </nav>

--- a/resume-builder-ui/src/components/AnonymousWarningBadge.tsx
+++ b/resume-builder-ui/src/components/AnonymousWarningBadge.tsx
@@ -82,7 +82,7 @@ export default function AnonymousWarningBadge({ onSignInClick }: AnonymousWarnin
                   hover:bg-accent/90
                   hover:shadow-md
                   transition-all duration-300
-                  focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2
+                  focus:outline-none focus:ring-2 focus:ring-accent-text focus:ring-offset-2
                 "
               >
                 Create Free Account

--- a/resume-builder-ui/src/components/AuthModal.tsx
+++ b/resume-builder-ui/src/components/AuthModal.tsx
@@ -137,7 +137,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onSuccess }) => 
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
-                      className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent"
+                      className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-text focus:border-transparent"
                       disabled={loading}
                     />
                   </div>

--- a/resume-builder-ui/src/components/BlogIndex.tsx
+++ b/resume-builder-ui/src/components/BlogIndex.tsx
@@ -58,7 +58,7 @@ export default function BlogIndex() {
                       <span className="px-3 py-1 bg-accent text-ink text-sm font-bold rounded-full">
                         Featured
                       </span>
-                      <span className="font-mono text-xs tracking-[0.15em] text-mist uppercase">
+                      <span className="font-mono text-xs tracking-[0.15em] text-stone-warm-inverse uppercase">
                         {featuredPost.category}
                       </span>
                     </div>
@@ -72,12 +72,12 @@ export default function BlogIndex() {
                       </Link>
                     </h2>
 
-                    <p className="font-display font-extralight text-mist text-lg mb-8 leading-relaxed max-w-3xl">
+                    <p className="font-display font-extralight text-stone-warm-inverse text-lg mb-8 leading-relaxed max-w-3xl">
                       {featuredPost.description}
                     </p>
 
                     <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                      <div className="flex items-center gap-4 text-sm text-mist font-mono">
+                      <div className="flex items-center gap-4 text-sm text-stone-warm-inverse font-mono">
                         <time dateTime={featuredPost.publishDate}>
                           {new Date(
                             featuredPost.publishDate
@@ -147,7 +147,7 @@ export default function BlogIndex() {
 
                       <h3 className="font-display text-lg font-extrabold mb-3 leading-tight">
                         {post.comingSoon ? (
-                          <span className="text-mist cursor-not-allowed">
+                          <span className="text-stone-warm cursor-not-allowed">
                             {post.title}
                           </span>
                         ) : (
@@ -165,7 +165,7 @@ export default function BlogIndex() {
                       </p>
 
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-3 text-xs text-mist font-mono">
+                        <div className="flex items-center gap-3 text-xs text-stone-warm font-mono">
                           <time dateTime={post.publishDate}>
                             {new Date(post.publishDate).toLocaleDateString(
                               "en-US",
@@ -180,7 +180,7 @@ export default function BlogIndex() {
                         </div>
 
                         {post.comingSoon ? (
-                          <span className="text-mist text-sm font-medium cursor-not-allowed">
+                          <span className="text-stone-warm text-sm font-medium cursor-not-allowed">
                             Coming Soon
                           </span>
                         ) : (
@@ -221,7 +221,7 @@ export default function BlogIndex() {
                   <h2 className="font-display text-2xl md:text-3xl font-extrabold text-white mt-3 mb-4">
                     Ready to Put These Tips into Action?
                   </h2>
-                  <p className="font-display text-lg font-extralight text-mist mb-8 max-w-2xl mx-auto">
+                  <p className="font-display text-lg font-extralight text-stone-warm-inverse mb-8 max-w-2xl mx-auto">
                     Create a professional resume in minutes with our free resume
                     builder
                   </p>

--- a/resume-builder-ui/src/components/BlogLayout.tsx
+++ b/resume-builder-ui/src/components/BlogLayout.tsx
@@ -126,11 +126,11 @@ export default function BlogLayout({
               <li>
                 <Link to="/" className="hover:text-accent transition-colors">Home</Link>
               </li>
-              <li className="text-mist">/</li>
+              <li className="text-stone-warm">/</li>
               <li>
                 <Link to="/blog" className="hover:text-accent transition-colors">Blog</Link>
               </li>
-              <li className="text-mist">/</li>
+              <li className="text-stone-warm">/</li>
               <li className="text-ink font-semibold truncate max-w-[200px] sm:max-w-none" title={title}>{title}</li>
             </ol>
           </nav>
@@ -181,7 +181,7 @@ export default function BlogLayout({
               </span>
             ))}
             {keywords.length > 5 && (
-              <span className="px-3 py-1 text-mist font-mono text-[10px] tracking-[0.1em] sm:hidden">
+              <span className="px-3 py-1 text-stone-warm font-mono text-[10px] tracking-[0.1em] sm:hidden">
                 +{keywords.length - 5} more
               </span>
             )}

--- a/resume-builder-ui/src/components/Contact.tsx
+++ b/resume-builder-ui/src/components/Contact.tsx
@@ -105,7 +105,7 @@ export default function Contact() {
                   Home
                 </Link>
               </li>
-              <li className="text-mist">/</li>
+              <li className="text-stone-warm">/</li>
               <li className="text-ink font-medium">Contact</li>
             </ol>
           </nav>
@@ -349,7 +349,7 @@ export default function Contact() {
                       <p className="text-stone-warm">
                         We typically respond within 24 hours
                       </p>
-                      <p className="text-sm text-mist mt-1">
+                      <p className="text-sm text-stone-warm mt-1">
                         Monday - Friday, 9 AM - 6 PM EST
                       </p>
                     </div>

--- a/resume-builder-ui/src/components/ContactInfoSection.tsx
+++ b/resume-builder-ui/src/components/ContactInfoSection.tsx
@@ -50,7 +50,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
             onChange={(e) =>
               onUpdate({ ...contactInfo, name: e.target.value })
             }
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
             placeholder="Enter your name"
             aria-label="Full name"
           />
@@ -69,7 +69,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
             onChange={(e) =>
               onUpdate({ ...contactInfo, location: e.target.value })
             }
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
             placeholder="Enter your location"
             aria-label="Location"
           />
@@ -88,7 +88,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
             onChange={(e) =>
               onUpdate({ ...contactInfo, email: e.target.value })
             }
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
             placeholder="Enter your email"
             aria-label="Email address"
           />
@@ -107,7 +107,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
             onChange={(e) =>
               onUpdate({ ...contactInfo, phone: e.target.value })
             }
-            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+            className="w-full border border-gray-300 rounded-xl p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
             placeholder="Enter your phone"
             aria-label="Phone number"
           />
@@ -121,7 +121,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
           <button
             type="button"
             onClick={onAddSocialLink}
-            className="bg-accent hover:bg-accent/90 text-ink px-4 py-2 rounded-lg transition-all duration-200 text-sm font-semibold flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+            className="bg-accent hover:bg-accent/90 text-ink px-4 py-2 rounded-lg transition-all duration-200 text-sm font-semibold flex items-center gap-2 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-accent-text focus:ring-offset-2"
             aria-label="Add social link"
           >
             <MdAdd className="text-lg" />
@@ -154,7 +154,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
                       onChange={(e) =>
                         onSocialLinkChange(index, "platform", e.target.value)
                       }
-                      className="w-full border border-gray-300 rounded-lg p-2.5 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200 bg-white"
+                      className="w-full border border-gray-300 rounded-lg p-2.5 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200 bg-white"
                       aria-label={`Platform for social link ${index + 1}`}
                     >
                       <option value="">Select platform...</option>
@@ -181,7 +181,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
                       className={`w-full border rounded-lg p-2.5 focus:ring-2 focus:border-accent transition-all duration-200 ${
                         socialLinkErrors[index]
                           ? "border-red-300 focus:ring-red-500 bg-red-50"
-                          : "border-gray-300 focus:ring-accent"
+                          : "border-gray-300 focus:ring-accent-text"
                       }`}
                       placeholder="Enter profile URL"
                       aria-label={`URL for social link ${index + 1}`}
@@ -208,7 +208,7 @@ const ContactInfoSection: React.FC<ContactInfoSectionProps> = ({
                         onChange={(e) =>
                           onSocialLinkChange(index, "display_text", e.target.value)
                         }
-                        className="w-full border border-gray-300 rounded-lg p-2.5 pr-10 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+                        className="w-full border border-gray-300 rounded-lg p-2.5 pr-10 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
                         placeholder="How it appears on resume"
                         aria-label={`Display text for social link ${index + 1}`}
                       />

--- a/resume-builder-ui/src/components/DownloadCelebrationModal.tsx
+++ b/resume-builder-ui/src/components/DownloadCelebrationModal.tsx
@@ -268,7 +268,7 @@ const DownloadCelebrationModal: React.FC<DownloadCelebrationModalProps> = ({
               {/* Divider */}
               <div className="flex items-center gap-3 mb-4">
                 <div className="flex-1 h-px bg-black/[0.06]" />
-                <span className="text-xs font-semibold text-mist uppercase tracking-wider">
+                <span className="text-xs font-semibold text-stone-warm uppercase tracking-wider">
                   What&apos;s Next?
                 </span>
                 <div className="flex-1 h-px bg-black/[0.06]" />
@@ -292,7 +292,7 @@ const DownloadCelebrationModal: React.FC<DownloadCelebrationModalProps> = ({
                         {affiliateConfig.resumeReview.description}
                       </p>
                     </div>
-                    <ExternalLink className="w-4 h-4 text-mist flex-shrink-0" />
+                    <ExternalLink className="w-4 h-4 text-stone-warm flex-shrink-0" />
                   </a>
                 )}
 
@@ -352,7 +352,7 @@ const DownloadCelebrationModal: React.FC<DownloadCelebrationModalProps> = ({
                                 </p>
                               )}
                             </div>
-                            <ExternalLink className="w-4 h-4 text-mist flex-shrink-0" />
+                            <ExternalLink className="w-4 h-4 text-stone-warm flex-shrink-0" />
                           </a>
                         );
                       })}
@@ -380,7 +380,7 @@ const DownloadCelebrationModal: React.FC<DownloadCelebrationModalProps> = ({
           <div className="mt-6 animate-dcm-content-fade-up" style={{ animationDelay: '225ms' }}>
             <div className="flex items-center gap-3 mb-4">
               <div className="flex-1 h-px bg-black/[0.06]" />
-              <span className="text-xs font-semibold text-mist uppercase tracking-wider">
+              <span className="text-xs font-semibold text-stone-warm uppercase tracking-wider">
                 One more thing
               </span>
               <div className="flex-1 h-px bg-black/[0.06]" />

--- a/resume-builder-ui/src/components/DuplicateResumeModal.tsx
+++ b/resume-builder-ui/src/components/DuplicateResumeModal.tsx
@@ -71,7 +71,7 @@ export function DuplicateResumeModal({
                 onChange={(e) => setNewTitle(e.target.value)}
                 disabled={isDuplicating}
                 autoFocus
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent focus:border-accent disabled:bg-gray-100 disabled:cursor-not-allowed"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-text focus:border-accent disabled:bg-gray-100 disabled:cursor-not-allowed"
                 placeholder="Enter new title"
                 maxLength={200}
               />

--- a/resume-builder-ui/src/components/EditableTitle.tsx
+++ b/resume-builder-ui/src/components/EditableTitle.tsx
@@ -73,7 +73,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
           value={temporaryTitle}
           onChange={(e) => onTitleChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="border border-gray-300 rounded-lg p-2 w-full text-xl font-semibold focus:outline-none focus:ring-2 focus:ring-accent"
+          className="border border-gray-300 rounded-lg p-2 w-full text-xl font-semibold focus:outline-none focus:ring-2 focus:ring-accent-text"
           autoFocus
           placeholder="Enter section title..."
         />

--- a/resume-builder-ui/src/components/ExperienceItem.tsx
+++ b/resume-builder-ui/src/components/ExperienceItem.tsx
@@ -123,7 +123,7 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
               value={item.company}
               onChange={(value) => handleUpdateField("company", value)}
               placeholder="Enter company name"
-              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
             />
           </div>
           <div>
@@ -132,7 +132,7 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
               value={item.title}
               onChange={(value) => handleUpdateField("title", value)}
               placeholder="Enter job title"
-              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
             />
           </div>
           <div>
@@ -141,7 +141,7 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
               type="text"
               value={item.dates}
               onChange={(e) => handleUpdateField("dates", e.target.value)}
-              className="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200"
+              className="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200"
               placeholder="e.g., Jan 2020 - Present"
             />
           </div>
@@ -174,7 +174,7 @@ const ExperienceItem: React.FC<ExperienceItemProps> = React.memo(({
                               value={desc}
                               onChange={(value) => handleDescUpdate(descIndex, value)}
                               placeholder="Describe your responsibilities, achievements, or key projects..."
-                              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+                              className="w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
                             />
                           </div>
                           <button

--- a/resume-builder-ui/src/components/Footer.tsx
+++ b/resume-builder-ui/src/components/Footer.tsx
@@ -62,7 +62,7 @@ function FooterColumn({
   links: { path: string; label: string; external?: boolean }[];
   scrollToTop: (path: string) => () => void;
 }) {
-  const linkClass = "inline-flex min-h-11 items-center rounded-md text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
+  const linkClass = "inline-flex min-h-11 items-center rounded-md text-gray-600 hover:text-accent font-medium transition-colors duration-200 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2";
   return (
     <nav aria-label={title}>
       <h3 className="font-bold text-gray-900 mb-4 text-sm md:text-base">{title}</h3>
@@ -146,7 +146,7 @@ export default function Footer() {
                 href="https://www.trustpilot.com/review/easyfreeresume.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 bg-emerald-50 px-3 py-2 rounded-lg hover:bg-emerald-100 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                className="flex items-center gap-2 bg-emerald-50 px-3 py-2 rounded-lg hover:bg-emerald-100 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
               >
                 <FaStar className="text-emerald-600" />
                 <span className="text-emerald-700 font-medium">Trustpilot</span>

--- a/resume-builder-ui/src/components/FormattingBubbleMenu.tsx
+++ b/resume-builder-ui/src/components/FormattingBubbleMenu.tsx
@@ -98,7 +98,7 @@ export const FormattingBubbleMenu: React.FC<FormattingBubbleMenuProps> = ({ edit
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleBold().run()}
-          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus:outline-none ${
+          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1 focus:outline-none ${
             editor.isActive('bold') ? 'bg-accent/10 text-ink/80' : 'text-gray-700'
           }`}
           title="Bold (Ctrl+B)"
@@ -115,7 +115,7 @@ export const FormattingBubbleMenu: React.FC<FormattingBubbleMenuProps> = ({ edit
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleItalic().run()}
-          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus:outline-none ${
+          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1 focus:outline-none ${
             editor.isActive('italic') ? 'bg-accent/10 text-ink/80' : 'text-gray-700'
           }`}
           title="Italic (Ctrl+I)"
@@ -133,7 +133,7 @@ export const FormattingBubbleMenu: React.FC<FormattingBubbleMenuProps> = ({ edit
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleUnderline().run()}
-          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus:outline-none ${
+          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1 focus:outline-none ${
             editor.isActive('underline') ? 'bg-accent/10 text-ink/80' : 'text-gray-700'
           }`}
           title="Underline (Ctrl+U)"
@@ -150,7 +150,7 @@ export const FormattingBubbleMenu: React.FC<FormattingBubbleMenuProps> = ({ edit
         <button
           type="button"
           onClick={() => editor.chain().focus().toggleStrike().run()}
-          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus:outline-none ${
+          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1 focus:outline-none ${
             editor.isActive('strike') ? 'bg-accent/10 text-ink/80' : 'text-gray-700'
           }`}
           title="Strikethrough (Ctrl+Shift+S)"
@@ -169,7 +169,7 @@ export const FormattingBubbleMenu: React.FC<FormattingBubbleMenuProps> = ({ edit
         <button
           type="button"
           onClick={handleOpenLinkModal}
-          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus:outline-none ${
+          className={`p-2 rounded transition-all hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1 focus:outline-none ${
             editor.isActive('link') ? 'bg-accent/10 text-ink/80' : 'text-accent'
           }`}
           title="Insert Link (Ctrl+K)"

--- a/resume-builder-ui/src/components/GenericSection.tsx
+++ b/resume-builder-ui/src/components/GenericSection.tsx
@@ -115,7 +115,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
               value={section.content || ""}
               onChange={(value) => handleContentChange(value)}
               placeholder="Enter text..."
-              className="w-full border border-gray-300 rounded-lg p-2 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+              className="w-full border border-gray-300 rounded-lg p-2 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
               rows={4}
             />
           </>
@@ -149,7 +149,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                                 value={item}
                                 onChange={(value) => handleContentChange(value, index)}
                                 placeholder="Add item..."
-                                className="w-full border border-gray-300 rounded-lg p-2 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+                                className="w-full border border-gray-300 rounded-lg p-2 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
                               />
                             </div>
                             <button
@@ -211,7 +211,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                                   value={item}
                                   onChange={(value) => handleContentChange(value, index)}
                                   placeholder="Add skill or item..."
-                                  className="w-full border border-gray-300 rounded-lg p-2 text-sm focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+                                  className="w-full border border-gray-300 rounded-lg p-2 text-sm focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
                                 />
                               </div>
                               <button
@@ -273,7 +273,7 @@ const GenericSection: React.FC<GenericSectionProps> = ({
                                   value={item}
                                   onChange={(value) => handleContentChange(value, index)}
                                   placeholder="Add item..."
-                                  className="w-full border border-gray-300 rounded-lg p-2 text-sm focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200"
+                                  className="w-full border border-gray-300 rounded-lg p-2 text-sm focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200"
                                 />
                               </div>
                               <button

--- a/resume-builder-ui/src/components/Header.tsx
+++ b/resume-builder-ui/src/components/Header.tsx
@@ -51,7 +51,7 @@ export default function Header() {
           {/* Logo and Home Navigation */}
           <Link
             to="/"
-            className="group flex min-h-11 min-w-11 items-center rounded-lg transition-all duration-200 relative flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="group flex min-h-11 min-w-11 items-center rounded-lg transition-all duration-200 relative flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
             aria-label="Go to homepage"
           >
             <LogoMark
@@ -69,7 +69,7 @@ export default function Header() {
               <Link
                 to="/my-resumes"
                 id="tour-my-resumes-link"
-                className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+                className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                   location.pathname === '/my-resumes'
                     ? 'bg-ink text-white shadow-sm'
                     : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -84,7 +84,7 @@ export default function Header() {
               </Link>
               <Link
                 to="/templates"
-                className={`inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+                className={`inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                   location.pathname === '/templates'
                     ? 'bg-ink text-white shadow-sm'
                     : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -95,7 +95,7 @@ export default function Header() {
               {affiliateConfig.jobSearch.enabled && (
                 <Link
                   to="/jobs"
-                  className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+                  className={`relative inline-flex min-h-11 items-center px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                     location.pathname === '/jobs'
                       ? 'bg-ink text-white shadow-sm'
                       : 'text-gray-600 hover:bg-black/5 hover:text-ink'
@@ -136,7 +136,7 @@ export default function Header() {
                 {/* My Resumes Icon with Badge */}
                 <Link
                   to="/my-resumes"
-                  className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg hover:bg-black/5 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                  className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg hover:bg-black/5 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
                   aria-label={`My Resumes${resumeCount > 0 ? ` (${resumeCount})` : ''}`}
                 >
                   <div className="relative">
@@ -183,7 +183,7 @@ export default function Header() {
                     <button
                       id="tour-sign-in-button"
                       onClick={showAuthModal}
-                      className="flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 font-semibold text-sm transition-all duration-200 text-ink hover:text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 lg:hover:no-underline lg:px-5 lg:bg-ink lg:text-white lg:shadow-sm lg:hover:shadow-md"
+                      className="flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 font-semibold text-sm transition-all duration-200 text-ink hover:text-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 lg:hover:no-underline lg:px-5 lg:bg-ink lg:text-white lg:shadow-sm lg:hover:shadow-md"
                     >
                       <span>Sign In</span>
                     </button>

--- a/resume-builder-ui/src/components/InputWithLinkButton.tsx
+++ b/resume-builder-ui/src/components/InputWithLinkButton.tsx
@@ -122,7 +122,7 @@ export const InputWithLinkButton: React.FC<InputWithLinkButtonProps> = ({
     setShowModal(true);
   };
 
-  const defaultInputClassName = "flex-1 border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all duration-200";
+  const defaultInputClassName = "flex-1 border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all duration-200";
   const combinedClassName = className || defaultInputClassName;
 
   return (

--- a/resume-builder-ui/src/components/JobsPage.tsx
+++ b/resume-builder-ui/src/components/JobsPage.tsx
@@ -505,7 +505,7 @@ export default function JobsPage() {
               <div className="flex flex-col sm:flex-row gap-3">
                 {/* Job Title */}
                 <div className="flex-1 relative">
-                  <Briefcase className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-mist" />
+                  <Briefcase className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-warm" />
                   <input
                     type="text"
                     value={titleInput}
@@ -517,7 +517,7 @@ export default function JobsPage() {
 
                 {/* Location */}
                 <div className="flex-1 relative">
-                  <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-mist" />
+                  <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-warm" />
                   <input
                     type="text"
                     value={locationInput}
@@ -529,7 +529,7 @@ export default function JobsPage() {
 
                 {/* Country */}
                 <div className="relative sm:w-44">
-                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-mist pointer-events-none" />
+                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-warm pointer-events-none" />
                   <select
                     value={country}
                     onChange={(e) => setCountry(e.target.value)}
@@ -557,7 +557,7 @@ export default function JobsPage() {
               </div>
 
               {/* Drop hint */}
-              <p className="text-xs text-mist text-center mt-2 flex items-center justify-center gap-1">
+              <p className="text-xs text-stone-warm text-center mt-2 flex items-center justify-center gap-1">
                 <Upload className="w-3 h-3" />
                 Or drag &amp; drop your resume (PDF/DOCX) for an instant personalized search
               </p>
@@ -595,7 +595,7 @@ export default function JobsPage() {
               <Sparkles className="w-4 h-4 text-accent" />
               <h3 className="text-sm font-display font-bold text-ink">Consider these related roles</h3>
             </div>
-            <p className="text-xs text-mist mb-3">Based on your resume skills and experience</p>
+            <p className="text-xs text-stone-warm mb-3">Based on your resume skills and experience</p>
             <div className="flex flex-wrap gap-2">
               {suggestions.alternative_roles.map((role) => (
                 <button
@@ -624,7 +624,7 @@ export default function JobsPage() {
 
         {/* Tier 3 AI Transparency */}
         {hasSearched && !loading && aiTermsUsed.length > 0 && (
-          <div className="flex items-center gap-2 mb-6 text-xs text-mist">
+          <div className="flex items-center gap-2 mb-6 text-xs text-stone-warm">
             <Info className="w-3.5 h-3.5 flex-shrink-0" />
             <span>Also searched for:</span>
             {aiTermsUsed.map((term) => (
@@ -647,7 +647,7 @@ export default function JobsPage() {
               </div>
               <button
                 onClick={handleClearResume}
-                className="p-1 rounded-lg hover:bg-black/5 text-mist hover:text-ink transition-colors flex-shrink-0"
+                className="p-1 rounded-lg hover:bg-black/5 text-stone-warm hover:text-ink transition-colors flex-shrink-0"
                 aria-label="Clear resume context"
               >
                 <X className="w-4 h-4" />
@@ -658,7 +658,7 @@ export default function JobsPage() {
                 <span className="font-medium">{resumeContext.displayTitle}</span>
               )}
               {resumeContext.displayTitle && resumeContext.skills.length > 0 && (
-                <span className="text-mist">|</span>
+                <span className="text-stone-warm">|</span>
               )}
               {resumeContext.skills.length > 0 && (
                 <span className="flex items-center gap-1 flex-wrap">
@@ -668,13 +668,13 @@ export default function JobsPage() {
                     </span>
                   ))}
                   {resumeContext.skills.length > 3 && (
-                    <span className="text-mist">+{resumeContext.skills.length - 3}</span>
+                    <span className="text-stone-warm">+{resumeContext.skills.length - 3}</span>
                   )}
                 </span>
               )}
               {resumeContext.yearsExperience > 0 && (
                 <>
-                  <span className="text-mist">|</span>
+                  <span className="text-stone-warm">|</span>
                   <span>{resumeContext.yearsExperience}yr exp</span>
                 </>
               )}
@@ -684,7 +684,7 @@ export default function JobsPage() {
 
         {/* Nudge Banner — when no resume */}
         {hasSearched && !loading && jobs.length > 0 && !resumeContext && (
-          <div className="flex items-center gap-2 mb-6 text-xs text-mist">
+          <div className="flex items-center gap-2 mb-6 text-xs text-stone-warm">
             <Upload className="w-3.5 h-3.5 text-accent flex-shrink-0" />
             <span>Drop your resume on the search box for personalized match scores</span>
           </div>
@@ -747,7 +747,7 @@ export default function JobsPage() {
                               ? 'bg-accent/10 text-accent'
                               : job.match_score >= 40
                                 ? 'bg-amber-50 text-amber-600'
-                                : 'bg-gray-100 text-mist'
+                                : 'bg-gray-100 text-stone-warm'
                           }`}>
                             {Math.round(job.match_score)}% match
                           </span>
@@ -762,7 +762,7 @@ export default function JobsPage() {
                           </span>
                         )}
                         {posted && (
-                          <span className="text-xs text-mist flex items-center gap-1">
+                          <span className="text-xs text-stone-warm flex items-center gap-1">
                             <Clock className="w-3 h-3" />
                             {posted}
                           </span>
@@ -798,7 +798,7 @@ export default function JobsPage() {
         {/* No Results State */}
         {hasSearched && !loading && !error && jobs.length === 0 && (
           <div className="text-center py-12 bg-white rounded-2xl card-gradient-border shadow-premium">
-            <Search className="w-12 h-12 mx-auto mb-3 text-mist" />
+            <Search className="w-12 h-12 mx-auto mb-3 text-stone-warm" />
             <h3 className="text-lg font-display font-bold text-ink mb-2">No jobs found</h3>
             <p className="text-sm text-stone-warm mb-6">Try different keywords or a broader location</p>
             <div className="flex flex-wrap justify-center gap-2 max-w-lg mx-auto">
@@ -818,9 +818,9 @@ export default function JobsPage() {
         {/* Empty State (before searching) — Popular searches */}
         {!hasSearched && !loading && (
           <div className="text-center py-12">
-            <Briefcase className="w-12 h-12 mx-auto mb-3 text-mist" />
+            <Briefcase className="w-12 h-12 mx-auto mb-3 text-stone-warm" />
             <p className="text-lg font-display font-bold text-ink mb-1">Search for your next opportunity</p>
-            <p className="text-sm text-mist mb-6">Or try one of these popular searches</p>
+            <p className="text-sm text-stone-warm mb-6">Or try one of these popular searches</p>
             <div className="flex flex-wrap justify-center gap-2 max-w-2xl mx-auto">
               {POPULAR_SEARCHES.map((title) => (
                 <button
@@ -837,7 +837,7 @@ export default function JobsPage() {
 
         {/* Powered by */}
         <div className="text-center mt-8 mb-12">
-          <p className="text-xs text-mist">
+          <p className="text-xs text-stone-warm">
             Job listings powered by Adzuna
           </p>
         </div>

--- a/resume-builder-ui/src/components/JobsPage.tsx
+++ b/resume-builder-ui/src/components/JobsPage.tsx
@@ -511,7 +511,7 @@ export default function JobsPage() {
                     value={titleInput}
                     onChange={(e) => setTitleInput(e.target.value)}
                     placeholder="Job title (e.g. Software Engineer)"
-                    className="w-full pl-10 pr-4 py-3 border border-black/[0.06] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                    className="w-full pl-10 pr-4 py-3 border border-black/[0.06] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-transparent"
                   />
                 </div>
 
@@ -523,7 +523,7 @@ export default function JobsPage() {
                     value={locationInput}
                     onChange={(e) => setLocationInput(e.target.value)}
                     placeholder="City or region (optional)"
-                    className="w-full pl-10 pr-4 py-3 border border-black/[0.06] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                    className="w-full pl-10 pr-4 py-3 border border-black/[0.06] rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-transparent"
                   />
                 </div>
 
@@ -533,7 +533,7 @@ export default function JobsPage() {
                   <select
                     value={country}
                     onChange={(e) => setCountry(e.target.value)}
-                    className="w-full appearance-none pl-4 pr-10 py-3 border border-black/[0.06] rounded-xl text-sm bg-white focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                    className="w-full appearance-none pl-4 pr-10 py-3 border border-black/[0.06] rounded-xl text-sm bg-white focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-transparent"
                   >
                     {ADZUNA_COUNTRIES.map((c) => (
                       <option key={c.code} value={c.code}>{c.label}</option>

--- a/resume-builder-ui/src/components/KebabMenu.tsx
+++ b/resume-builder-ui/src/components/KebabMenu.tsx
@@ -59,7 +59,7 @@ export function KebabMenu({
           e.stopPropagation();
           setIsOpen(!isOpen);
         }}
-        className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+        className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
         title="More options"
         aria-label="More options"
         aria-haspopup="menu"

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -702,7 +702,7 @@ const LandingPage: React.FC = () => {
                 key={index}
                 className="border-b border-black/[0.06] last:border-b-0 group"
               >
-                <summary className="flex items-center justify-between w-full text-left py-5 cursor-pointer list-none [&::-webkit-details-marker]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-lg">
+                <summary className="flex items-center justify-between w-full text-left py-5 cursor-pointer list-none [&::-webkit-details-marker]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 rounded-lg">
                   <h3 className="font-display text-base font-extrabold text-ink pr-4">
                     {faq.question}
                   </h3>

--- a/resume-builder-ui/src/components/LandingPage.tsx
+++ b/resume-builder-ui/src/components/LandingPage.tsx
@@ -496,7 +496,7 @@ const LandingPage: React.FC = () => {
                 </div>
                 <div className="flex-1 flex justify-center">
                   <div className="bg-white/5 rounded-md px-4 py-1">
-                    <span className="font-mono text-[11px] text-mist">youtube.com/@EasyFreeResume</span>
+                    <span className="font-mono text-[11px] text-stone-warm-inverse">youtube.com/@EasyFreeResume</span>
                   </div>
                 </div>
               </div>
@@ -738,7 +738,7 @@ const LandingPage: React.FC = () => {
                 <h2 className="font-display text-3xl md:text-[3.5rem] font-extrabold text-white mb-6 tracking-tight leading-tight">
                   Ready to Land Your Dream Job?
                 </h2>
-                <p className="font-display text-lg font-extralight text-mist mb-10 max-w-xl mx-auto leading-relaxed">
+                <p className="font-display text-lg font-extralight text-stone-warm-inverse mb-10 max-w-xl mx-auto leading-relaxed">
                   Join thousands of job seekers who've successfully created
                   professional resumes with our free builder.
                 </p>

--- a/resume-builder-ui/src/components/LinkInsertionModal.tsx
+++ b/resume-builder-ui/src/components/LinkInsertionModal.tsx
@@ -121,7 +121,7 @@ export const LinkInsertionModal: React.FC<LinkInsertionModalProps> = ({
               value={linkText}
               onChange={(e) => setLinkText(e.target.value)}
               placeholder="e.g., Visit our website"
-              className="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all"
+              className="w-full border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all"
               autoFocus
             />
           </div>
@@ -143,7 +143,7 @@ export const LinkInsertionModal: React.FC<LinkInsertionModalProps> = ({
               placeholder="e.g., https://example.com"
               className={`w-full border ${
                 urlError ? 'border-red-500' : 'border-gray-300'
-              } rounded-lg p-3 focus:ring-2 focus:ring-accent focus:border-accent transition-all`}
+              } rounded-lg p-3 focus:ring-2 focus:ring-accent-text focus:border-accent transition-all`}
               aria-invalid={!!urlError}
               aria-describedby={urlError ? "url-error" : undefined}
             />

--- a/resume-builder-ui/src/components/MobileActionBar.tsx
+++ b/resume-builder-ui/src/components/MobileActionBar.tsx
@@ -90,7 +90,7 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
         <button
           onClick={onNavigationClick}
           disabled={isGenerating || isGeneratingPreview}
-          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 rounded-lg transition-all disabled:opacity-50 hover:bg-gray-100 active:bg-gray-200 active:scale-[0.98] border border-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+          className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 rounded-lg transition-all disabled:opacity-50 hover:bg-gray-100 active:bg-gray-200 active:scale-[0.98] border border-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
           aria-label="Open navigation menu"
         >
           <MdMenu className="text-2xl text-gray-700 mb-1.5" aria-hidden="true" />
@@ -102,7 +102,7 @@ const MobileActionBar: React.FC<MobileActionBarProps> = ({
           <button
             onClick={onPreviewClick}
             disabled={isPreviewLoading || isGenerating}
-            className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-accent text-ink rounded-lg shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="flex flex-col items-center justify-center min-h-[60px] px-3 py-2 bg-accent text-ink rounded-lg shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
             aria-label="Preview resume PDF"
             >
             {/* Staleness indicator */}

--- a/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
+++ b/resume-builder-ui/src/components/MobileNavigationDrawer.tsx
@@ -249,7 +249,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           {/* Add Section Button */}
           <button
             onClick={() => handleAction(onAddSection)}
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent text-ink rounded-lg font-medium shadow-sm hover:shadow-md active:scale-[0.98] transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent text-ink rounded-lg font-medium shadow-sm hover:shadow-md active:scale-[0.98] transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
           >
             <MdAdd className="text-xl" />
             <span>Add Section</span>
@@ -259,7 +259,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
           <div className="relative">
             <button
               onClick={() => setShowAdvancedMenu(!showAdvancedMenu)}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 active:bg-gray-100 transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 active:bg-gray-100 transition-all min-h-[48px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
             >
               <MdMoreVert className="text-xl" />
               <span>More Options</span>
@@ -272,7 +272,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 <button
                   onClick={() => handleAction(onExportYAML)}
                   disabled={loadingSave}
-                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-inset"
                 >
                   {loadingSave ? (
                     <span className="h-2 w-8 overflow-hidden rounded-full bg-accent/20">
@@ -293,7 +293,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 <button
                   onClick={() => handleAction(onImportYAML)}
                   disabled={loadingLoad}
-                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-green-50 active:bg-green-100 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-green-50 active:bg-green-100 transition-colors flex items-center gap-3 border-b border-gray-100 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-inset"
                 >
                   {loadingLoad ? (
                     <span className="h-2 w-8 overflow-hidden rounded-full bg-green-100">
@@ -313,7 +313,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 {/* Start Fresh */}
                 <button
                   onClick={() => handleAction(onStartFresh)}
-                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-orange-50 active:bg-orange-100 transition-colors flex items-center gap-3 border-b border-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-orange-50 active:bg-orange-100 transition-colors flex items-center gap-3 border-b border-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-inset"
                 >
                   <MdRefresh className="text-orange-600 text-xl" />
                   <div className="flex-1">
@@ -325,7 +325,7 @@ const MobileNavigationDrawer: React.FC<MobileNavigationDrawerProps> = ({
                 {/* Help */}
                 <button
                   onClick={() => handleAction(onHelp)}
-                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
+                  className="w-full min-h-11 text-left px-4 py-3 hover:bg-accent/[0.06] active:bg-accent/10 transition-colors flex items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-inset"
                 >
                   <MdHelpOutline className="text-accent text-xl" />
                   <div className="flex-1">

--- a/resume-builder-ui/src/components/ResumeCard.tsx
+++ b/resume-builder-ui/src/components/ResumeCard.tsx
@@ -126,7 +126,7 @@ export function ResumeCard({
             e.currentTarget.click();
           }
         }}
-        className={`relative bg-slate-100 h-48 overflow-hidden rounded-t-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+        className={`relative bg-slate-100 h-48 overflow-hidden rounded-t-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
           isPreviewLoading ? 'cursor-wait' : 'cursor-pointer'
         }`}
         onClick={() => !isPreviewLoading && onPreview(resume.id)}
@@ -182,11 +182,11 @@ export function ResumeCard({
             autoFocus
             disabled={isSaving}
             maxLength={200}
-            className="font-bold text-xl text-gray-900 w-full bg-white border border-slate-300 rounded-lg px-2 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50 mb-2"
+            className="font-bold text-xl text-gray-900 w-full bg-white border border-slate-300 rounded-lg px-2 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text disabled:opacity-50 mb-2"
           />
         ) : (
           <h3
-            className="font-bold text-xl text-gray-900 truncate mb-2 cursor-text hover:bg-gray-50 rounded-lg px-2 py-2 -mx-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="font-bold text-xl text-gray-900 truncate mb-2 cursor-text hover:bg-gray-50 rounded-lg px-2 py-2 -mx-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text"
             role="button"
             tabIndex={0}
             aria-label={`Rename ${resume.title}`}
@@ -224,7 +224,7 @@ export function ResumeCard({
               onEdit(resume.id);
             }}
             disabled={isEditButtonLoading}
-            className={`flex-1 min-h-11 bg-accent text-ink py-2 px-4 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+            className={`flex-1 min-h-11 bg-accent text-ink py-2 px-4 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
               isEditButtonLoading
                 ? 'opacity-75 cursor-not-allowed'
                 : 'hover:bg-accent/90 active:scale-[0.98]'
@@ -247,7 +247,7 @@ export function ResumeCard({
               e.stopPropagation();
               onDownload(resume.id);
             }}
-            className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
             title="Download PDF"
             aria-label="Download PDF"
           >

--- a/resume-builder-ui/src/components/RichTextArea.tsx
+++ b/resume-builder-ui/src/components/RichTextArea.tsx
@@ -56,7 +56,7 @@ export const RichTextArea: React.FC<RichTextAreaProps> = ({
     }
   }, [value, editor]);
 
-  const defaultClassName = "w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200";
+  const defaultClassName = "w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200";
   const combinedClassName = className || defaultClassName;
   const minHeight = `${rows * 24 + 24}px`; // Approximate height based on rows
 

--- a/resume-builder-ui/src/components/RichTextInput.tsx
+++ b/resume-builder-ui/src/components/RichTextInput.tsx
@@ -54,7 +54,7 @@ export const RichTextInput: React.FC<RichTextInputProps> = ({
     }
   }, [value, editor]);
 
-  const defaultClassName = "w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent focus-within:border-accent transition-all duration-200 min-h-[44px]";
+  const defaultClassName = "w-full border border-gray-300 rounded-lg p-3 focus-within:ring-2 focus-within:ring-accent-text focus-within:border-accent transition-all duration-200 min-h-[44px]";
   const combinedClassName = className || defaultClassName;
 
   return (

--- a/resume-builder-ui/src/components/SectionControls.tsx
+++ b/resume-builder-ui/src/components/SectionControls.tsx
@@ -27,7 +27,7 @@ const SectionControls: React.FC<{
         title="Move section up"
         onClick={() => moveSection(sectionIndex, sectionIndex - 1)}
         disabled={sectionIndex === 0}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent-text ${
           sectionIndex === 0
             ? "bg-gray-300 cursor-not-allowed text-gray-500"
             : "bg-accent hover:bg-accent text-ink"
@@ -41,7 +41,7 @@ const SectionControls: React.FC<{
         title="Move section down"
         onClick={() => moveSection(sectionIndex, sectionIndex + 1)}
         disabled={sectionIndex === sections.length - 1}
-        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent ${
+        className={`p-2 rounded focus-visible:ring-2 focus-visible:ring-accent-text ${
           sectionIndex === sections.length - 1
             ? "bg-gray-300 cursor-not-allowed text-gray-500"
             : "bg-accent hover:bg-accent text-ink"

--- a/resume-builder-ui/src/components/SectionHeader.tsx
+++ b/resume-builder-ui/src/components/SectionHeader.tsx
@@ -94,7 +94,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
           <button
             type="button"
             onClick={onToggleCollapse}
-            className="p-2 text-gray-600 hover:text-accent hover:bg-accent/[0.06] rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            className="p-2 text-gray-600 hover:text-accent hover:bg-accent/[0.06] rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1"
             aria-label={isCollapsed ? "Expand section" : "Collapse section"}
             title={isCollapsed ? "Expand section" : "Collapse section"}
           >
@@ -122,7 +122,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
           <button
             type="button"
             onClick={onDelete}
-            className="flex items-center gap-1.5 text-gray-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm font-medium hover:text-red-600 hover:border-red-300 hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            className="flex items-center gap-1.5 text-gray-500 border border-gray-300 px-3 py-1.5 rounded-lg text-sm font-medium hover:text-red-600 hover:border-red-300 hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-1"
             title="Remove Section"
 
 

--- a/resume-builder-ui/src/components/SectionNavigator.tsx
+++ b/resume-builder-ui/src/components/SectionNavigator.tsx
@@ -316,7 +316,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
         )}
         <button
           onClick={handleToggle}
-          className={`inline-flex min-h-11 min-w-11 items-center justify-center p-2 hover:bg-white rounded-lg transition-all text-gray-500 hover:text-gray-800 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+          className={`inline-flex min-h-11 min-w-11 items-center justify-center p-2 hover:bg-white rounded-lg transition-all text-gray-500 hover:text-gray-800 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
             isCollapsed ? "mx-auto" : ""
           }`}
           aria-label={isCollapsed ? "Expand sidebar (Ctrl+\\)" : "Collapse sidebar (Ctrl+\\)"}
@@ -557,7 +557,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               id="tour-preview-button"
               onClick={onPreviewResume}
               disabled={isPreviewLoading}
-              className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-semibold rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-semibold rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2.5 px-1 mb-2"
                   : "flex-row gap-2 px-4 py-2.5 mb-2.5"
@@ -612,7 +612,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
           {/* Secondary Action: Add Section */}
           <button
             onClick={onAddSection}
-            className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-medium rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+            className={`w-full min-h-11 flex items-center justify-center bg-accent text-ink font-medium rounded-lg shadow-sm hover:shadow-md hover:bg-accent/90 transition-all active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
               isCollapsed
                 ? "flex-col gap-1 py-2 px-1 mt-2"
                 : "flex-row gap-2 px-4 py-2 mb-3"
@@ -631,7 +631,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
               id="tour-backup-button"
               onClick={onExportYAML}
               disabled={loadingSave}
-              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]"
                   : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06] text-gray-700 hover:text-ink/80"
@@ -668,7 +668,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             <button
               onClick={onImportYAML}
               disabled={loadingLoad}
-              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-green-50/80"
                   : "flex-row gap-3 px-3 py-2 hover:bg-green-50/80 text-green-800 hover:text-green-700"
@@ -697,7 +697,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             {/* Start Fresh - KEEP LABEL AS-IS (not renamed) */}
             <button
               onClick={handleStartFresh}
-              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-orange-50/80"
                   : "flex-row gap-3 px-3 py-2 hover:bg-orange-50/80 text-orange-800 hover:text-orange-700"
@@ -720,7 +720,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
             {/* Help */}
             <button
               onClick={onHelp}
-              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-accent/[0.06]"
                   : "flex-row gap-3 px-3 py-2 hover:bg-accent/[0.06] text-gray-700 hover:text-ink/80"
@@ -745,7 +745,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
           <div className={`border-t border-gray-200/60 ${isCollapsed ? "pt-2 px-2" : "pt-3 px-4"}`}>
             <Link
               to="/contact"
-              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+              className={`w-full min-h-11 flex items-center transition-all rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                 isCollapsed
                   ? "flex-col gap-1 py-2 px-1 hover:bg-teal-50/80"
                   : "flex-row gap-3 px-3 py-2 hover:bg-teal-50/80 text-teal-800 hover:text-teal-700"

--- a/resume-builder-ui/src/components/SectionNavigator.tsx
+++ b/resume-builder-ui/src/components/SectionNavigator.tsx
@@ -455,7 +455,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
                       Will your resume pass the filter?
                     </p>
                   </div>
-                  <ChevronRight className="w-4 h-4 text-mist group-hover:text-accent group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+                  <ChevronRight className="w-4 h-4 text-stone-warm group-hover:text-accent group-hover:translate-x-0.5 transition-all flex-shrink-0" />
                 </div>
               </a>
             )
@@ -535,7 +535,7 @@ const SectionNavigator: React.FC<SectionNavigatorProps> = ({
                       Matched to your resume skills
                     </p>
                   </div>
-                  <ChevronRight className="w-4 h-4 text-mist group-hover:text-accent group-hover:translate-x-0.5 transition-all flex-shrink-0" />
+                  <ChevronRight className="w-4 h-4 text-stone-warm group-hover:text-accent group-hover:translate-x-0.5 transition-all flex-shrink-0" />
                 </div>
               </Link>
             )

--- a/resume-builder-ui/src/components/SectionTypeModal.tsx
+++ b/resume-builder-ui/src/components/SectionTypeModal.tsx
@@ -137,7 +137,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
             <button
               type="button"
               onClick={() => handleTopBottomSelect('top')}
-              className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-md text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-md text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text
                 ${selectedPosition === 'top'
                   ? 'bg-accent text-ink shadow-sm'
                   : 'text-gray-600 hover:bg-accent/[0.06] hover:text-ink/80'
@@ -149,7 +149,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
             <button
               type="button"
               onClick={() => handleTopBottomSelect('bottom')}
-              className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-md text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-md text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text
                 ${selectedPosition === 'bottom'
                   ? 'bg-accent text-ink shadow-sm'
                   : 'text-gray-600 hover:bg-accent/[0.06] hover:text-ink/80'
@@ -166,7 +166,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
               <button
                 type="button"
                 onClick={() => setShowAfterSection(!showAfterSection)}
-                className={`text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded ${
+                className={`text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text rounded ${
                   showAfterSection || !isTopOrBottom
                     ? 'text-ink/80'
                     : 'text-accent hover:text-ink/80'
@@ -182,7 +182,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
                       key={`${section.name}-${index}`}
                       type="button"
                       onClick={() => handleAfterSectionSelect(index + 1)}
-                      className={`px-3 py-1.5 text-xs rounded-full border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+                      className={`px-3 py-1.5 text-xs rounded-full border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text
                         ${selectedPosition === index + 1
                           ? 'bg-accent text-ink border-accent'
                           : 'bg-white text-gray-600 border-gray-300 hover:border-accent/40 hover:text-ink/80'
@@ -206,7 +206,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
                 type="button"
                 onClick={() => handleTypeSelect(section.type)}
                 className={`group flex flex-col text-left bg-white rounded-xl border
-                           overflow-hidden shadow-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+                           overflow-hidden shadow-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text
                            ${isSelected
                              ? 'border-accent ring-2 ring-accent/30 shadow-md'
                              : 'border-gray-200 hover:shadow-md hover:border-accent/70 hover:ring-2 hover:ring-accent/20'
@@ -234,7 +234,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
         <div className="mt-4 sm:mt-6 flex gap-3">
           <button
             type="button"
-            className="flex-1 bg-gray-100 text-gray-700 px-4 py-2.5 rounded-lg font-medium hover:bg-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="flex-1 bg-gray-100 text-gray-700 px-4 py-2.5 rounded-lg font-medium hover:bg-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text"
             onClick={onClose}
           >
             Cancel
@@ -243,7 +243,7 @@ const SectionTypeModal: React.FC<SectionTypeModalProps> = ({
             type="button"
             onClick={handleConfirm}
             disabled={!selectedType}
-            className={`flex-1 px-4 py-2.5 rounded-lg font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+            className={`flex-1 px-4 py-2.5 rounded-lg font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-text
                        ${selectedType
                          ? 'bg-accent text-ink hover:bg-accent/90'
                          : 'bg-gray-200 text-gray-400 cursor-not-allowed'

--- a/resume-builder-ui/src/components/SignInRequiredGate.tsx
+++ b/resume-builder-ui/src/components/SignInRequiredGate.tsx
@@ -131,7 +131,7 @@ export default function SignInRequiredGate({
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="you@example.com"
-                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent focus:border-transparent"
+                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-accent-text focus:border-transparent"
                     disabled={loading}
                   />
                 </div>

--- a/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
+++ b/resume-builder-ui/src/components/blog/AIResumePromptsHub.tsx
@@ -438,7 +438,7 @@ export default function AIResumePromptsHub() {
             <SectionEyebrow>The Short Answer</SectionEyebrow>
             <time
               dateTime={REVIEW_DATE}
-              className="font-mono text-[11px] tracking-[0.15em] text-mist uppercase block mb-3"
+              className="font-mono text-[11px] tracking-[0.15em] text-stone-warm uppercase block mb-3"
             >
               Last reviewed {REVIEW_DATE} · Refresh cadence: Quarterly
             </time>
@@ -596,7 +596,7 @@ export default function AIResumePromptsHub() {
                   id={model.id}
                   className="bg-white rounded-2xl p-6 md:p-8 shadow-premium shadow-premium-hover hover:-translate-y-0.5 transition-all duration-300"
                 >
-                  <span className="font-mono text-[11px] tracking-[0.15em] text-mist uppercase block mb-2">
+                  <span className="font-mono text-[11px] tracking-[0.15em] text-stone-warm uppercase block mb-2">
                     {String(idx + 1).padStart(2, "0")} / {String(MODEL_SECTIONS.length).padStart(2, "0")}
                   </span>
                   <h3 className="font-display text-xl font-bold text-ink">{model.name}</h3>

--- a/resume-builder-ui/src/components/blog/AuthorBio.tsx
+++ b/resume-builder-ui/src/components/blog/AuthorBio.tsx
@@ -23,7 +23,7 @@ export default function AuthorBio() {
               >
                 More articles &rarr;
               </Link>
-              <span className="text-mist">|</span>
+              <span className="text-stone-warm">|</span>
               <Link
                 to="/templates"
                 className="text-sm font-medium text-accent hover:text-ink transition-colors"

--- a/resume-builder-ui/src/components/blog/HowToUseResumeKeywords.tsx
+++ b/resume-builder-ui/src/components/blog/HowToUseResumeKeywords.tsx
@@ -306,7 +306,7 @@ export default function HowToUseResumeKeywords() {
               </Link>
               .
             </p>
-            <div className="text-sm text-mist">
+            <div className="text-sm text-stone-warm">
               Common keywords: Python, React, Agile, CI/CD, AWS, Microservices
             </div>
           </div>
@@ -325,7 +325,7 @@ export default function HowToUseResumeKeywords() {
               </Link>
               .
             </p>
-            <div className="text-sm text-mist">
+            <div className="text-sm text-stone-warm">
               Common keywords: CRM, Zendesk, Customer Satisfaction, Conflict
               Resolution
             </div>

--- a/resume-builder-ui/src/components/blog/RelatedArticles.tsx
+++ b/resume-builder-ui/src/components/blog/RelatedArticles.tsx
@@ -50,7 +50,7 @@ export default function RelatedArticles({ currentSlug, category, maxArticles = 3
               {post.description}
             </p>
 
-            <div className="flex items-center gap-3 text-[11px] text-mist font-mono">
+            <div className="flex items-center gap-3 text-[11px] text-stone-warm font-mono">
               <time dateTime={post.publishDate}>
                 {new Date(post.publishDate).toLocaleDateString('en-US', {
                   month: 'short',

--- a/resume-builder-ui/src/components/editor/EditorContent.tsx
+++ b/resume-builder-ui/src/components/editor/EditorContent.tsx
@@ -280,7 +280,7 @@ export const EditorContent: React.FC<EditorContentProps> = ({
           </div>
           <button
             onClick={modals.closeAIWarning}
-            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2"
             aria-label="Close review banner"
           >
             <X className="w-4 h-4" />

--- a/resume-builder-ui/src/components/editor/EditorHeader.tsx
+++ b/resume-builder-ui/src/components/editor/EditorHeader.tsx
@@ -215,7 +215,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
                 handleBadgeClick();
                 dismissMobileBanner();
               }}
-              className="flex min-h-11 items-center gap-2 flex-1 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="flex min-h-11 items-center gap-2 flex-1 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
             >
               <JobSparkleIcon className="w-4 h-4 flex-shrink-0 text-accent" />
               <span className="text-sm font-medium truncate">
@@ -225,7 +225,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
             </Link>
             <button
               onClick={dismissMobileBanner}
-              className="ml-2 inline-flex min-h-11 min-w-11 items-center justify-center p-1 hover:bg-white/10 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+              className="ml-2 inline-flex min-h-11 min-w-11 items-center justify-center p-1 hover:bg-white/10 rounded-lg transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
               aria-label="Dismiss"
             >
               <X className="w-4 h-4" />

--- a/resume-builder-ui/src/components/editor/EditorHeader.tsx
+++ b/resume-builder-ui/src/components/editor/EditorHeader.tsx
@@ -174,7 +174,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
         <JobSparkleIcon className="w-3.5 h-3.5 text-accent" />
       )}
       <div className="flex flex-col leading-none">
-        <span className="text-[10px] uppercase font-bold text-mist tracking-wider group-hover:text-accent transition-colors">
+        <span className="text-[10px] uppercase font-bold text-stone-warm tracking-wider group-hover:text-accent transition-colors">
           Matches
         </span>
         <span className="text-xs font-bold text-ink tabular-nums">
@@ -221,7 +221,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
               <span className="text-sm font-medium truncate">
                 {jobCount} jobs matched to your skills
               </span>
-              <span className="text-xs text-mist flex-shrink-0">View &rarr;</span>
+              <span className="text-xs text-stone-warm-inverse flex-shrink-0">View &rarr;</span>
             </Link>
             <button
               onClick={dismissMobileBanner}

--- a/resume-builder-ui/src/components/jobs/FilterChips.tsx
+++ b/resume-builder-ui/src/components/jobs/FilterChips.tsx
@@ -31,7 +31,7 @@ export default function FilterChips({ filters, onRemove, onClearAll }: FilterChi
         <button
           type="button"
           onClick={onClearAll}
-          className="text-xs text-mist hover:text-ink underline"
+          className="text-xs text-stone-warm hover:text-ink underline"
         >
           Clear all
         </button>

--- a/resume-builder-ui/src/components/jobs/JobFilters.tsx
+++ b/resume-builder-ui/src/components/jobs/JobFilters.tsx
@@ -158,7 +158,7 @@ export default function JobFilters({ filters, onChange, hasLocation }: JobFilter
               <select
                 value={filters.distance}
                 onChange={(e) => updateFilter('distance', Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-text"
               >
                 {DISTANCE_OPTIONS.map((o) => (
                   <option key={o.value} value={o.value}>{o.label}</option>
@@ -174,7 +174,7 @@ export default function JobFilters({ filters, onChange, hasLocation }: JobFilter
               value={filters.company}
               onChange={(e) => updateFilter('company', e.target.value)}
               placeholder="e.g. Google"
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-text"
             />
           </FilterField>
 
@@ -185,7 +185,7 @@ export default function JobFilters({ filters, onChange, hasLocation }: JobFilter
               value={filters.whatExclude}
               onChange={(e) => updateFilter('whatExclude', e.target.value)}
               placeholder="e.g. senior, manager"
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-text"
             />
           </FilterField>
 
@@ -194,7 +194,7 @@ export default function JobFilters({ filters, onChange, hasLocation }: JobFilter
             <select
               value={filters.salaryMax}
               onChange={(e) => updateFilter('salaryMax', Number(e.target.value))}
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-text"
             >
               <option value={0}>No max</option>
               {SALARY_PRESETS.map((p) => (
@@ -209,7 +209,7 @@ export default function JobFilters({ filters, onChange, hasLocation }: JobFilter
               <select
                 value={filters.sortDir}
                 onChange={(e) => updateFilter('sortDir', e.target.value as FilterState['sortDir'])}
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-text"
               >
                 <option value="">Default</option>
                 <option value="down">Highest first</option>
@@ -245,7 +245,7 @@ function QuickSelect({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="px-2.5 py-1.5 border border-gray-200 rounded-lg text-xs bg-white focus:outline-none focus:ring-2 focus:ring-accent appearance-none cursor-pointer hover:border-gray-300 transition-colors"
+      className="px-2.5 py-1.5 border border-gray-200 rounded-lg text-xs bg-white focus:outline-none focus:ring-2 focus:ring-accent-text appearance-none cursor-pointer hover:border-gray-300 transition-colors"
     >
       {options.map((o) => (
         <option key={o.value} value={o.value}>{o.label}</option>

--- a/resume-builder-ui/src/components/jobs/JobsLandingPage.tsx
+++ b/resume-builder-ui/src/components/jobs/JobsLandingPage.tsx
@@ -82,7 +82,7 @@ export default function JobsLandingPage() {
   if (!data) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-12 text-center">
-        <p className="text-mist">No job data available for this page.</p>
+        <p className="text-stone-warm">No job data available for this page.</p>
         <Link to="/jobs" className="text-accent hover:underline mt-2 inline-block">
           Back to Jobs
         </Link>
@@ -266,9 +266,9 @@ function JobCard({ job }: { job: PseoJob }) {
             </a>
           </h2>
           <p className="text-sm text-stone-warm mt-0.5">{job.company}</p>
-          <p className="text-sm text-mist mt-0.5">{job.location}</p>
+          <p className="text-sm text-stone-warm mt-0.5">{job.location}</p>
           {job.description && (
-            <p className="text-sm text-mist mt-1 line-clamp-2">{job.description}</p>
+            <p className="text-sm text-stone-warm mt-1 line-clamp-2">{job.description}</p>
           )}
         </div>
         <div className="text-right flex-shrink-0">

--- a/resume-builder-ui/src/components/jobs/JobsRoleHub.tsx
+++ b/resume-builder-ui/src/components/jobs/JobsRoleHub.tsx
@@ -55,7 +55,7 @@ export default function JobsRoleHub() {
   if (!data) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-12 text-center">
-        <p className="text-mist">No data available.</p>
+        <p className="text-stone-warm">No data available.</p>
         <Link to="/jobs" className="text-accent hover:underline mt-2 inline-block">
           Back to Jobs
         </Link>
@@ -107,7 +107,7 @@ export default function JobsRoleHub() {
             className="bg-white rounded-2xl border border-black/[0.06] p-3 hover:border-accent/30 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300 text-center"
           >
             <span className="block text-sm font-medium text-ink">{loc.name}</span>
-            <span className="block text-xs text-mist mt-0.5">View jobs &rarr;</span>
+            <span className="block text-xs text-stone-warm mt-0.5">View jobs &rarr;</span>
           </Link>
         ))}
       </div>

--- a/resume-builder-ui/src/components/seo/ActualFreeResumeBuilder.tsx
+++ b/resume-builder-ui/src/components/seo/ActualFreeResumeBuilder.tsx
@@ -130,7 +130,7 @@ export default function ActualFreeResumeBuilder() {
               </tr>
             </tbody>
           </table>
-          <p className="text-sm text-mist mt-4 text-center">
+          <p className="text-sm text-stone-warm mt-4 text-center">
             Comparison based on publicly available pricing from popular resume builders (Jan 2026)
           </p>
         </div>

--- a/resume-builder-ui/src/components/seo/BestFreeResumeBuilderReddit.tsx
+++ b/resume-builder-ui/src/components/seo/BestFreeResumeBuilderReddit.tsx
@@ -194,7 +194,7 @@ export default function BestFreeResumeBuilderReddit() {
             </tbody>
           </table>
         </div>
-        <p className="text-xs text-mist text-center max-w-3xl mx-auto mt-4">
+        <p className="text-xs text-stone-warm text-center max-w-3xl mx-auto mt-4">
           Based on publicly documented free-plan behavior; specific plans change over time, so verify
           the download step yourself before relying on any tool.
         </p>
@@ -327,7 +327,7 @@ export default function BestFreeResumeBuilderReddit() {
         <div className="max-w-4xl mx-auto space-y-4">
           <div className="bg-white rounded-2xl shadow-premium border border-black/[0.06] p-6">
             <div className="flex items-center gap-2 mb-3">
-              <span className="text-sm font-medium text-mist">r/resumes</span>
+              <span className="text-sm font-medium text-stone-warm">r/resumes</span>
             </div>
             <p className="text-stone-warm">
               A recurring frustration is building a full resume on a "free" tool only to be asked for
@@ -337,7 +337,7 @@ export default function BestFreeResumeBuilderReddit() {
           </div>
           <div className="bg-white rounded-2xl shadow-premium border border-black/[0.06] p-6">
             <div className="flex items-center gap-2 mb-3">
-              <span className="text-sm font-medium text-mist">r/jobs</span>
+              <span className="text-sm font-medium text-stone-warm">r/jobs</span>
             </div>
             <p className="text-stone-warm">
               A common warning is that design-first tools (like graphic-design apps) can produce
@@ -347,7 +347,7 @@ export default function BestFreeResumeBuilderReddit() {
           </div>
           <div className="bg-white rounded-2xl shadow-premium border border-black/[0.06] p-6">
             <div className="flex items-center gap-2 mb-3">
-              <span className="text-sm font-medium text-mist">r/cscareerquestions</span>
+              <span className="text-sm font-medium text-stone-warm">r/cscareerquestions</span>
             </div>
             <p className="text-stone-warm">
               For tech resumes, the repeated guidance is to keep formatting simple and ATS-parseable.

--- a/resume-builder-ui/src/components/seo/CVTemplatesPage.tsx
+++ b/resume-builder-ui/src/components/seo/CVTemplatesPage.tsx
@@ -196,7 +196,7 @@ export default function CVTemplatesPage() {
               <p className="mb-2">
                 <strong>Standard UK CV:</strong> 2 pages is the accepted length for most professional roles.
               </p>
-              <p className="text-sm text-mist">
+              <p className="text-sm text-stone-warm">
                 Exceptions: Academic CVs can be longer. Entry-level CVs may be 1 page.
                 Senior executives with 15+ years experience may extend to 3 pages if needed.
               </p>

--- a/resume-builder-ui/src/components/seo/FreeCVBuilder.tsx
+++ b/resume-builder-ui/src/components/seo/FreeCVBuilder.tsx
@@ -52,7 +52,7 @@ export default function FreeCVBuilder() {
                   <li>Canada</li>
                   <li>Corporate roles (US companies)</li>
                 </ul>
-                <p className="mt-4 text-sm text-mist">
+                <p className="mt-4 text-sm text-stone-warm">
                   Our templates work for both—the format is the same; only the terminology differs.
                 </p>
               </div>

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderDownload.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderDownload.tsx
@@ -100,7 +100,7 @@ export default function FreeResumeBuilderDownload() {
               </ul>
             </div>
           </div>
-          <p className="text-sm text-mist mt-6 text-center max-w-2xl mx-auto">
+          <p className="text-sm text-stone-warm mt-6 text-center max-w-2xl mx-auto">
             Not sure which to choose? Use PDF for most online applications. Use DOCX if the job posting
             asks for Word format or if you want to edit the file later.
           </p>
@@ -311,7 +311,7 @@ export default function FreeResumeBuilderDownload() {
                 </div>
               </div>
             </div>
-            <p className="text-sm text-mist">
+            <p className="text-sm text-stone-warm">
               All EasyFreeResume templates are built to be{' '}
               <Link to="/templates/ats-friendly" className="text-accent hover:underline">
                 ATS-friendly

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderNoPayment.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderNoPayment.tsx
@@ -138,7 +138,7 @@ export default function FreeResumeBuilderNoPayment() {
                 ))}
               </tbody>
             </table>
-            <p className="text-sm text-mist mt-4 text-center">
+            <p className="text-sm text-stone-warm mt-4 text-center">
               Pricing data collected from publicly available information (March 2026). Prices may vary by region.
             </p>
           </div>
@@ -257,7 +257,7 @@ export default function FreeResumeBuilderNoPayment() {
               </div>
             ))}
           </div>
-          <p className="text-sm text-mist mt-6 text-center">
+          <p className="text-sm text-stone-warm mt-6 text-center">
             Scenarios based on common user patterns. Want to see how free resume builders compare?
             Read our{' '}
             <Link to="/blog/best-free-resume-builders-2026" className="text-accent hover:underline">

--- a/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
+++ b/resume-builder-ui/src/components/seo/FreeResumeBuilderNoSignUp.tsx
@@ -219,7 +219,7 @@ export default function FreeResumeBuilderNoSignUp() {
             </tbody>
           </table>
         </div>
-        <p className="text-center text-sm text-mist mt-4 max-w-2xl mx-auto">
+        <p className="text-center text-sm text-stone-warm mt-4 max-w-2xl mx-auto">
           Pricing based on published rates for Zety, Resume.io, and Resume Genius as of February 2026.
           See our detailed <Link to="/best-free-resume-builder-reddit" className="text-accent hover:underline">Reddit-recommended builders comparison</Link>.
         </p>

--- a/resume-builder-ui/src/components/seo/JobExamplePage.tsx
+++ b/resume-builder-ui/src/components/seo/JobExamplePage.tsx
@@ -274,7 +274,7 @@ export default function JobExamplePage() {
               <div className="bg-white rounded-2xl shadow-premium border border-black/[0.06] overflow-hidden">
                 <div className="bg-chalk px-6 py-4 border-b border-black/[0.06] flex items-center justify-between">
                   <h2 className="font-bold text-ink">Resume Preview</h2>
-                  <span className="text-sm text-mist">
+                  <span className="text-sm text-stone-warm">
                     Template: {data.resume.template.charAt(0).toUpperCase() + data.resume.template.slice(1)}
                   </span>
                 </div>
@@ -326,12 +326,12 @@ export default function JobExamplePage() {
                             <p className="font-semibold text-ink">{exp.title}</p>
                             <p className="text-stone-warm">{exp.company}</p>
                           </div>
-                          <p className="text-mist text-sm">{exp.dates}</p>
+                          <p className="text-stone-warm text-sm">{exp.dates}</p>
                         </div>
                         <ul className="mt-2 space-y-1">
                           {exp.bullets.map((bullet, bIndex) => (
                             <li key={bIndex} className="text-ink/80 text-sm pl-4 relative">
-                              <span className="absolute left-0 text-mist">&bull;</span>
+                              <span className="absolute left-0 text-stone-warm">&bull;</span>
                               {bullet}
                             </li>
                           ))}
@@ -349,7 +349,7 @@ export default function JobExamplePage() {
                           <p className="font-semibold text-ink">{edu.degree}</p>
                           <p className="text-stone-warm">{edu.school}</p>
                         </div>
-                        <p className="text-mist text-sm">{edu.year}</p>
+                        <p className="text-stone-warm text-sm">{edu.year}</p>
                       </div>
                     ))}
                   </div>
@@ -373,7 +373,7 @@ export default function JobExamplePage() {
                       <ul className="space-y-1">
                         {data.resume.certifications.map((cert, index) => (
                           <li key={index} className="text-ink/80 text-sm pl-4 relative">
-                            <span className="absolute left-0 text-mist">&bull;</span>
+                            <span className="absolute left-0 text-stone-warm">&bull;</span>
                             {cert}
                           </li>
                         ))}

--- a/resume-builder-ui/src/components/seo/TemplatesHub.tsx
+++ b/resume-builder-ui/src/components/seo/TemplatesHub.tsx
@@ -167,27 +167,27 @@ export default function TemplatesHub() {
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">Workday</div>
-                <p className="text-mist text-xs mt-1">Fortune 500 standard</p>
+                <p className="text-stone-warm text-xs mt-1">Fortune 500 standard</p>
               </div>
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">Taleo (Oracle)</div>
-                <p className="text-mist text-xs mt-1">Enterprise & government</p>
+                <p className="text-stone-warm text-xs mt-1">Enterprise & government</p>
               </div>
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">iCIMS</div>
-                <p className="text-mist text-xs mt-1">Large employers</p>
+                <p className="text-stone-warm text-xs mt-1">Large employers</p>
               </div>
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">Greenhouse</div>
-                <p className="text-mist text-xs mt-1">Tech & startups</p>
+                <p className="text-stone-warm text-xs mt-1">Tech & startups</p>
               </div>
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">Lever</div>
-                <p className="text-mist text-xs mt-1">Mid-size tech</p>
+                <p className="text-stone-warm text-xs mt-1">Mid-size tech</p>
               </div>
               <div className="bg-white rounded-xl p-5 shadow-premium border border-black/[0.06] text-center">
                 <div className="font-display font-bold text-ink text-lg">BambooHR</div>
-                <p className="text-mist text-xs mt-1">Small to mid-size</p>
+                <p className="text-stone-warm text-xs mt-1">Small to mid-size</p>
               </div>
             </div>
           </div>

--- a/resume-builder-ui/src/components/shared/ActionIcon.tsx
+++ b/resume-builder-ui/src/components/shared/ActionIcon.tsx
@@ -58,7 +58,7 @@ export const ActionIcon: React.FC<ActionIconProps> = ({
       disabled={disabled}
       className={`
         inline-flex items-center justify-center rounded-md transition-colors duration-150
-        focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1
+        focus:outline-none focus:ring-2 focus:ring-accent-text focus:ring-offset-1
         disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent
         ${variantStyles[variant]}
         ${sizeStyles[size]}

--- a/resume-builder-ui/src/components/shared/BreadcrumbsWithSchema.tsx
+++ b/resume-builder-ui/src/components/shared/BreadcrumbsWithSchema.tsx
@@ -21,7 +21,7 @@ export default function BreadcrumbsWithSchema({
       <ol className="flex items-center space-x-2 text-sm text-stone-warm">
         {breadcrumbs.map((crumb, index) => (
           <li key={index} className="flex items-center">
-            {index > 0 && <span className="mx-2 text-mist">/</span>}
+            {index > 0 && <span className="mx-2 text-stone-warm">/</span>}
             {index === breadcrumbs.length - 1 ? (
               <span className="font-medium text-ink">{crumb.label}</span>
             ) : (

--- a/resume-builder-ui/src/components/shared/BulletPointBank.tsx
+++ b/resume-builder-ui/src/components/shared/BulletPointBank.tsx
@@ -77,12 +77,12 @@ export default function BulletPointBank({ categories, jobTitle }: BulletPointBan
                   <span className="font-semibold text-ink">
                     {category.category}
                   </span>
-                  <span className="text-sm text-mist">
+                  <span className="text-sm text-stone-warm">
                     ({category.bullets.length} bullets)
                   </span>
                 </div>
                 <svg
-                  className={`w-5 h-5 text-mist transition-transform ${
+                  className={`w-5 h-5 text-stone-warm transition-transform ${
                     expandedCategories.has(category.category) ? 'rotate-180' : ''
                   }`}
                   fill="none"
@@ -118,7 +118,7 @@ export default function BulletPointBank({ categories, jobTitle }: BulletPointBan
                         `}
                       >
                         <div className="flex items-start gap-3">
-                          <span className="text-mist mt-0.5" aria-hidden="true">
+                          <span className="text-stone-warm mt-0.5" aria-hidden="true">
                             &bull;
                           </span>
                           <p className="text-ink/80 flex-1 pr-12">
@@ -136,7 +136,7 @@ export default function BulletPointBank({ categories, jobTitle }: BulletPointBan
                               Copied!
                             </span>
                           ) : (
-                            <span className="flex items-center gap-1 text-mist group-hover:text-accent text-sm">
+                            <span className="flex items-center gap-1 text-stone-warm group-hover:text-accent text-sm">
                               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                               </svg>

--- a/resume-builder-ui/src/components/shared/FAQSection.tsx
+++ b/resume-builder-ui/src/components/shared/FAQSection.tsx
@@ -35,7 +35,7 @@ export default function FAQSection({
             <summary className="px-6 py-4 text-left flex justify-between items-center bg-chalk hover:bg-chalk-dark transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">
               <span className="font-semibold text-ink pr-4">{faq.question}</span>
               <ChevronDownIcon
-                className="w-5 h-5 text-mist flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                className="w-5 h-5 text-stone-warm flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
               />
             </summary>
             <div className="faq-content">

--- a/resume-builder-ui/src/components/shared/GhostButton.tsx
+++ b/resume-builder-ui/src/components/shared/GhostButton.tsx
@@ -39,7 +39,7 @@ export const GhostButton: React.FC<GhostButtonProps> = ({
         text-gray-500 text-sm font-medium
         bg-transparent
         hover:border-accent/70 hover:text-accent hover:bg-accent/[0.06]
-        focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-1
+        focus:outline-none focus:ring-2 focus:ring-accent-text focus:ring-offset-1
         transition-colors duration-150
         disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-gray-300 disabled:hover:text-gray-500 disabled:hover:bg-transparent
         ${className}

--- a/resume-builder-ui/src/components/shared/InlineTextEditor.tsx
+++ b/resume-builder-ui/src/components/shared/InlineTextEditor.tsx
@@ -127,7 +127,7 @@ export const InlineTextEditor: React.FC<InlineTextEditorProps> = ({
         placeholder={placeholder}
         className={`
           bg-white border border-accent/70 rounded px-2 py-1
-          focus:outline-none focus:ring-2 focus:ring-accent
+          focus:outline-none focus:ring-2 focus:ring-accent-text
           ${textClassName}
           ${inputClassName}
           ${className}
@@ -153,7 +153,7 @@ export const InlineTextEditor: React.FC<InlineTextEditorProps> = ({
         cursor-pointer rounded px-2 py-1 -mx-2 -my-1
         border border-transparent
         hover:border-gray-300 hover:bg-gray-50
-        focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent
+        focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-transparent
         transition-colors duration-150
         ${disabled ? 'cursor-default hover:border-transparent hover:bg-transparent' : ''}
         ${!value ? 'text-gray-400 italic' : ''}

--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -485,7 +485,7 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="resume-text"
-                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste your resume text here..."
                 value={resumeText}
                 onChange={(e) => setResumeText(e.target.value)}
@@ -508,7 +508,7 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="job-description"
-                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent/30 focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste the job description here..."
                 value={jobDescription}
                 onChange={(e) => setJobDescription(e.target.value)}
@@ -644,7 +644,7 @@ export default function ResumeKeywordScanner() {
                     type="button"
                     key={tab.key}
                     onClick={() => setActiveTab(tab.key)}
-                    className={`min-h-11 px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+                    className={`min-h-11 px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-text focus-visible:ring-offset-2 ${
                       activeTab === tab.key
                         ? tab.activeClass
                         : 'text-stone-warm hover:bg-chalk-dark border border-transparent'

--- a/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
+++ b/resume-builder-ui/src/components/tools/ResumeKeywordScanner.tsx
@@ -130,8 +130,8 @@ export function ModelStatusIndicator({
   if (status === 'idle') {
     return (
       <div className="min-h-[32px] flex items-center gap-2">
-        <span className="w-1.5 h-1.5 rounded-full bg-mist/40" />
-        <span className="font-mono text-xs tracking-[0.15em] text-mist uppercase">
+        <span className="w-1.5 h-1.5 rounded-full bg-stone-warm/40" />
+        <span className="font-mono text-xs tracking-[0.15em] text-stone-warm uppercase">
           AI Engine
         </span>
       </div>
@@ -159,7 +159,7 @@ export function ModelStatusIndicator({
               <span
                 key={i}
                 className={`w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
-                  i < litCount ? 'bg-accent' : 'bg-mist/30'
+                  i < litCount ? 'bg-accent' : 'bg-stone-warm/30'
                 }`}
                 style={
                   i === litCount - 1 && litCount > 0
@@ -170,7 +170,7 @@ export function ModelStatusIndicator({
             ))}
           </span>
           {progress > 0 && (
-            <span className="font-mono text-[10px] text-mist tabular-nums">
+            <span className="font-mono text-[10px] text-stone-warm tabular-nums">
               {progress}%
             </span>
           )}
@@ -178,7 +178,7 @@ export function ModelStatusIndicator({
         {/* Phase 3: explicit one-time/size copy so a slow first load reads as
             expected progress, not a hang. */}
         {statusText && (
-          <span className="font-mono text-[10px] text-mist tracking-wide">{statusText}</span>
+          <span className="font-mono text-[10px] text-stone-warm tracking-wide">{statusText}</span>
         )}
       </div>
     );
@@ -291,7 +291,7 @@ function ContextCard({ kw }: { kw: EnhancedKeywordResult }) {
   if (!kw.bestMatchContext) return null;
   return (
     <div className="bg-chalk rounded-lg p-3 text-xs flex-1 min-w-0">
-      <span className="text-mist block mb-1">Closest match in your resume:</span>
+      <span className="text-stone-warm block mb-1">Closest match in your resume:</span>
       <span className="text-stone-warm italic line-clamp-2">&ldquo;{kw.bestMatchContext}&rdquo;</span>
     </div>
   );
@@ -327,7 +327,7 @@ function KeywordSection({
       {showContext && (variant === 'partial' || variant === 'missing') && (
         <div className="space-y-3 mt-4 pt-4 border-t border-black/[0.06]">
           {variant === 'partial' && (
-            <p className="text-xs text-mist mb-2">
+            <p className="text-xs text-stone-warm mb-2">
               Your resume mentions related concepts. Consider adding these keywords explicitly.
             </p>
           )}
@@ -342,7 +342,7 @@ function KeywordSection({
                 <ContextCard kw={kw} />
               ) : kw.suggestedPlacement ? (
                 <span className="text-xs text-stone-warm">
-                  <span className="text-mist mr-1">&rarr;</span> {kw.suggestedPlacement}
+                  <span className="text-stone-warm mr-1">&rarr;</span> {kw.suggestedPlacement}
                 </span>
               ) : null}
             </div>
@@ -360,7 +360,7 @@ function KeywordSection({
             {keywords.filter(kw => kw.suggestedPlacement).slice(6, 14).map((kw) => (
               <div key={kw.keyword} className="flex items-start gap-3 text-sm">
                 <span className="text-red-500 font-mono shrink-0 min-w-[80px]">{kw.keyword}</span>
-                <span className="text-mist">&rarr;</span>
+                <span className="text-stone-warm">&rarr;</span>
                 <span className="text-stone-warm">{kw.suggestedPlacement}</span>
               </div>
             ))}
@@ -467,7 +467,7 @@ export default function ResumeKeywordScanner() {
       <RevealSection variant="fade-up">
         <div ref={scannerSectionRef} className="mb-16 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
           {/* Privacy trust signal */}
-          <div className="flex items-center justify-center gap-2 mb-6 text-xs text-mist">
+          <div className="flex items-center justify-center gap-2 mb-6 text-xs text-stone-warm">
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
             </svg>
@@ -485,13 +485,13 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="resume-text"
-                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-stone-warm focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste your resume text here..."
                 value={resumeText}
                 onChange={(e) => setResumeText(e.target.value)}
                 onFocus={handleTextareaFocus}
               />
-              <p className="text-xs text-mist mt-1">
+              <p className="text-xs text-stone-warm mt-1">
                 {resumeText.length > 0
                   ? `${resumeText.split(/\s+/).filter(Boolean).length} words`
                   : 'Tip: Copy all text from your resume and paste it here'}
@@ -508,13 +508,13 @@ export default function ResumeKeywordScanner() {
               </label>
               <textarea
                 id="job-description"
-                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-mist focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
+                className="w-full h-56 md:h-64 rounded-lg border border-slate-200 bg-white p-4 text-sm text-ink placeholder:text-stone-warm focus:outline-none focus:ring-2 focus:ring-accent-text focus:border-accent/40 resize-none transition-all"
                 placeholder="Paste the job description here..."
                 value={jobDescription}
                 onChange={(e) => setJobDescription(e.target.value)}
                 onFocus={handleTextareaFocus}
               />
-              <p className="text-xs text-mist mt-1">
+              <p className="text-xs text-stone-warm mt-1">
                 {jobDescription.length > 0
                   ? `${jobDescription.split(/\s+/).filter(Boolean).length} words`
                   : 'Tip: Copy the full job posting including requirements'}

--- a/resume-builder-ui/src/styles.css
+++ b/resume-builder-ui/src/styles.css
@@ -70,10 +70,13 @@
   @apply relative inline-flex min-h-11 items-center justify-center text-gray-700 hover:text-ink transition-all duration-200 font-medium px-3 py-2 rounded-lg hover:bg-black/5;
 }
 
+/* Focus ring is Deep Signal, not Signal Green: #00d47e measures 1.87:1 on Chalk
+   and cannot carry the 3:1 non-text contrast requirement. #007a48 measures
+   5.18:1 on Chalk and 4.70:1 on Chalk Dark, and stays in the same green. */
 .btn-primary:focus-visible,
 .btn-secondary:focus-visible,
 .btn-ghost:focus-visible {
-  @apply outline-none ring-2 ring-accent ring-offset-2 ring-offset-white;
+  @apply outline-none ring-2 ring-accent-text ring-offset-2 ring-offset-white;
 }
 
 .btn-ghost::before {

--- a/resume-builder-ui/tailwind.config.js
+++ b/resume-builder-ui/tailwind.config.js
@@ -19,10 +19,12 @@ module.exports = {
           DEFAULT: '#fafaf8',
           dark: '#f0efe9',
         },
-        // WCAG 2.2 AA, measured on Chalk / white / Chalk Dark (strictest ground):
-        // stone-warm 5.38 / 5.62 / 4.88, mist 4.98 / 5.21 / 4.52. See DESIGN.md.
+        // Warm grey is surface-polarity-paired: each token is AA-valid only against
+        // the polarity it was measured on. Never use one on the other's ground.
+        // stone-warm on Chalk / white / Chalk Dark (strictest): 5.38 / 5.62 / 4.88
         'stone-warm': '#6b6761',
-        mist: '#706c68',
+        // ...-inverse on ink / ink-light / white-5%-over-ink-light: 7.90 / 7.03 / 6.19
+        'stone-warm-inverse': '#a8a4a0',
         accent: '#00d47e',
         'accent-text': '#007a48',
       },

--- a/resume-builder-ui/tailwind.config.js
+++ b/resume-builder-ui/tailwind.config.js
@@ -19,8 +19,10 @@ module.exports = {
           DEFAULT: '#fafaf8',
           dark: '#f0efe9',
         },
-        'stone-warm': '#8a8680',
-        mist: '#a8a4a0',
+        // WCAG 2.2 AA, measured on Chalk / white / Chalk Dark (strictest ground):
+        // stone-warm 5.38 / 5.62 / 4.88, mist 4.98 / 5.21 / 4.52. See DESIGN.md.
+        'stone-warm': '#6b6761',
+        mist: '#706c68',
         accent: '#00d47e',
         'accent-text': '#007a48',
       },


### PR DESCRIPTION
Stacked on #702. **Merge #702 first.**

Fixes the three measured contrast failures recorded in DESIGN.md, plus a fourth found on the way. Colors only — no layout, spacing, typography, copy, or structural change.

## Measured results

Every value recomputed independently against all three grounds the system paints text on. AA requires 4.5:1 for body text and 3:1 for focus indicators.

| Token | Old → New | chalk `#fafaf8` | white `#ffffff` | chalk-dark `#f0efe9` |
|---|---|---|---|---|
| `stone-warm` | `#8a8680` → `#6b6761` | 3.46 → **5.38** | 3.62 → **5.62** | 3.14 → **4.88** |
| `mist` | `#a8a4a0` → `#706c68` | 2.37 → **4.98** | 2.48 → **5.21** | 2.15 → **4.52** |
| focus ring | `#00d47e` → `#007a48` | 1.87 → **5.18** | 1.96 → **5.42** | 1.70 → **4.70** |

**Chalk Dark is the binding ground**, not white — it has the lowest luminance of the three (0.8614 vs 0.9547 vs 1.0000), so it yields the lowest contrast for dark text. It's also pervasive: 88 files use `bg-chalk-dark`. Both greys keep their original channel deltas, so the warm hue family is unchanged.

## Focus ring

Moved to Deep Signal `#007a48` — the palette's existing text-safe sibling, so it stays the same green and needs no new token. Applied at the shared `.btn-*:focus-visible` rule in `styles.css` and swept across **92 inline usages in 32 components** (`focus-visible:`, `focus:`, `focus-within:`), including two scanner textareas that were at 30% accent opacity.

Left deliberately alone: `focus:border-accent` (supplementary to the ring, not the indicator itself) and decorative `ring-accent/20|/30` halos on selected cards and thumbnails, which are paired with a solid border and aren't focus states.

## Fourth failure, found and fixed

`index.html:120` hardcoded the prerendered hero eyebrow as Signal Green (1.87:1) while `LandingPage.tsx:207` already rendered that same eyebrow as `text-accent-text`. That was **both** an AA failure on the LCP element **and** a color flip at hydration. One hex; the shell and the component now agree.

## Review question: does `mist` still earn its existence?

`#6b6761` and `#706c68` are five points apart per channel — visually near-identical. The compression is forced: `mist` was verified to carry task-critical content (job locations and descriptions in `JobsLandingPage.tsx`, match hints in `ResumeKeywordScanner.tsx`, blog dates), so restricting its usage instead would have meant a content rewrite across those surfaces. The light end of a warm-grey ramp isn't available to text under AA on a near-white ground.

The consequence is that the secondary/tertiary tone distinction is effectively gone. Worth deciding now, while 88 files depend on it: keep both tokens and carry that hierarchy deliberately through size and weight, or collapse `mist` into `stone-warm`.

## Verification

```
npx tsc -b       → exit 0        (-b, not --noEmit, which is vacuous on this solution-style config)
npx vitest run   → 73 files passed | 3 skipped
                   1474 tests passed | 23 skipped
npm run build    → succeeded, sitemap generated (120 URLs)
```

Test suite re-run independently after the agent reported it; counts match exactly.

## Guardrails

Verified untouched by diff: ad surfaces (`.ad-surface`, `ins.adsbygoogle`, `.google-auto-placed`), `sitemapUrls.ts`, `components/ads/`, and everything SEO-governed. No dependencies added, no dark mode, no layout change.

`DESIGN.md`, `.impeccable/design.json`, and `CLAUDE.md`'s token table were updated in the same PR so the design authority doesn't go stale against the code.

https://claude.ai/code/session_01Hb7Wis9ypfYjrUYQVeZDic