### PR TITLE
🎨 Palette: [UX improvement] Add autoFocus to cancel button in destructive dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-18 - Accessibility focus trap for destructive dialogs
+**Learning:** In destructive confirmation dialogs (like `ResponsiveConfirmDialog`), it's dangerous if the focus isn't trapped or managed. If a user presses 'Enter' quickly, they could accidentally trigger the destructive action. Placing `autoFocus` on the safe cancellation action (e.g., 'Cancel') ensures that an accidental keystroke doesn't lead to unintended data loss.
+**Action:** Add `autoFocus` to the Cancel button in `ResponsiveConfirmDialog` to provide a safer default focus state.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -118,6 +118,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
           {/* Actions - Mobile: Stack vertically, Desktop: Side by side */}
           <div className="p-6 border-t border-gray-200 space-y-3 lg:space-y-0 lg:flex lg:gap-3 lg:justify-end">
             <button
+              autoFocus
               onClick={onClose}
               disabled={isLoading}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700


### PR DESCRIPTION
💡 What: Added the `autoFocus` attribute to the cancel button in the `ResponsiveConfirmDialog` component.
🎯 Why: To prevent users from accidentally triggering a destructive action (like deleting data) if they inadvertently press 'Enter' when the dialog opens.
📸 Before/After: Visuals remain unchanged, but focus defaults to the safer action.
♿ Accessibility: Improves keyboard navigation and provides a safer default focus state for users relying on screen readers or keyboard navigation.

---
*PR created automatically by Jules for task [1930579038426487469](https://jules.google.com/task/1930579038426487469) started by @aafre*