### PR TITLE
🎨 Palette: Add focus states and safe defaults to confirmation dialogs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - ResponsiveConfirmDialog for Destructive Actions
 **Learning:** Destructive actions (like Delete) implemented with custom hardcoded modals lack standard accessibility attributes (`role="dialog"`, `aria-modal`, etc.) and mobile responsiveness (like bottom sheets). This app has a `ResponsiveConfirmDialog` component designed specifically for this purpose, but it was not being utilized uniformly.
 **Action:** Always use `ResponsiveConfirmDialog` for destructive confirmation prompts (such as `DeleteResumeModal`) to ensure a consistent, accessible, and mobile-friendly UX that prevents accidental data loss.
+
+## 2025-02-14 - Keyboard Accessibility in Destructive Dialogs
+**Learning:** Destructive dialogs without auto-focus on the cancel action can lead to accidental data loss if a user presses Enter. Additionally, custom styled buttons often lose default browser focus outlines.
+**Action:** Always add `autoFocus` to the safe cancel action in destructive dialogs and explicitly include `focus-visible` utilities to ensure safe keyboard navigation and clear focus states.

--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -42,8 +42,8 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
 
   // Default button styles based on action type
   const defaultConfirmClass = isDestructive
-    ? "bg-red-600 hover:bg-red-700 text-white"
-    : "bg-accent hover:bg-accent/90 text-white";
+    ? "bg-red-600 hover:bg-red-700 text-white focus-visible:ring-red-600"
+    : "bg-accent hover:bg-accent/90 text-white focus-visible:ring-accent";
 
   const confirmClass = confirmButtonClass || defaultConfirmClass;
 
@@ -97,7 +97,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             </div>
             <button
               onClick={onClose}
-              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1"
+              className="flex-shrink-0 text-gray-400 hover:text-gray-600 transition-colors p-1 -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               aria-label="Close dialog"
               disabled={isLoading}
             >
@@ -120,8 +120,9 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus={isDestructive}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
-                hover:bg-gray-50 active:bg-gray-100
+                hover:bg-gray-50 active:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-400
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]"
               style={{ WebkitTapHighlightColor: "transparent" }}
@@ -131,7 +132,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={handleConfirm}
               disabled={isLoading}
-              className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium
+              className={`w-full lg:w-auto px-6 py-3 rounded-lg font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
                 shadow-md hover:shadow-lg active:scale-95
                 transition-all disabled:opacity-50 disabled:cursor-not-allowed
                 min-h-[48px] lg:min-h-[44px]


### PR DESCRIPTION
💡 What: Added `autoFocus={isDestructive}` to the cancel button in `ResponsiveConfirmDialog` and explicitly added `focus-visible` Tailwind classes to all buttons in the dialog. 

🎯 Why: Prevents accidental destructive actions (like deleting a resume) if the user accidentally presses Enter immediately after the dialog opens. 

📸 Before/After: Before, focus was not visible and could default to the destructive action. After, focus defaults safely to Cancel and is clearly visible on all interactive elements. 

♿ Accessibility: Improves keyboard navigation clarity and adds an extra layer of safety for screen reader and keyboard users.

---
*PR created automatically by Jules for task [6694834885633230291](https://jules.google.com/task/6694834885633230291) started by @aafre*