### PR TITLE
🎨 Palette: [UX improvement] Add autoFocus to Cancel button in destructive dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,11 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2023-10-24 - AutoFocus and Focus-Visible on Destructive Dialogs
+**Learning:** In destructive confirmation dialogs, users can accidentally trigger the destructive action (e.g. by pressing Enter) if the default focus is not managed. Furthermore, custom Tailwind buttons often lose default browser focus outlines.
+**Action:** Always place `autoFocus={isDestructive}` on the safe cancellation action (like the 'Cancel' button) in destructive dialogs, and explicitly include `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to ensure clear visual indicators for keyboard navigation.
+
+## 2023-10-24 - AutoFocus and Focus-Visible on Destructive Dialogs
+**Learning:** In destructive confirmation dialogs, users can accidentally trigger the destructive action (e.g. by pressing Enter) if the default focus is not managed. Furthermore, custom Tailwind buttons often lose default browser focus outlines.
+**Action:** Always place `autoFocus={isDestructive}` on the safe cancellation action (like the 'Cancel' button) in destructive dialogs, and explicitly include `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to ensure clear visual indicators for keyboard navigation.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -123,8 +123,10 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
+              autoFocus={isDestructive}
             >
               {cancelText}
             </button>
@@ -134,6 +136,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
               className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${isDestructive ? 'focus-visible:ring-red-600' : 'focus-visible:ring-gray-900'}
                 min-h-[48px] lg:min-h-[44px]
                 ${confirmClass}`}
               style={{ WebkitTapHighlightColor: "transparent" }}


### PR DESCRIPTION
💡 What: Added `autoFocus` to the Cancel button when the dialog is destructive, and applied explicit focus-visible styles to both Cancel and Confirm buttons.
🎯 Why: Prevents accidental destructive actions when a user presses 'Enter' immediately after the dialog mounts, and improves keyboard navigation visibility.
📸 Before/After: Focus ring now clearly displays on the Cancel button by default for destructive actions.
♿ Accessibility: Improves keyboard navigation support and prevents accidental data loss.

---
*PR created automatically by Jules for task [18232369098143321644](https://jules.google.com/task/18232369098143321644) started by @aafre*