### PR TITLE
🎨 Palette: [UX improvement] Add autoFocus to cancel button in destructive dialogs

### DIFF
--- a/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
+++ b/resume-builder-ui/src/components/ResponsiveConfirmDialog.tsx
@@ -120,6 +120,7 @@ const ResponsiveConfirmDialog: React.FC<ResponsiveConfirmDialogProps> = ({
             <button
               onClick={onClose}
               disabled={isLoading}
+              autoFocus={isDestructive}
               className="w-full lg:w-auto px-6 py-3 border border-gray-300 rounded-lg font-medium text-gray-700
                 hover:bg-gray-50 active:bg-gray-100
                 transition-colors disabled:opacity-50 disabled:cursor-not-allowed


### PR DESCRIPTION
💡 What: Added `autoFocus={isDestructive}` to the Cancel button in `ResponsiveConfirmDialog`.
🎯 Why: To prevent users from accidentally triggering destructive actions (like deleting a resume) by pressing 'Enter' immediately after the dialog mounts.
📸 Before/After: Focus is now safely on 'Cancel' by default instead of unassigned.
♿ Accessibility: Ensures safer keyboard navigation for destructive modals.

---
*PR created automatically by Jules for task [16081379246923186629](https://jules.google.com/task/16081379246923186629) started by @aafre*