### PR TITLE
🎨 Palette: Improve keyboard accessibility for destructive dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+## 2025-02-14 - Auto-Focus Safe Actions in Destructive Dialogs
+**Learning:** Default focus in custom dialogs is often overlooked. In destructive dialogs (like Delete confirmations), if focus lands on the "Confirm" action by default or there is no default focus, users may accidentally trigger the destructive action by pressing 'Enter'. Adding `autoFocus` to the safe "Cancel" action prevents this, and adding visible focus rings (`focus-visible:ring-2`) ensures keyboard accessibility.
+**Action:** When implementing custom dialogs for destructive actions, always place `autoFocus={isDestructive}` on the safe/cancel button and explicitly add `focus-visible` styles to both buttons to ensure clear keyboard navigation.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -120,10 +120,12 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus={isDestructive}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
-                min-h-[48px] lg:min-h-[44px]"
+                min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-2"
               style={{ WebkitTapHighlightColor: "transparent" }}
             >
               {cancelText}
@@ -135,6 +137,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                ${isDestructive ? 'focus-visible:ring-red-500' : 'focus-visible:ring-accent'}
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}
             >


### PR DESCRIPTION
💡 What: Added `autoFocus={isDestructive}` to the safe "Cancel" button in the `ResponsiveConfirmDialog` component, and added explicit `focus-visible` ring outlines to both the Confirm and Cancel buttons for clear keyboard navigation.

🎯 Why: In destructive dialogs (like deleting a resume), focusing the confirmation button by default can lead to accidental data loss if a user immediately hits Enter. Focusing the safe action ("Cancel") prevents this while ensuring keyboard users have a visible indicator of their current location.

📸 Before/After: Before, no buttons had an outline when navigating by keyboard, and neither received default focus. After, the Cancel button is focused immediately for destructive actions, and tab navigation clearly highlights active buttons with styled rings.

♿ Accessibility: Ensures the dialog aligns with WCAG guidelines for focus management (sending focus to the least destructive action) and visible focus indicators (focus rings with high contrast).

---
*PR created automatically by Jules for task [8205542356050507034](https://jules.google.com/task/8205542356050507034) started by @aafre*